### PR TITLE
Add basic support for the new license expression field

### DIFF
--- a/CycloneDX/Program.cs
+++ b/CycloneDX/Program.cs
@@ -355,9 +355,6 @@ namespace CycloneDX {
 			// As a final step (and before optionally fetching transitive dependencies), add the component to the dictionary.
 			AddPreventDuplicates(component);
 
-			//TODO: nuspec authors thought it would be a good idea to publish the URL to the license
-			//rather than the SPDX identifier of the license itself. Genius! NOT! nuspec will need to
-			//change the spec if they wish to provide accurate license information in boms.
 			if (followTransitive) {
                 var dependencies = metadata.SelectNodes("/*[local-name() = 'package']/*[local-name() = 'metadata']/*[local-name() = 'dependencies']/*[local-name() = 'dependency']");
                 foreach (XmlNode dependency in dependencies) {


### PR DESCRIPTION
Adding support for some basic parsing of the new license expression field, which is found in more recent nuget packages.  [https://github.com/NuGet/Home/wiki/Packaging-License-within-the-nupkg#project-properties](url)