### PR TITLE
Include license URL if license id is not available. Moved to 1.1 schema

### DIFF
--- a/CycloneDX/Model/License.cs
+++ b/CycloneDX/Model/License.cs
@@ -19,6 +19,6 @@ namespace CycloneDX.Model {
     public class License {
         public string Id { get; set; }
         public string Name { get; set; }
+        public string Url { get; set; }
     }
-
 }


### PR DESCRIPTION
Include the license URL when the license id is not available in the package metadata. This allows us to to further post-processing on the BOM to determine what the license for the package is. This is helpful since most nuget packages don't currently include the license id.

I had to bump the schema version to 1.1 to support this change.