### PR TITLE
Use same logic as dotnet restore/build for dependency resolution

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -3,18 +3,20 @@ name: .NET Core CI
 on: [push, pull_request]
 
 jobs:
-  test:
-    name: Test on ${{ matrix.os }}
+  tests:
+    name: ${{ matrix.tests }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        tests: [Tests, IntegrationTests]
         os: [ubuntu-latest, windows-latest, macos-latest]
+    timeout-minutes: 10
     
     steps:
     - uses: actions/checkout@v1
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 2.2.108
+        dotnet-version: 2.1.803
     - name: Tests
-      run: dotnet test
+      run: dotnet test CycloneDX.${{ matrix.tests }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 /.vscode/
 bin/
 obj/
+packages/
 coverage-report/
 coverage.cobertura.xml

--- a/CycloneDX.IntegrationTests/CycloneDX.IntegrationTests.csproj
+++ b/CycloneDX.IntegrationTests/CycloneDX.IntegrationTests.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="5.0.0" />
+    <PackageReference Include="Snapshooter.Xunit" Version="0.5.2" />
     <PackageReference Include="System.IO.Abstractions" Version="7.0.7" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="7.0.7" />
     <PackageReference Include="xunit" Version="2.4.1" />
@@ -29,6 +30,11 @@
 
   <ItemGroup>
     <ProjectReference Include="..\CycloneDX\CycloneDX.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="Resources\**" CopyToOutputDirectory="Always" />
+    <Content Include="__snapshots__\**" CopyToOutputDirectory="Always" />
   </ItemGroup>
 
 </Project>

--- a/CycloneDX.IntegrationTests/IntegrationTests.cs
+++ b/CycloneDX.IntegrationTests/IntegrationTests.cs
@@ -14,340 +14,100 @@
 //
 // Copyright (c) Steve Springett. All Rights Reserved.
 
+using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using Xunit;
-using System.IO.Abstractions.TestingHelpers;
-using XFS = System.IO.Abstractions.TestingHelpers.MockUnixSupport;
+using Snapshooter;
+using Snapshooter.Xunit;
 
 namespace CycloneDX.IntegrationTests
 {
     public class Tests
     {
-        [Fact]
-        public void CallingCycloneDX_WithNoPackages_GeneratesEmptyBom()
+        private void AssertEqualIgnoringSpaces(string expected, string actual)
         {
-            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
-            {
-                { XFS.Path(@"c:\Solution\Solution.sln"), new MockFileData(@"Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
-MinimumVisualStudioVersion = 15.0.26124.0
-Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""Project"", ""Project\Project.csproj"", ""{318AD44C-F5E0-49E4-B474-AE5D20C74A1A}""
-EndProject
-Global
-GlobalSection(SolutionConfigurationPlatforms) = preSolution
-Debug|Any CPU = Debug|Any CPU
-Debug|x64 = Debug|x64
-Debug|x86 = Debug|x86
-Release|Any CPU = Release|Any CPU
-Release|x64 = Release|x64
-Release|x86 = Release|x86
-EndGlobalSection
-GlobalSection(SolutionProperties) = preSolution
-HideSolutionNode = FALSE
-EndGlobalSection
-GlobalSection(ProjectConfigurationPlatforms) = postSolution
-{318AD44C-F5E0-49E4-B474-AE5D20C74A1A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-{318AD44C-F5E0-49E4-B474-AE5D20C74A1A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-{318AD44C-F5E0-49E4-B474-AE5D20C74A1A}.Debug|x64.ActiveCfg = Debug|Any CPU
-{318AD44C-F5E0-49E4-B474-AE5D20C74A1A}.Debug|x64.Build.0 = Debug|Any CPU
-{318AD44C-F5E0-49E4-B474-AE5D20C74A1A}.Debug|x86.ActiveCfg = Debug|Any CPU
-{318AD44C-F5E0-49E4-B474-AE5D20C74A1A}.Debug|x86.Build.0 = Debug|Any CPU
-{318AD44C-F5E0-49E4-B474-AE5D20C74A1A}.Release|Any CPU.ActiveCfg = Release|Any CPU
-{318AD44C-F5E0-49E4-B474-AE5D20C74A1A}.Release|Any CPU.Build.0 = Release|Any CPU
-{318AD44C-F5E0-49E4-B474-AE5D20C74A1A}.Release|x64.ActiveCfg = Release|Any CPU
-{318AD44C-F5E0-49E4-B474-AE5D20C74A1A}.Release|x64.Build.0 = Release|Any CPU
-{318AD44C-F5E0-49E4-B474-AE5D20C74A1A}.Release|x86.ActiveCfg = Release|Any CPU
-{318AD44C-F5E0-49E4-B474-AE5D20C74A1A}.Release|x86.Build.0 = Release|Any CPU
-EndGlobalSection
-EndGlobal")},
-                { 
-                    XFS.Path(@"c:\Solution\Project\Project.csproj"), 
-                    new MockFileData(@"<Project Sdk=""Microsoft.NET.Sdk""><ItemGroup></ItemGroup></Project>")
-                },
-            });
-            Program.fileSystem = mockFileSystem;
-
-            var exitCode = Program.Main(new string[] {
-                XFS.Path(@"c:\Solution\Solution.sln"),
-                "--noSerialNumber",
-                "--out", XFS.Path(@"c:\Solution")
-            });
-            var bomContents = mockFileSystem.File.ReadAllText(XFS.Path(@"c:\Solution\bom.xml"));
-
-            Assert.Equal(@"<?xml version=""1.0"" encoding=""utf-8""?>
-<bom version=""1"" xmlns=""http://cyclonedx.org/schema/bom/1.1"">
-  <components />
-</bom>", bomContents);
+            var exp = Regex.Replace(expected, @"\n\s*", "");
+            var act = Regex.Replace(actual, @"\n\s*", "");
+            Assert.Equal(exp, act);
         }
 
-        [Fact]
-        public void CallingCycloneDX_WithNoProjects_GeneratesEmptyBom()
+        [Theory]
+        [InlineData("CSharp")]
+        [InlineData("FullFrameworkAndCore")]
+        [InlineData("NoDependencies")]
+        [InlineData("Vb")]
+        public async Task CallingCycloneDX_WithDirectoryPath_GeneratesBom(string directoryName)
         {
-            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            // a lot of these are actually empty boms
+            // .net core doesn't use packages.config
+            using (var tempDir = new TempDirectory())
             {
-                { XFS.Path(@"c:\Solution\Solution.sln"), new MockFileData(@"Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
-MinimumVisualStudioVersion = 15.0.26124.0
-Global
-  GlobalSection(SolutionConfigurationPlatforms) = preSolution
-    Debug|Any CPU = Debug|Any CPU
-    Debug|x64 = Debug|x64
-    Debug|x86 = Debug|x86
-    Release|Any CPU = Release|Any CPU
-    Release|x64 = Release|x64
-    Release|x86 = Release|x86
-  EndGlobalSection
-  GlobalSection(SolutionProperties) = preSolution
-    HideSolutionNode = FALSE
-  EndGlobalSection
-EndGlobal")}
-            });
-            Program.fileSystem = mockFileSystem;
+                var exitCode = await Program.Main(new string[] {
+                    Path.Join("Resources", directoryName),
+                    "--noSerialNumber",
+                    "--out", tempDir.DirectoryPath
+                });
+                // defensive assert, if this fails there is no point attempting to inspect the bom contents
+                Assert.Equal(0, exitCode);
 
-            var exitCode = Program.Main(new string[] {
-                XFS.Path(@"c:\Solution\Solution.sln"),
-                "--noSerialNumber",
-                "--out", XFS.Path(@"c:\Solution")
-            });
-            var bomContents = mockFileSystem.File.ReadAllText(XFS.Path(@"c:\Solution\bom.xml"));
+                var bomContents = File.ReadAllText(Path.Combine(tempDir.DirectoryPath, "bom.xml"));
 
-            Assert.Equal(@"<?xml version=""1.0"" encoding=""utf-8""?>
-<bom version=""1"" xmlns=""http://cyclonedx.org/schema/bom/1.1"">
-  <components />
-</bom>", bomContents);
+                Snapshot.Match(bomContents, SnapshotNameExtension.Create(directoryName));
+            }
         }
 
-        [Fact]
-        public void CallingCycloneDX__GeneratesBom()
+        [Theory]
+        [InlineData("CSharp")]
+        [InlineData("FullFrameworkAndCore")]
+        [InlineData("NoDependencies")]
+        [InlineData("Vb")]
+        public async Task CallingCycloneDX_WithSolutionFilePath_GeneratesBom(string solutionName)
         {
-            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            using (var tempDir = new TempDirectory())
             {
-                { XFS.Path(@"c:\Solution\Solution.sln"), new MockFileData(@"Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
-MinimumVisualStudioVersion = 15.0.26124.0
-Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""Project.WithPackages"", ""Project.WithPackages\Project.WithPackages.csproj"", ""{5849EBB9-CC38-4FCE-A3E1-3501C674249C}""
-EndProject
-Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""Project.NoPackages"", ""Project.NoPackages\Project.NoPackages.csproj"", ""{C6071BA2-1168-41E7-9BD3-A48585C9637A}""
-EndProject
-Project(""{F184B08F-C81C-45F6-A57F-5ABD9991F28F}"") = ""Project.Vb"", ""Project.Vb\Project.Vb.vbproj"", ""{A775F37D-4AA6-47D8-8305-6DFDB843B347}""
-EndProject
-Global
-  GlobalSection(SolutionConfigurationPlatforms) = preSolution
-    Debug|Any CPU = Debug|Any CPU
-    Debug|x64 = Debug|x64
-    Debug|x86 = Debug|x86
-    Release|Any CPU = Release|Any CPU
-    Release|x64 = Release|x64
-    Release|x86 = Release|x86
-  EndGlobalSection
-  GlobalSection(SolutionProperties) = preSolution
-    HideSolutionNode = FALSE
-  EndGlobalSection
-  GlobalSection(ProjectConfigurationPlatforms) = postSolution
-    {5849EBB9-CC38-4FCE-A3E1-3501C674249C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-    {5849EBB9-CC38-4FCE-A3E1-3501C674249C}.Debug|Any CPU.Build.0 = Debug|Any CPU
-    {5849EBB9-CC38-4FCE-A3E1-3501C674249C}.Debug|x64.ActiveCfg = Debug|Any CPU
-    {5849EBB9-CC38-4FCE-A3E1-3501C674249C}.Debug|x64.Build.0 = Debug|Any CPU
-    {5849EBB9-CC38-4FCE-A3E1-3501C674249C}.Debug|x86.ActiveCfg = Debug|Any CPU
-    {5849EBB9-CC38-4FCE-A3E1-3501C674249C}.Debug|x86.Build.0 = Debug|Any CPU
-    {5849EBB9-CC38-4FCE-A3E1-3501C674249C}.Release|Any CPU.ActiveCfg = Release|Any CPU
-    {5849EBB9-CC38-4FCE-A3E1-3501C674249C}.Release|Any CPU.Build.0 = Release|Any CPU
-    {5849EBB9-CC38-4FCE-A3E1-3501C674249C}.Release|x64.ActiveCfg = Release|Any CPU
-    {5849EBB9-CC38-4FCE-A3E1-3501C674249C}.Release|x64.Build.0 = Release|Any CPU
-    {5849EBB9-CC38-4FCE-A3E1-3501C674249C}.Release|x86.ActiveCfg = Release|Any CPU
-    {5849EBB9-CC38-4FCE-A3E1-3501C674249C}.Release|x86.Build.0 = Release|Any CPU
-    {C6071BA2-1168-41E7-9BD3-A48585C9637A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-    {C6071BA2-1168-41E7-9BD3-A48585C9637A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-    {C6071BA2-1168-41E7-9BD3-A48585C9637A}.Debug|x64.ActiveCfg = Debug|Any CPU
-    {C6071BA2-1168-41E7-9BD3-A48585C9637A}.Debug|x64.Build.0 = Debug|Any CPU
-    {C6071BA2-1168-41E7-9BD3-A48585C9637A}.Debug|x86.ActiveCfg = Debug|Any CPU
-    {C6071BA2-1168-41E7-9BD3-A48585C9637A}.Debug|x86.Build.0 = Debug|Any CPU
-    {C6071BA2-1168-41E7-9BD3-A48585C9637A}.Release|Any CPU.ActiveCfg = Release|Any CPU
-    {C6071BA2-1168-41E7-9BD3-A48585C9637A}.Release|Any CPU.Build.0 = Release|Any CPU
-    {C6071BA2-1168-41E7-9BD3-A48585C9637A}.Release|x64.ActiveCfg = Release|Any CPU
-    {C6071BA2-1168-41E7-9BD3-A48585C9637A}.Release|x64.Build.0 = Release|Any CPU
-    {C6071BA2-1168-41E7-9BD3-A48585C9637A}.Release|x86.ActiveCfg = Release|Any CPU
-    {C6071BA2-1168-41E7-9BD3-A48585C9637A}.Release|x86.Build.0 = Release|Any CPU
-    {A775F37D-4AA6-47D8-8305-6DFDB843B347}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-    {A775F37D-4AA6-47D8-8305-6DFDB843B347}.Debug|Any CPU.Build.0 = Debug|Any CPU
-    {A775F37D-4AA6-47D8-8305-6DFDB843B347}.Debug|x64.ActiveCfg = Debug|Any CPU
-    {A775F37D-4AA6-47D8-8305-6DFDB843B347}.Debug|x64.Build.0 = Debug|Any CPU
-    {A775F37D-4AA6-47D8-8305-6DFDB843B347}.Debug|x86.ActiveCfg = Debug|Any CPU
-    {A775F37D-4AA6-47D8-8305-6DFDB843B347}.Debug|x86.Build.0 = Debug|Any CPU
-    {A775F37D-4AA6-47D8-8305-6DFDB843B347}.Release|Any CPU.ActiveCfg = Release|Any CPU
-    {A775F37D-4AA6-47D8-8305-6DFDB843B347}.Release|Any CPU.Build.0 = Release|Any CPU
-    {A775F37D-4AA6-47D8-8305-6DFDB843B347}.Release|x64.ActiveCfg = Release|Any CPU
-    {A775F37D-4AA6-47D8-8305-6DFDB843B347}.Release|x64.Build.0 = Release|Any CPU
-    {A775F37D-4AA6-47D8-8305-6DFDB843B347}.Release|x86.ActiveCfg = Release|Any CPU
-    {A775F37D-4AA6-47D8-8305-6DFDB843B347}.Release|x86.Build.0 = Release|Any CPU
-  EndGlobalSection
-EndGlobal")},
-                { 
-                    XFS.Path(@"c:\Solution\Project.WithPackages\Project.WithPackages.csproj"), 
-                    new MockFileData(@"<Project Sdk=""Microsoft.NET.Sdk"">
-  <ItemGroup>
-    <PackageReference Include=""Microsoft.AspNetCore.All"" Version=""1.0.0"" />
-    <PackageReference Include=""Microsoft.AspNetCore.Mvc"" Version=""1.0.0"" />
-    <PackageReference Include=""Microsoft.AspNetCore.Mvc.Core"" Version=""1.0.0"" />
-    <PackageReference Include=""Microsoft.AspNetCore.Server.IISIntegration"" Version=""1.0.0"" />
-    <PackageReference Include=""System.Net.Http"" Version=""4.3.1"" />
-    <PackageReference Include=""System.Net.Security"" Version=""4.3.0"" />
-  </ItemGroup>
-</Project>")
-                },
-                { 
-                    XFS.Path(@"c:\Solution\Project.NoPackages\Project.NoPackages.csproj"), 
-                    new MockFileData(@"<Project Sdk=""Microsoft.NET.Sdk""><ItemGroup></ItemGroup></Project>")
-                },
-                { 
-                    XFS.Path(@"c:\Solution\Project.Vb\Project.Vb.vbproj"), 
-                    new MockFileData(@"<Project Sdk=""Microsoft.NET.Sdk"">
-  <ItemGroup>
-    <PackageReference Include=""Microsoft.AspNetCore.All"" Version=""1.0.0"" />
-    <PackageReference Include=""Microsoft.AspNetCore.Mvc"" Version=""1.0.0"" />
-    <PackageReference Include=""Microsoft.AspNetCore.Mvc.Core"" Version=""1.0.0"" />
-    <PackageReference Include=""Microsoft.AspNetCore.Server.IISIntegration"" Version=""1.0.0"" />
-    <PackageReference Include=""System.Net.Http"" Version=""4.3.1"" />
-    <PackageReference Include=""System.Net.Security"" Version=""4.3.0"" />
-  </ItemGroup>
-</Project>")
-                },
-            });
-            Program.fileSystem = mockFileSystem;
+                var exitCode = await Program.Main(new string[] {
+                    Path.Join("Resources", solutionName, $"{solutionName}.sln"),
+                    "--noSerialNumber",
+                    "--out", tempDir.DirectoryPath
+                });
+                // defensive assert, if this fails there is no point attempting to inspect the bom contents
+                Assert.Equal(0, exitCode);
 
-            var exitCode = Program.Main(new string[] {
-                XFS.Path(@"c:\Solution\Solution.sln"),
-                "--noSerialNumber",
-                "--out", XFS.Path(@"c:\Solution")
-            });
-            var bomContents = mockFileSystem.File.ReadAllText(XFS.Path(@"c:\Solution\bom.xml"));
+                var bomContents = File.ReadAllText(Path.Combine(tempDir.DirectoryPath, "bom.xml"));
 
-            Assert.Equal(@"<?xml version=""1.0"" encoding=""utf-8""?>
-<bom version=""1"" xmlns=""http://cyclonedx.org/schema/bom/1.1"">
-  <components>
-    <component type=""library"">
-      <name>Microsoft.AspNetCore.All</name>
-      <version>1.0.0</version>
-      <purl>pkg:nuget/Microsoft.AspNetCore.All@1.0.0</purl>
-    </component>
-    <component type=""library"">
-      <name>Microsoft.AspNetCore.Mvc</name>
-      <version>1.0.0</version>
-      <description><![CDATA[ASP.NET Core MVC is a web framework that gives you a powerful, patterns-based way to build dynamic websites and web APIs. ASP.NET Core MVC enables a clean separation of concerns and gives you full control over markup.]]></description>
-      <licenses>
-        <license>
-          <url>http://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm</url>
-        </license>
-      </licenses>
-      <copyright>Copyright © Microsoft Corporation</copyright>
-      <purl>pkg:nuget/Microsoft.AspNetCore.Mvc@1.0.0</purl>
-      <externalReferences>
-        <reference type=""website"">
-          <url>http://www.asp.net/</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type=""library"">
-      <name>Microsoft.AspNetCore.Mvc.Core</name>
-      <version>1.0.0</version>
-      <description><![CDATA[ASP.NET Core MVC core components. Contains common action result types, attribute routing, application model conventions, API explorer, application parts, filters, formatters, model binding, and more.
-Commonly used types:
-Microsoft.AspNetCore.Mvc.AreaAttribute
-Microsoft.AspNetCore.Mvc.BindAttribute
-Microsoft.AspNetCore.Mvc.ControllerBase
-Microsoft.AspNetCore.Mvc.FromBodyAttribute
-Microsoft.AspNetCore.Mvc.FromFormAttribute
-Microsoft.AspNetCore.Mvc.RequireHttpsAttribute
-Microsoft.AspNetCore.Mvc.RouteAttribute]]></description>
-      <licenses>
-        <license>
-          <url>http://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm</url>
-        </license>
-      </licenses>
-      <copyright>Copyright © Microsoft Corporation</copyright>
-      <purl>pkg:nuget/Microsoft.AspNetCore.Mvc.Core@1.0.0</purl>
-      <externalReferences>
-        <reference type=""website"">
-          <url>http://www.asp.net/</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type=""library"">
-      <name>Microsoft.AspNetCore.Server.IISIntegration</name>
-      <version>1.0.0</version>
-      <description><![CDATA[ASP.NET Core components for working with the IIS AspNetCoreModule.]]></description>
-      <licenses>
-        <license>
-          <url>http://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm</url>
-        </license>
-      </licenses>
-      <copyright>Copyright © Microsoft Corporation</copyright>
-      <purl>pkg:nuget/Microsoft.AspNetCore.Server.IISIntegration@1.0.0</purl>
-      <externalReferences>
-        <reference type=""website"">
-          <url>http://www.asp.net/</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type=""library"">
-      <name>System.Net.Http</name>
-      <version>4.3.1</version>
-      <description><![CDATA[Provides a programming interface for modern HTTP applications, including HTTP client components that allow applications to consume web services over HTTP and HTTP components that can be used by both clients and servers for parsing HTTP headers.
+                Snapshot.Match(bomContents, SnapshotNameExtension.Create(solutionName));
+            }
+        }
 
-Commonly Used Types:
-System.Net.Http.HttpResponseMessage
-System.Net.Http.DelegatingHandler
-System.Net.Http.HttpRequestException
-System.Net.Http.HttpClient
-System.Net.Http.MultipartContent
-System.Net.Http.Headers.HttpContentHeaders
-System.Net.Http.HttpClientHandler
-System.Net.Http.StreamContent
-System.Net.Http.FormUrlEncodedContent
-System.Net.Http.HttpMessageHandler
- 
-When using NuGet 3.x this package requires at least version 3.4.]]></description>
-      <licenses>
-        <license>
-          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
-        </license>
-      </licenses>
-      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
-      <purl>pkg:nuget/System.Net.Http@4.3.1</purl>
-      <externalReferences>
-        <reference type=""website"">
-          <url>https://dot.net/</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type=""library"">
-      <name>System.Net.Security</name>
-      <version>4.3.0</version>
-      <description><![CDATA[Provides types, such as System.Net.Security.SslStream, that uses SSL/TLS protocols to provide secure network communication between client and server endpoints.
+        [Theory]
+        [InlineData("CSharp", "CSharp", "csproj")]
+        [InlineData("FullFrameworkAndCore", "DotnetCore", "csproj")]
+        [InlineData("FullFrameworkAndCore", "FullFramework", "csproj")]
+        [InlineData("NoDependencies", "NoDependencies", "csproj")]
+        [InlineData("NoDependencies", "NoDependencies.Tests", "csproj")]
+        [InlineData("Vb", "Vb", "vbproj")]
+        public async Task CallingCycloneDX_WithProjectPath_GeneratesBom(string solutionName, string projectName, string projectFileExtension)
+        {
+            using (var tempDir = new TempDirectory())
+            {
+                var projectFilePath = Path.Join(
+                        Path.Join("Resources", solutionName, projectName),
+                        $"{projectName}.{projectFileExtension}");
+                var exitCode = await Program.Main(new string[] {
+                    projectFilePath,
+                    "--noSerialNumber",
+                    "--out", tempDir.DirectoryPath
+                });
+                // defensive assert, if this fails there is no point attempting to inspect the bom contents
+                Assert.Equal(0, exitCode);
 
-Commonly Used Types:
-System.Net.Security.SslStream
-System.Net.Security.ExtendedProtectionPolicy
- 
-When using NuGet 3.x this package requires at least version 3.4.]]></description>
-      <licenses>
-        <license>
-          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
-        </license>
-      </licenses>
-      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
-      <purl>pkg:nuget/System.Net.Security@4.3.0</purl>
-      <externalReferences>
-        <reference type=""website"">
-          <url>https://dot.net/</url>
-        </reference>
-      </externalReferences>
-    </component>
-  </components>
-</bom>", bomContents);
+                var bomContents = File.ReadAllText(Path.Combine(tempDir.DirectoryPath, "bom.xml"));
+
+                Snapshot.Match(bomContents, SnapshotNameExtension.Create(solutionName, projectName, projectFileExtension));
+            }
         }
     }
 }

--- a/CycloneDX.IntegrationTests/Resources/CSharp/CSharp.sln
+++ b/CycloneDX.IntegrationTests/Resources/CSharp/CSharp.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CSharp", "CSharp\CSharp.csproj", "{D3749C94-05EE-4544-9443-39563BEE8D68}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D3749C94-05EE-4544-9443-39563BEE8D68}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D3749C94-05EE-4544-9443-39563BEE8D68}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D3749C94-05EE-4544-9443-39563BEE8D68}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D3749C94-05EE-4544-9443-39563BEE8D68}.Debug|x64.Build.0 = Debug|Any CPU
+		{D3749C94-05EE-4544-9443-39563BEE8D68}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D3749C94-05EE-4544-9443-39563BEE8D68}.Debug|x86.Build.0 = Debug|Any CPU
+		{D3749C94-05EE-4544-9443-39563BEE8D68}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D3749C94-05EE-4544-9443-39563BEE8D68}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D3749C94-05EE-4544-9443-39563BEE8D68}.Release|x64.ActiveCfg = Release|Any CPU
+		{D3749C94-05EE-4544-9443-39563BEE8D68}.Release|x64.Build.0 = Release|Any CPU
+		{D3749C94-05EE-4544-9443-39563BEE8D68}.Release|x86.ActiveCfg = Release|Any CPU
+		{D3749C94-05EE-4544-9443-39563BEE8D68}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/CycloneDX.IntegrationTests/Resources/CSharp/CSharp/CSharp.csproj
+++ b/CycloneDX.IntegrationTests/Resources/CSharp/CSharp/CSharp.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Nuget.ProjectModel" Version="5.4.0" />
+  </ItemGroup>
+
+</Project>

--- a/CycloneDX.IntegrationTests/Resources/FullFrameworkAndCore/DotnetCore/DotnetCore.csproj
+++ b/CycloneDX.IntegrationTests/Resources/FullFrameworkAndCore/DotnetCore/DotnetCore.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Nuget.ProjectModel" Version="5.4.0" />
+  </ItemGroup>
+
+</Project>

--- a/CycloneDX.IntegrationTests/Resources/FullFrameworkAndCore/FullFramework/App.config
+++ b/CycloneDX.IntegrationTests/Resources/FullFrameworkAndCore/FullFramework/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
+    </startup>
+</configuration>

--- a/CycloneDX.IntegrationTests/Resources/FullFrameworkAndCore/FullFramework/FullFramework.csproj
+++ b/CycloneDX.IntegrationTests/Resources/FullFrameworkAndCore/FullFramework/FullFramework.csproj
@@ -1,0 +1,57 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{F8690922-C5FC-4A0E-B7AE-75D18C26E928}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>FullFramework</RootNamespace>
+    <AssemblyName>FullFramework</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/CycloneDX.IntegrationTests/Resources/FullFrameworkAndCore/FullFramework/packages.config
+++ b/CycloneDX.IntegrationTests/Resources/FullFrameworkAndCore/FullFramework/packages.config
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net472" />
+  <package id="NuGet.Common" version="5.2.0" targetFramework="net472" />
+  <package id="NuGet.Configuration" version="5.2.0" targetFramework="net472" />
+  <package id="NuGet.DependencyResolver.Core" version="5.2.0" targetFramework="net472" />
+  <package id="NuGet.Frameworks" version="5.2.0" targetFramework="net472" />
+  <package id="NuGet.LibraryModel" version="5.2.0" targetFramework="net472" />
+  <package id="NuGet.Packaging" version="5.2.0" targetFramework="net472" />
+  <package id="NuGet.ProjectModel" version="5.2.0" targetFramework="net472" />
+  <package id="NuGet.Protocol" version="5.2.0" targetFramework="net472" />
+  <package id="NuGet.Versioning" version="5.2.0" targetFramework="net472" />
+</packages>

--- a/CycloneDX.IntegrationTests/Resources/FullFrameworkAndCore/FullFrameworkAndCore.sln
+++ b/CycloneDX.IntegrationTests/Resources/FullFrameworkAndCore/FullFrameworkAndCore.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29609.76
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FullFramework", "FullFramework\FullFramework.csproj", "{F8690922-C5FC-4A0E-B7AE-75D18C26E928}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotnetCore", "DotnetCore\DotnetCore.csproj", "{EC78EFE0-697A-4F77-967E-92054A91A8BE}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F8690922-C5FC-4A0E-B7AE-75D18C26E928}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F8690922-C5FC-4A0E-B7AE-75D18C26E928}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F8690922-C5FC-4A0E-B7AE-75D18C26E928}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F8690922-C5FC-4A0E-B7AE-75D18C26E928}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EC78EFE0-697A-4F77-967E-92054A91A8BE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EC78EFE0-697A-4F77-967E-92054A91A8BE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EC78EFE0-697A-4F77-967E-92054A91A8BE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EC78EFE0-697A-4F77-967E-92054A91A8BE}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {DCA238A3-1829-4C95-8800-A3509ACFAF63}
+	EndGlobalSection
+EndGlobal

--- a/CycloneDX.IntegrationTests/Resources/NoDependencies/NoDependencies.Tests/NoDependencies.Tests.csproj
+++ b/CycloneDX.IntegrationTests/Resources/NoDependencies/NoDependencies.Tests/NoDependencies.Tests.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+</Project>

--- a/CycloneDX.IntegrationTests/Resources/NoDependencies/NoDependencies.sln
+++ b/CycloneDX.IntegrationTests/Resources/NoDependencies/NoDependencies.sln
@@ -1,0 +1,48 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NoDependencies", "NoDependencies\NoDependencies.csproj", "{63199851-FAE6-4443-8AD7-7AF8322EEADB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NoDependencies.Tests", "NoDependencies.Tests\NoDependencies.Tests.csproj", "{EEBC99CE-1B1E-47A2-8CC5-85BB67134ADE}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{63199851-FAE6-4443-8AD7-7AF8322EEADB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{63199851-FAE6-4443-8AD7-7AF8322EEADB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{63199851-FAE6-4443-8AD7-7AF8322EEADB}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{63199851-FAE6-4443-8AD7-7AF8322EEADB}.Debug|x64.Build.0 = Debug|Any CPU
+		{63199851-FAE6-4443-8AD7-7AF8322EEADB}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{63199851-FAE6-4443-8AD7-7AF8322EEADB}.Debug|x86.Build.0 = Debug|Any CPU
+		{63199851-FAE6-4443-8AD7-7AF8322EEADB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{63199851-FAE6-4443-8AD7-7AF8322EEADB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{63199851-FAE6-4443-8AD7-7AF8322EEADB}.Release|x64.ActiveCfg = Release|Any CPU
+		{63199851-FAE6-4443-8AD7-7AF8322EEADB}.Release|x64.Build.0 = Release|Any CPU
+		{63199851-FAE6-4443-8AD7-7AF8322EEADB}.Release|x86.ActiveCfg = Release|Any CPU
+		{63199851-FAE6-4443-8AD7-7AF8322EEADB}.Release|x86.Build.0 = Release|Any CPU
+		{EEBC99CE-1B1E-47A2-8CC5-85BB67134ADE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EEBC99CE-1B1E-47A2-8CC5-85BB67134ADE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EEBC99CE-1B1E-47A2-8CC5-85BB67134ADE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{EEBC99CE-1B1E-47A2-8CC5-85BB67134ADE}.Debug|x64.Build.0 = Debug|Any CPU
+		{EEBC99CE-1B1E-47A2-8CC5-85BB67134ADE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{EEBC99CE-1B1E-47A2-8CC5-85BB67134ADE}.Debug|x86.Build.0 = Debug|Any CPU
+		{EEBC99CE-1B1E-47A2-8CC5-85BB67134ADE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EEBC99CE-1B1E-47A2-8CC5-85BB67134ADE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EEBC99CE-1B1E-47A2-8CC5-85BB67134ADE}.Release|x64.ActiveCfg = Release|Any CPU
+		{EEBC99CE-1B1E-47A2-8CC5-85BB67134ADE}.Release|x64.Build.0 = Release|Any CPU
+		{EEBC99CE-1B1E-47A2-8CC5-85BB67134ADE}.Release|x86.ActiveCfg = Release|Any CPU
+		{EEBC99CE-1B1E-47A2-8CC5-85BB67134ADE}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/CycloneDX.IntegrationTests/Resources/NoDependencies/NoDependencies/NoDependencies.csproj
+++ b/CycloneDX.IntegrationTests/Resources/NoDependencies/NoDependencies/NoDependencies.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/CycloneDX.IntegrationTests/Resources/Vb/Vb.sln
+++ b/CycloneDX.IntegrationTests/Resources/Vb/Vb.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{F184B08F-C81C-45F6-A57F-5ABD9991F28F}") = "Vb", "Vb\Vb.vbproj", "{389EEA82-4DB4-4379-8502-89E775CEF455}"
+EndProject
+Global
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{389EEA82-4DB4-4379-8502-89E775CEF455}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{389EEA82-4DB4-4379-8502-89E775CEF455}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{389EEA82-4DB4-4379-8502-89E775CEF455}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{389EEA82-4DB4-4379-8502-89E775CEF455}.Debug|x64.Build.0 = Debug|Any CPU
+		{389EEA82-4DB4-4379-8502-89E775CEF455}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{389EEA82-4DB4-4379-8502-89E775CEF455}.Debug|x86.Build.0 = Debug|Any CPU
+		{389EEA82-4DB4-4379-8502-89E775CEF455}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{389EEA82-4DB4-4379-8502-89E775CEF455}.Release|Any CPU.Build.0 = Release|Any CPU
+		{389EEA82-4DB4-4379-8502-89E775CEF455}.Release|x64.ActiveCfg = Release|Any CPU
+		{389EEA82-4DB4-4379-8502-89E775CEF455}.Release|x64.Build.0 = Release|Any CPU
+		{389EEA82-4DB4-4379-8502-89E775CEF455}.Release|x86.ActiveCfg = Release|Any CPU
+		{389EEA82-4DB4-4379-8502-89E775CEF455}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/CycloneDX.IntegrationTests/Resources/Vb/Vb/Program.vb
+++ b/CycloneDX.IntegrationTests/Resources/Vb/Vb/Program.vb
@@ -1,0 +1,7 @@
+Imports System
+
+Module Program
+    Sub Main(args As String())
+        Console.WriteLine("Hello World!")
+    End Sub
+End Module

--- a/CycloneDX.IntegrationTests/Resources/Vb/Vb/Vb.vbproj
+++ b/CycloneDX.IntegrationTests/Resources/Vb/Vb/Vb.vbproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>VbProject</RootNamespace>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="2.0.0" />
+    <PackageReference Include="System.Net.Http" Version="4.3.1" />
+    <PackageReference Include="System.Net.Security" Version="4.3.0" />
+  </ItemGroup>
+
+</Project>

--- a/CycloneDX.IntegrationTests/TempDirectory.cs
+++ b/CycloneDX.IntegrationTests/TempDirectory.cs
@@ -1,0 +1,44 @@
+// This file is part of the CycloneDX Tool for .NET
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright (c) Steve Springett. All Rights Reserved.
+
+using System;
+using System.IO;
+
+namespace CycloneDX.IntegrationTests
+{
+    class TempDirectory : IDisposable
+    {
+        private string tempPath;
+        private string tempDirName;
+
+        public TempDirectory()
+        {
+            tempPath = Path.GetTempPath();
+            tempDirName = Path.GetRandomFileName();
+            Directory.CreateDirectory(DirectoryPath);
+        }
+
+        public void Dispose()
+        {
+            Directory.Delete(DirectoryPath, true);
+        }
+
+        public string DirectoryPath
+        {
+            get => Path.Join(tempPath, tempDirName);
+        }
+    }
+}

--- a/CycloneDX.IntegrationTests/__snapshots__/Tests.CallingCycloneDX_WithDirectoryPath_GeneratesBom_CSharp.snap
+++ b/CycloneDX.IntegrationTests/__snapshots__/Tests.CallingCycloneDX_WithDirectoryPath_GeneratesBom_CSharp.snap
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<bom version="1" xmlns="http://cyclonedx.org/schema/bom/1.1">
+  <components />
+</bom>

--- a/CycloneDX.IntegrationTests/__snapshots__/Tests.CallingCycloneDX_WithDirectoryPath_GeneratesBom_FullFrameworkAndCore.snap
+++ b/CycloneDX.IntegrationTests/__snapshots__/Tests.CallingCycloneDX_WithDirectoryPath_GeneratesBom_FullFrameworkAndCore.snap
@@ -1,0 +1,174 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<bom version="1" xmlns="http://cyclonedx.org/schema/bom/1.1">
+  <components>
+    <component type="library">
+      <name>Newtonsoft.Json</name>
+      <version>9.0.1</version>
+      <description><![CDATA[Json.NET is a popular high-performance JSON framework for .NET]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.github.com/JamesNK/Newtonsoft.Json/master/LICENSE.md</url>
+        </license>
+      </licenses>
+      <purl>pkg:nuget/Newtonsoft.Json@9.0.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>http://www.newtonsoft.com/json</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.Common</name>
+      <version>5.2.0</version>
+      <description><![CDATA[NuGet client library.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.Common@5.2.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.Configuration</name>
+      <version>5.2.0</version>
+      <description><![CDATA[NuGet's client configuration settings implementation.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.Configuration@5.2.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.DependencyResolver.Core</name>
+      <version>5.2.0</version>
+      <description><![CDATA[NuGet client library.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.DependencyResolver.Core@5.2.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.Frameworks</name>
+      <version>5.2.0</version>
+      <description><![CDATA[The understanding of target frameworks for NuGet.Packaging.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.Frameworks@5.2.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.LibraryModel</name>
+      <version>5.2.0</version>
+      <description><![CDATA[NuGet client library.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.LibraryModel@5.2.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.Packaging</name>
+      <version>5.2.0</version>
+      <description><![CDATA[NuGet's implementation for reading nupkg package and nuspec package specification files.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.Packaging@5.2.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.ProjectModel</name>
+      <version>5.2.0</version>
+      <description><![CDATA[NuGet client library.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.ProjectModel@5.2.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.Protocol</name>
+      <version>5.2.0</version>
+      <description><![CDATA[NuGet client library.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.Protocol@5.2.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.Versioning</name>
+      <version>5.2.0</version>
+      <description><![CDATA[NuGet's implementation of Semantic Versioning.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.Versioning@5.2.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+</bom>

--- a/CycloneDX.IntegrationTests/__snapshots__/Tests.CallingCycloneDX_WithDirectoryPath_GeneratesBom_NoDependencies.snap
+++ b/CycloneDX.IntegrationTests/__snapshots__/Tests.CallingCycloneDX_WithDirectoryPath_GeneratesBom_NoDependencies.snap
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<bom version="1" xmlns="http://cyclonedx.org/schema/bom/1.1">
+  <components />
+</bom>

--- a/CycloneDX.IntegrationTests/__snapshots__/Tests.CallingCycloneDX_WithDirectoryPath_GeneratesBom_Vb.snap
+++ b/CycloneDX.IntegrationTests/__snapshots__/Tests.CallingCycloneDX_WithDirectoryPath_GeneratesBom_Vb.snap
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<bom version="1" xmlns="http://cyclonedx.org/schema/bom/1.1">
+  <components />
+</bom>

--- a/CycloneDX.IntegrationTests/__snapshots__/Tests.CallingCycloneDX_WithProjectPath_GeneratesBom_CSharp_CSharp_csproj.snap
+++ b/CycloneDX.IntegrationTests/__snapshots__/Tests.CallingCycloneDX_WithProjectPath_GeneratesBom_CSharp_CSharp_csproj.snap
@@ -1,0 +1,1241 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<bom version="1" xmlns="http://cyclonedx.org/schema/bom/1.1">
+  <components>
+    <component type="library">
+      <name>Microsoft.NETCore.App</name>
+      <version>2.1.0</version>
+      <description><![CDATA[A set of .NET API's that are included in the default .NET Core application model. 
+caa7b7e2bad98e56a687fb5cbaf60825500800f7 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.NETCore.App@2.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.NETCore.DotNetAppHost</name>
+      <version>2.1.0</version>
+      <description><![CDATA[Provides the .NET Core app bootstrapper intended for use in the application directory 
+caa7b7e2bad98e56a687fb5cbaf60825500800f7 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.NETCore.DotNetAppHost@2.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.NETCore.DotNetHostPolicy</name>
+      <version>2.1.0</version>
+      <description><![CDATA[Provides a CoreCLR hosting policy implementation -- configuration settings, assembly paths and assembly servicing 
+caa7b7e2bad98e56a687fb5cbaf60825500800f7 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.NETCore.DotNetHostPolicy@2.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.NETCore.DotNetHostResolver</name>
+      <version>2.1.0</version>
+      <description><![CDATA[Provides an implementation of framework resolution strategy used by Microsoft.NETCore.DotNetHost 
+caa7b7e2bad98e56a687fb5cbaf60825500800f7 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.NETCore.DotNetHostResolver@2.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.NETCore.Platforms</name>
+      <version>2.1.0</version>
+      <description><![CDATA[Provides runtime information required to resolve target framework, platform, and runtime specific implementations of .NETCore packages. 
+30ab651fcb4354552bd4891619a0bdd81e0ebdbf 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/corefx/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.NETCore.Platforms@2.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.NETCore.Targets</name>
+      <version>2.1.0</version>
+      <description><![CDATA[Provides supporting infrastructure for portable projects: support identifiers that define framework and runtime for support targets and packages that reference the minimum supported package versions when targeting these. 
+30ab651fcb4354552bd4891619a0bdd81e0ebdbf 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/corefx/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.NETCore.Targets@2.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.Win32.Primitives</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides common types for Win32-based libraries.
+
+Commonly Used Types:
+System.ComponentModel.Win32Exception
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.Win32.Primitives@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.Win32.Registry</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides support for accessing and modifying the Windows Registry.
+
+Commonly Used Types:
+Microsoft.Win32.RegistryKey
+Microsoft.Win32.Registry
+Microsoft.Win32.RegistryValueKind
+Microsoft.Win32.RegistryHive
+Microsoft.Win32.RegistryView
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.Win32.Registry@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NETStandard.Library</name>
+      <version>2.0.3</version>
+      <description><![CDATA[A set of standard .NET APIs that are prescribed to be used and supported together. 
+18a36291e48808fa7ef2d00a764ceb1ec95645a5 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/standard/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>.NET Foundation and Contributors</copyright>
+      <purl>pkg:nuget/NETStandard.Library@2.0.3</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Newtonsoft.Json</name>
+      <version>12.0.3</version>
+      <description><![CDATA[Json.NET is a popular high-performance JSON framework for .NET]]></description>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <copyright>Copyright © James Newton-King 2008</copyright>
+      <purl>pkg:nuget/Newtonsoft.Json@12.0.3</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://www.newtonsoft.com/json</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.Common</name>
+      <version>5.4.0</version>
+      <description><![CDATA[NuGet client library.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.Common@5.4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.Configuration</name>
+      <version>5.4.0</version>
+      <description><![CDATA[NuGet's client configuration settings implementation.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.Configuration@5.4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.DependencyResolver.Core</name>
+      <version>5.4.0</version>
+      <description><![CDATA[NuGet client library.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.DependencyResolver.Core@5.4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.Frameworks</name>
+      <version>5.4.0</version>
+      <description><![CDATA[The understanding of target frameworks for NuGet.Packaging.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.Frameworks@5.4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.LibraryModel</name>
+      <version>5.4.0</version>
+      <description><![CDATA[NuGet client library.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.LibraryModel@5.4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.Packaging</name>
+      <version>5.4.0</version>
+      <description><![CDATA[NuGet's implementation for reading nupkg package and nuspec package specification files.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.Packaging@5.4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.ProjectModel</name>
+      <version>5.4.0</version>
+      <description><![CDATA[NuGet client library.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.ProjectModel@5.4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.Protocol</name>
+      <version>5.4.0</version>
+      <description><![CDATA[NuGet client library.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.Protocol@5.4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.Versioning</name>
+      <version>5.4.0</version>
+      <description><![CDATA[NuGet's implementation of Semantic Versioning.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.Versioning@5.4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>runtime.native.System</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Internal implementation package not meant for direct consumption.  Please do not reference directly. 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/runtime.native.System@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Collections</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes that define generic collections, which allow developers to create strongly typed collections that provide better type safety and performance than non-generic strongly typed collections.
+
+Commonly Used Types:
+System.Collections.Generic.List<T>
+System.Collections.Generic.Dictionary<TKey, TValue>
+System.Collections.Generic.Queue<T>
+System.Collections.Generic.Stack<T>
+System.Collections.Generic.HashSet<T>
+System.Collections.Generic.LinkedList<T>
+System.Collections.Generic.EqualityComparer<T>
+System.Collections.Generic.Comparer<T>
+System.Collections.Generic.SortedDictionary<TKey, TValue>
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Collections@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Diagnostics.Debug</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes and attributes that allows basic interaction with a debugger.
+
+Commonly Used Types:
+System.Diagnostics.Debug
+System.Diagnostics.DebuggerStepThroughAttribute
+System.Diagnostics.Debugger
+System.Diagnostics.DebuggerDisplayAttribute
+System.Diagnostics.DebuggerBrowsableAttribute
+System.Diagnostics.DebuggerBrowsableState
+System.Diagnostics.DebuggerHiddenAttribute
+System.Diagnostics.DebuggerNonUserCodeAttribute
+System.Diagnostics.DebuggerTypeProxyAttribute
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Diagnostics.Debug@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Diagnostics.Process</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the System.Diagnostics.Process class, which allows interaction with local and remote processes.
+
+Commonly Used Types:
+System.Diagnostics.Process
+System.Diagnostics.ProcessModule
+System.Diagnostics.ProcessStartInfo
+System.Diagnostics.ProcessThread
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Diagnostics.Process@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Dynamic.Runtime</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes and interfaces that support the Dynamic Language Runtime (DLR).
+
+Commonly Used Types:
+System.Runtime.CompilerServices.CallSite
+System.Runtime.CompilerServices.CallSite<T>
+System.Dynamic.IDynamicMetaObjectProvider
+System.Dynamic.DynamicMetaObject
+System.Dynamic.SetMemberBinder
+System.Dynamic.GetMemberBinder
+System.Dynamic.ExpandoObject
+System.Dynamic.DynamicObject
+System.Runtime.CompilerServices.CallSiteBinder
+System.Runtime.CompilerServices.ConditionalWeakTable<TKey, TValue>
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Dynamic.Runtime@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Globalization</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes that define culture-related information, including language, country/region, calendars in use, format patterns for dates, currency, and numbers, and sort order for strings.
+
+Commonly Used Types:
+System.Globalization.DateTimeFormatInfo
+System.Globalization.CultureInfo
+System.Globalization.NumberFormatInfo
+System.Globalization.CalendarWeekRule
+System.Globalization.TextInfo
+System.Globalization.Calendar
+System.Globalization.CompareInfo
+System.Globalization.CompareOptions
+System.Globalization.UnicodeCategory
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Globalization@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.IO</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides base input and output (I/O) types, including System.IO.Stream, System.IO.StreamReader and System.IO.StreamWriter, that allow reading and writing to data streams
+
+Commonly Used Types:
+System.IO.Stream
+System.IO.EndOfStreamException
+System.IO.MemoryStream
+System.IO.StreamReader
+System.IO.StreamWriter
+System.IO.StringWriter
+System.IO.TextWriter
+System.IO.TextReader
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.IO@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.IO.FileSystem</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides types that allow reading and writing to files and types that provide basic file and directory support.
+
+Commonly Used Types:
+System.IO.FileStream
+System.IO.FileInfo
+System.IO.DirectoryInfo
+System.IO.FileSystemInfo
+System.IO.File
+System.IO.Directory
+System.IO.SearchOption
+System.IO.FileOptions
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.IO.FileSystem@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.IO.FileSystem.Primitives</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides common enumerations and exceptions for path-based I/O libraries.
+
+Commonly Used Types:
+System.IO.DirectoryNotFoundException
+System.IO.FileAccess
+System.IO.FileLoadException
+System.IO.PathTooLongException
+System.IO.FileMode
+System.IO.FileShare
+System.IO.FileAttributes
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.IO.FileSystem.Primitives@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Linq</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes and interfaces that supports queries that use Language-Integrated Query (LINQ).
+
+Commonly Used Types:
+System.Linq.Enumerable
+System.Linq.IGrouping<TKey, TElement>
+System.Linq.IOrderedEnumerable<TElement>
+System.Linq.ILookup<TKey, TElement>
+System.Linq.Lookup<TKey, TElement>
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Linq@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Linq.Expressions</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes, interfaces and enumerations that enable language-level code expressions to be represented as objects in the form of expression trees.
+
+Commonly Used Types:
+System.Linq.IQueryable<T>
+System.Linq.IQueryable
+System.Linq.Expressions.Expression<TDelegate>
+System.Linq.Expressions.Expression
+System.Linq.Expressions.ExpressionVisitor
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Linq.Expressions@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.ObjectModel</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides types and interfaces that allow the creation of observable types that provide notifications to clients when changes are made to it.
+
+Commonly Used Types:
+System.ComponentModel.INotifyPropertyChanged
+System.Collections.ObjectModel.ObservableCollection<T>
+System.ComponentModel.PropertyChangedEventHandler
+System.Windows.Input.ICommand
+System.Collections.Specialized.INotifyCollectionChanged
+System.Collections.Specialized.NotifyCollectionChangedEventArgs
+System.Collections.Specialized.NotifyCollectionChangedEventHandler
+System.Collections.ObjectModel.KeyedCollection<TKey, TItem>
+System.ComponentModel.PropertyChangedEventArgs
+System.Collections.ObjectModel.ReadOnlyDictionary<TKey, TValue>
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.ObjectModel@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Reflection</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides types that retrieve information about assemblies, modules, members, parameters, and other entities in managed code by examining their metadata. These types also can be used to manipulate instances of loaded types, for example to hook up events or to invoke methods.
+
+Commonly Used Types:
+System.Reflection.MethodInfo
+System.Reflection.PropertyInfo
+System.Reflection.ParameterInfo
+System.Reflection.FieldInfo
+System.Reflection.ConstructorInfo
+System.Reflection.Assembly
+System.Reflection.MemberInfo
+System.Reflection.EventInfo
+System.Reflection.Module
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Reflection@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Reflection.Emit</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes that allow a compiler or tool to emit metadata and optionally generate a PE file on disk. The primary clients of these classes are script engines and compilers.
+
+Commonly Used Types:
+System.Reflection.Emit.AssemblyBuilder
+System.Reflection.Emit.FieldBuilder
+System.Reflection.Emit.TypeBuilder
+System.Reflection.Emit.MethodBuilder
+System.Reflection.Emit.ConstructorBuilder
+System.Reflection.Emit.GenericTypeParameterBuilder
+System.Reflection.Emit.ModuleBuilder
+System.Reflection.Emit.PropertyBuilder
+System.Reflection.Emit.AssemblyBuilderAccess
+System.Reflection.Emit.EventBuilder
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Reflection.Emit@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Reflection.Emit.ILGeneration</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes that allow a compiler or tool to emit Microsoft intermediate language (MSIL). The primary clients of these classes are script engines and compilers.
+
+Commonly Used Types:
+System.Reflection.Emit.ILGenerator
+System.Reflection.Emit.Label
+System.Reflection.Emit.CustomAttributeBuilder
+System.Reflection.Emit.LocalBuilder
+System.Reflection.Emit.ParameterBuilder
+System.Reflection.Emit.SignatureHelper
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Reflection.Emit.ILGeneration@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Reflection.Emit.Lightweight</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the System.Reflection.Emit.DynamicMethod class, which represents a dynamic method that can be compiled, executed, and discarded. Discarded methods are available for garbage collection.
+
+Commonly Used Types:
+System.Reflection.Emit.DynamicMethod
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Reflection.Emit.Lightweight@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Reflection.Extensions</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides custom attribute extension methods for System.Reflection types.
+
+Commonly Used Types:
+System.Reflection.InterfaceMapping
+System.Reflection.CustomAttributeExtensions
+System.Reflection.RuntimeReflectionExtensions
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Reflection.Extensions@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Reflection.Primitives</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides common enumerations for reflection-based libraries.
+
+Commonly Used Types:
+System.Reflection.FieldAttributes
+System.Reflection.Emit.OpCode
+System.Reflection.TypeAttributes
+System.Reflection.MethodAttributes
+System.Reflection.CallingConventions
+System.Reflection.PropertyAttributes
+System.Reflection.EventAttributes
+System.Reflection.ParameterAttributes
+System.Reflection.GenericParameterAttributes
+System.Reflection.MethodImplAttributes
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Reflection.Primitives@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Reflection.TypeExtensions</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides extensions methods for System.Type that are designed to be source-compatible with older framework reflection-based APIs.
+
+Commonly Used Types:
+System.Reflection.TypeExtensions
+System.Reflection.BindingFlags
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Reflection.TypeExtensions@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Resources.ResourceManager</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes and attributes that allow developers to create, store, and manage various culture-specific resources used in an application.
+
+Commonly Used Types:
+System.Resources.ResourceManager
+System.Resources.NeutralResourcesLanguageAttribute
+System.Resources.SatelliteContractVersionAttribute
+System.Resources.MissingManifestResourceException
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Resources.ResourceManager@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Runtime</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the fundamental primitives, classes and base classes that define commonly-used value and reference data types, events and event handlers, interfaces, attributes, and exceptions. This packages represents the core package, and provides the minimal set of types required to build a managed application.
+
+Commonly Used Types:
+System.Object
+System.Exception
+System.Int16
+System.Int32
+System.Int64
+System.Enum
+System.String
+System.Char
+System.Boolean
+System.SByte
+System.Byte
+System.DateTime
+System.DateTimeOffset
+System.Single
+System.Double
+System.UInt16
+System.UInt32
+System.UInt64
+System.IDisposable
+System.Uri
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Runtime@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Runtime.Extensions</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides commonly-used classes for performing mathematical functions, conversions, string comparisons and querying environment information.
+
+Commonly Used Types:
+System.Math
+System.Environment
+System.Random
+System.Progress<T>
+System.Convert
+System.Diagnostics.Stopwatch
+System.Runtime.Versioning.FrameworkName
+System.StringComparer
+System.IO.Path
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Runtime.Extensions@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Runtime.Handles</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides base classes, including System.Runtime.InteropServices.CriticalHandle and System.Runtime.InteropServices.SafeHandle, for types that represent operating system handles.
+
+Commonly Used Types:
+System.Runtime.InteropServices.SafeHandle
+Microsoft.Win32.SafeHandles.SafeWaitHandle
+System.Runtime.InteropServices.CriticalHandle
+System.Threading.WaitHandleExtensions
+System.IO.HandleInheritability
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Runtime.Handles@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Runtime.InteropServices</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides types that support COM interop and platform invoke services.
+
+Commonly Used Types:
+System.Runtime.InteropServices.GCHandle
+System.Runtime.InteropServices.GuidAttribute
+System.Runtime.InteropServices.COMException
+System.DllNotFoundException
+System.Runtime.InteropServices.DllImportAttribute
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Runtime.InteropServices@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Security.Cryptography.Primitives</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides common types for the cryptographic libraries.
+
+Commonly Used Types:
+System.Security.Cryptography.ICryptoTransform
+System.Security.Cryptography.AsymmetricAlgorithm
+System.Security.Cryptography.SymmetricAlgorithm
+System.Security.Cryptography.HashAlgorithm
+System.Security.Cryptography.KeyedHashAlgorithm
+System.Security.Cryptography.HMAC
+System.Security.Cryptography.KeySizes
+System.Security.Cryptography.CryptographicException
+System.Security.Cryptography.CipherMode
+System.Security.Cryptography.PaddingMode
+System.Security.Cryptography.CryptoStream
+System.Security.Cryptography.CryptoStreamMode
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Security.Cryptography.Primitives@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Security.Cryptography.ProtectedData</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides access to Windows Data Protection Api.
+
+Commonly Used Types:
+System.Security.Cryptography.DataProtectionScope
+System.Security.Cryptography.ProtectedData
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Security.Cryptography.ProtectedData@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Text.Encoding</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides base abstract encoding classes for converting blocks of characters to and from blocks of bytes.
+
+Commonly Used Types:
+System.Text.Encoding
+System.Text.DecoderFallbackException
+System.Text.Decoder
+System.Text.EncoderFallbackException
+System.Text.Encoder
+System.Text.EncoderFallback
+System.Text.EncoderFallbackBuffer
+System.Text.DecoderFallback
+System.Text.DecoderFallbackBuffer
+System.Text.DecoderExceptionFallback
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Text.Encoding@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Text.Encoding.Extensions</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides support for specific encodings, including ASCII, UTF-7, UTF-8, UTF-16, and UTF-32.
+
+Commonly Used Types:
+System.Text.UTF8Encoding
+System.Text.UnicodeEncoding
+System.Text.ASCIIEncoding
+System.Text.UTF7Encoding
+System.Text.UTF32Encoding
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Text.Encoding.Extensions@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Threading</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the fundamental synchronization primitives, including System.Threading.Monitor and System.Threading.Mutex, that are required when writing asynchronous code.
+
+Commonly Used Types:
+System.Threading.Monitor
+System.Threading.SynchronizationContext
+System.Threading.ManualResetEvent
+System.Threading.AutoResetEvent
+System.Threading.ThreadLocal<T>
+System.Threading.EventWaitHandle
+System.Threading.SemaphoreSlim
+System.Threading.Mutex
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Threading@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Threading.Tasks</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides types that simplify the work of writing concurrent and asynchronous code.
+
+Commonly Used Types:
+System.Threading.Tasks.Task<TResult>
+System.Runtime.CompilerServices.TaskAwaiter<TResult>
+System.Threading.Tasks.TaskCompletionSource<TResult>
+System.Threading.Tasks.Task
+System.OperationCanceledException
+System.AggregateException
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Threading.Tasks@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Threading.Thread</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the System.Threading.Thread class, which allows developers to create and control a thread, set its priority, and get its state.
+
+Commonly Used Types:
+System.Threading.Thread
+System.Threading.ThreadStart
+System.Threading.ParameterizedThreadStart
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Threading.Thread@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Threading.ThreadPool</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the System.Threading.ThreadPool class, which contains a pool of threads that can be used to execute tasks, post work items, wait on behalf of other threads, and process timers.
+
+Commonly Used Types:
+System.Threading.ThreadPool
+System.Threading.WaitOrTimerCallback
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Threading.ThreadPool@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+</bom>

--- a/CycloneDX.IntegrationTests/__snapshots__/Tests.CallingCycloneDX_WithProjectPath_GeneratesBom_FullFrameworkAndCore_DotnetCore_csproj.snap
+++ b/CycloneDX.IntegrationTests/__snapshots__/Tests.CallingCycloneDX_WithProjectPath_GeneratesBom_FullFrameworkAndCore_DotnetCore_csproj.snap
@@ -1,0 +1,1241 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<bom version="1" xmlns="http://cyclonedx.org/schema/bom/1.1">
+  <components>
+    <component type="library">
+      <name>Microsoft.NETCore.App</name>
+      <version>2.1.0</version>
+      <description><![CDATA[A set of .NET API's that are included in the default .NET Core application model. 
+caa7b7e2bad98e56a687fb5cbaf60825500800f7 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.NETCore.App@2.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.NETCore.DotNetAppHost</name>
+      <version>2.1.0</version>
+      <description><![CDATA[Provides the .NET Core app bootstrapper intended for use in the application directory 
+caa7b7e2bad98e56a687fb5cbaf60825500800f7 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.NETCore.DotNetAppHost@2.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.NETCore.DotNetHostPolicy</name>
+      <version>2.1.0</version>
+      <description><![CDATA[Provides a CoreCLR hosting policy implementation -- configuration settings, assembly paths and assembly servicing 
+caa7b7e2bad98e56a687fb5cbaf60825500800f7 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.NETCore.DotNetHostPolicy@2.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.NETCore.DotNetHostResolver</name>
+      <version>2.1.0</version>
+      <description><![CDATA[Provides an implementation of framework resolution strategy used by Microsoft.NETCore.DotNetHost 
+caa7b7e2bad98e56a687fb5cbaf60825500800f7 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.NETCore.DotNetHostResolver@2.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.NETCore.Platforms</name>
+      <version>2.1.0</version>
+      <description><![CDATA[Provides runtime information required to resolve target framework, platform, and runtime specific implementations of .NETCore packages. 
+30ab651fcb4354552bd4891619a0bdd81e0ebdbf 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/corefx/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.NETCore.Platforms@2.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.NETCore.Targets</name>
+      <version>2.1.0</version>
+      <description><![CDATA[Provides supporting infrastructure for portable projects: support identifiers that define framework and runtime for support targets and packages that reference the minimum supported package versions when targeting these. 
+30ab651fcb4354552bd4891619a0bdd81e0ebdbf 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/corefx/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.NETCore.Targets@2.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.Win32.Primitives</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides common types for Win32-based libraries.
+
+Commonly Used Types:
+System.ComponentModel.Win32Exception
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.Win32.Primitives@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.Win32.Registry</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides support for accessing and modifying the Windows Registry.
+
+Commonly Used Types:
+Microsoft.Win32.RegistryKey
+Microsoft.Win32.Registry
+Microsoft.Win32.RegistryValueKind
+Microsoft.Win32.RegistryHive
+Microsoft.Win32.RegistryView
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.Win32.Registry@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NETStandard.Library</name>
+      <version>2.0.3</version>
+      <description><![CDATA[A set of standard .NET APIs that are prescribed to be used and supported together. 
+18a36291e48808fa7ef2d00a764ceb1ec95645a5 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/standard/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>.NET Foundation and Contributors</copyright>
+      <purl>pkg:nuget/NETStandard.Library@2.0.3</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Newtonsoft.Json</name>
+      <version>12.0.3</version>
+      <description><![CDATA[Json.NET is a popular high-performance JSON framework for .NET]]></description>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <copyright>Copyright © James Newton-King 2008</copyright>
+      <purl>pkg:nuget/Newtonsoft.Json@12.0.3</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://www.newtonsoft.com/json</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.Common</name>
+      <version>5.4.0</version>
+      <description><![CDATA[NuGet client library.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.Common@5.4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.Configuration</name>
+      <version>5.4.0</version>
+      <description><![CDATA[NuGet's client configuration settings implementation.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.Configuration@5.4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.DependencyResolver.Core</name>
+      <version>5.4.0</version>
+      <description><![CDATA[NuGet client library.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.DependencyResolver.Core@5.4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.Frameworks</name>
+      <version>5.4.0</version>
+      <description><![CDATA[The understanding of target frameworks for NuGet.Packaging.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.Frameworks@5.4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.LibraryModel</name>
+      <version>5.4.0</version>
+      <description><![CDATA[NuGet client library.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.LibraryModel@5.4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.Packaging</name>
+      <version>5.4.0</version>
+      <description><![CDATA[NuGet's implementation for reading nupkg package and nuspec package specification files.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.Packaging@5.4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.ProjectModel</name>
+      <version>5.4.0</version>
+      <description><![CDATA[NuGet client library.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.ProjectModel@5.4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.Protocol</name>
+      <version>5.4.0</version>
+      <description><![CDATA[NuGet client library.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.Protocol@5.4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.Versioning</name>
+      <version>5.4.0</version>
+      <description><![CDATA[NuGet's implementation of Semantic Versioning.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.Versioning@5.4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>runtime.native.System</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Internal implementation package not meant for direct consumption.  Please do not reference directly. 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/runtime.native.System@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Collections</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes that define generic collections, which allow developers to create strongly typed collections that provide better type safety and performance than non-generic strongly typed collections.
+
+Commonly Used Types:
+System.Collections.Generic.List<T>
+System.Collections.Generic.Dictionary<TKey, TValue>
+System.Collections.Generic.Queue<T>
+System.Collections.Generic.Stack<T>
+System.Collections.Generic.HashSet<T>
+System.Collections.Generic.LinkedList<T>
+System.Collections.Generic.EqualityComparer<T>
+System.Collections.Generic.Comparer<T>
+System.Collections.Generic.SortedDictionary<TKey, TValue>
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Collections@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Diagnostics.Debug</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes and attributes that allows basic interaction with a debugger.
+
+Commonly Used Types:
+System.Diagnostics.Debug
+System.Diagnostics.DebuggerStepThroughAttribute
+System.Diagnostics.Debugger
+System.Diagnostics.DebuggerDisplayAttribute
+System.Diagnostics.DebuggerBrowsableAttribute
+System.Diagnostics.DebuggerBrowsableState
+System.Diagnostics.DebuggerHiddenAttribute
+System.Diagnostics.DebuggerNonUserCodeAttribute
+System.Diagnostics.DebuggerTypeProxyAttribute
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Diagnostics.Debug@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Diagnostics.Process</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the System.Diagnostics.Process class, which allows interaction with local and remote processes.
+
+Commonly Used Types:
+System.Diagnostics.Process
+System.Diagnostics.ProcessModule
+System.Diagnostics.ProcessStartInfo
+System.Diagnostics.ProcessThread
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Diagnostics.Process@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Dynamic.Runtime</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes and interfaces that support the Dynamic Language Runtime (DLR).
+
+Commonly Used Types:
+System.Runtime.CompilerServices.CallSite
+System.Runtime.CompilerServices.CallSite<T>
+System.Dynamic.IDynamicMetaObjectProvider
+System.Dynamic.DynamicMetaObject
+System.Dynamic.SetMemberBinder
+System.Dynamic.GetMemberBinder
+System.Dynamic.ExpandoObject
+System.Dynamic.DynamicObject
+System.Runtime.CompilerServices.CallSiteBinder
+System.Runtime.CompilerServices.ConditionalWeakTable<TKey, TValue>
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Dynamic.Runtime@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Globalization</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes that define culture-related information, including language, country/region, calendars in use, format patterns for dates, currency, and numbers, and sort order for strings.
+
+Commonly Used Types:
+System.Globalization.DateTimeFormatInfo
+System.Globalization.CultureInfo
+System.Globalization.NumberFormatInfo
+System.Globalization.CalendarWeekRule
+System.Globalization.TextInfo
+System.Globalization.Calendar
+System.Globalization.CompareInfo
+System.Globalization.CompareOptions
+System.Globalization.UnicodeCategory
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Globalization@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.IO</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides base input and output (I/O) types, including System.IO.Stream, System.IO.StreamReader and System.IO.StreamWriter, that allow reading and writing to data streams
+
+Commonly Used Types:
+System.IO.Stream
+System.IO.EndOfStreamException
+System.IO.MemoryStream
+System.IO.StreamReader
+System.IO.StreamWriter
+System.IO.StringWriter
+System.IO.TextWriter
+System.IO.TextReader
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.IO@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.IO.FileSystem</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides types that allow reading and writing to files and types that provide basic file and directory support.
+
+Commonly Used Types:
+System.IO.FileStream
+System.IO.FileInfo
+System.IO.DirectoryInfo
+System.IO.FileSystemInfo
+System.IO.File
+System.IO.Directory
+System.IO.SearchOption
+System.IO.FileOptions
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.IO.FileSystem@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.IO.FileSystem.Primitives</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides common enumerations and exceptions for path-based I/O libraries.
+
+Commonly Used Types:
+System.IO.DirectoryNotFoundException
+System.IO.FileAccess
+System.IO.FileLoadException
+System.IO.PathTooLongException
+System.IO.FileMode
+System.IO.FileShare
+System.IO.FileAttributes
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.IO.FileSystem.Primitives@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Linq</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes and interfaces that supports queries that use Language-Integrated Query (LINQ).
+
+Commonly Used Types:
+System.Linq.Enumerable
+System.Linq.IGrouping<TKey, TElement>
+System.Linq.IOrderedEnumerable<TElement>
+System.Linq.ILookup<TKey, TElement>
+System.Linq.Lookup<TKey, TElement>
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Linq@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Linq.Expressions</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes, interfaces and enumerations that enable language-level code expressions to be represented as objects in the form of expression trees.
+
+Commonly Used Types:
+System.Linq.IQueryable<T>
+System.Linq.IQueryable
+System.Linq.Expressions.Expression<TDelegate>
+System.Linq.Expressions.Expression
+System.Linq.Expressions.ExpressionVisitor
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Linq.Expressions@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.ObjectModel</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides types and interfaces that allow the creation of observable types that provide notifications to clients when changes are made to it.
+
+Commonly Used Types:
+System.ComponentModel.INotifyPropertyChanged
+System.Collections.ObjectModel.ObservableCollection<T>
+System.ComponentModel.PropertyChangedEventHandler
+System.Windows.Input.ICommand
+System.Collections.Specialized.INotifyCollectionChanged
+System.Collections.Specialized.NotifyCollectionChangedEventArgs
+System.Collections.Specialized.NotifyCollectionChangedEventHandler
+System.Collections.ObjectModel.KeyedCollection<TKey, TItem>
+System.ComponentModel.PropertyChangedEventArgs
+System.Collections.ObjectModel.ReadOnlyDictionary<TKey, TValue>
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.ObjectModel@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Reflection</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides types that retrieve information about assemblies, modules, members, parameters, and other entities in managed code by examining their metadata. These types also can be used to manipulate instances of loaded types, for example to hook up events or to invoke methods.
+
+Commonly Used Types:
+System.Reflection.MethodInfo
+System.Reflection.PropertyInfo
+System.Reflection.ParameterInfo
+System.Reflection.FieldInfo
+System.Reflection.ConstructorInfo
+System.Reflection.Assembly
+System.Reflection.MemberInfo
+System.Reflection.EventInfo
+System.Reflection.Module
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Reflection@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Reflection.Emit</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes that allow a compiler or tool to emit metadata and optionally generate a PE file on disk. The primary clients of these classes are script engines and compilers.
+
+Commonly Used Types:
+System.Reflection.Emit.AssemblyBuilder
+System.Reflection.Emit.FieldBuilder
+System.Reflection.Emit.TypeBuilder
+System.Reflection.Emit.MethodBuilder
+System.Reflection.Emit.ConstructorBuilder
+System.Reflection.Emit.GenericTypeParameterBuilder
+System.Reflection.Emit.ModuleBuilder
+System.Reflection.Emit.PropertyBuilder
+System.Reflection.Emit.AssemblyBuilderAccess
+System.Reflection.Emit.EventBuilder
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Reflection.Emit@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Reflection.Emit.ILGeneration</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes that allow a compiler or tool to emit Microsoft intermediate language (MSIL). The primary clients of these classes are script engines and compilers.
+
+Commonly Used Types:
+System.Reflection.Emit.ILGenerator
+System.Reflection.Emit.Label
+System.Reflection.Emit.CustomAttributeBuilder
+System.Reflection.Emit.LocalBuilder
+System.Reflection.Emit.ParameterBuilder
+System.Reflection.Emit.SignatureHelper
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Reflection.Emit.ILGeneration@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Reflection.Emit.Lightweight</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the System.Reflection.Emit.DynamicMethod class, which represents a dynamic method that can be compiled, executed, and discarded. Discarded methods are available for garbage collection.
+
+Commonly Used Types:
+System.Reflection.Emit.DynamicMethod
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Reflection.Emit.Lightweight@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Reflection.Extensions</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides custom attribute extension methods for System.Reflection types.
+
+Commonly Used Types:
+System.Reflection.InterfaceMapping
+System.Reflection.CustomAttributeExtensions
+System.Reflection.RuntimeReflectionExtensions
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Reflection.Extensions@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Reflection.Primitives</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides common enumerations for reflection-based libraries.
+
+Commonly Used Types:
+System.Reflection.FieldAttributes
+System.Reflection.Emit.OpCode
+System.Reflection.TypeAttributes
+System.Reflection.MethodAttributes
+System.Reflection.CallingConventions
+System.Reflection.PropertyAttributes
+System.Reflection.EventAttributes
+System.Reflection.ParameterAttributes
+System.Reflection.GenericParameterAttributes
+System.Reflection.MethodImplAttributes
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Reflection.Primitives@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Reflection.TypeExtensions</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides extensions methods for System.Type that are designed to be source-compatible with older framework reflection-based APIs.
+
+Commonly Used Types:
+System.Reflection.TypeExtensions
+System.Reflection.BindingFlags
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Reflection.TypeExtensions@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Resources.ResourceManager</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes and attributes that allow developers to create, store, and manage various culture-specific resources used in an application.
+
+Commonly Used Types:
+System.Resources.ResourceManager
+System.Resources.NeutralResourcesLanguageAttribute
+System.Resources.SatelliteContractVersionAttribute
+System.Resources.MissingManifestResourceException
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Resources.ResourceManager@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Runtime</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the fundamental primitives, classes and base classes that define commonly-used value and reference data types, events and event handlers, interfaces, attributes, and exceptions. This packages represents the core package, and provides the minimal set of types required to build a managed application.
+
+Commonly Used Types:
+System.Object
+System.Exception
+System.Int16
+System.Int32
+System.Int64
+System.Enum
+System.String
+System.Char
+System.Boolean
+System.SByte
+System.Byte
+System.DateTime
+System.DateTimeOffset
+System.Single
+System.Double
+System.UInt16
+System.UInt32
+System.UInt64
+System.IDisposable
+System.Uri
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Runtime@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Runtime.Extensions</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides commonly-used classes for performing mathematical functions, conversions, string comparisons and querying environment information.
+
+Commonly Used Types:
+System.Math
+System.Environment
+System.Random
+System.Progress<T>
+System.Convert
+System.Diagnostics.Stopwatch
+System.Runtime.Versioning.FrameworkName
+System.StringComparer
+System.IO.Path
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Runtime.Extensions@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Runtime.Handles</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides base classes, including System.Runtime.InteropServices.CriticalHandle and System.Runtime.InteropServices.SafeHandle, for types that represent operating system handles.
+
+Commonly Used Types:
+System.Runtime.InteropServices.SafeHandle
+Microsoft.Win32.SafeHandles.SafeWaitHandle
+System.Runtime.InteropServices.CriticalHandle
+System.Threading.WaitHandleExtensions
+System.IO.HandleInheritability
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Runtime.Handles@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Runtime.InteropServices</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides types that support COM interop and platform invoke services.
+
+Commonly Used Types:
+System.Runtime.InteropServices.GCHandle
+System.Runtime.InteropServices.GuidAttribute
+System.Runtime.InteropServices.COMException
+System.DllNotFoundException
+System.Runtime.InteropServices.DllImportAttribute
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Runtime.InteropServices@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Security.Cryptography.Primitives</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides common types for the cryptographic libraries.
+
+Commonly Used Types:
+System.Security.Cryptography.ICryptoTransform
+System.Security.Cryptography.AsymmetricAlgorithm
+System.Security.Cryptography.SymmetricAlgorithm
+System.Security.Cryptography.HashAlgorithm
+System.Security.Cryptography.KeyedHashAlgorithm
+System.Security.Cryptography.HMAC
+System.Security.Cryptography.KeySizes
+System.Security.Cryptography.CryptographicException
+System.Security.Cryptography.CipherMode
+System.Security.Cryptography.PaddingMode
+System.Security.Cryptography.CryptoStream
+System.Security.Cryptography.CryptoStreamMode
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Security.Cryptography.Primitives@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Security.Cryptography.ProtectedData</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides access to Windows Data Protection Api.
+
+Commonly Used Types:
+System.Security.Cryptography.DataProtectionScope
+System.Security.Cryptography.ProtectedData
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Security.Cryptography.ProtectedData@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Text.Encoding</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides base abstract encoding classes for converting blocks of characters to and from blocks of bytes.
+
+Commonly Used Types:
+System.Text.Encoding
+System.Text.DecoderFallbackException
+System.Text.Decoder
+System.Text.EncoderFallbackException
+System.Text.Encoder
+System.Text.EncoderFallback
+System.Text.EncoderFallbackBuffer
+System.Text.DecoderFallback
+System.Text.DecoderFallbackBuffer
+System.Text.DecoderExceptionFallback
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Text.Encoding@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Text.Encoding.Extensions</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides support for specific encodings, including ASCII, UTF-7, UTF-8, UTF-16, and UTF-32.
+
+Commonly Used Types:
+System.Text.UTF8Encoding
+System.Text.UnicodeEncoding
+System.Text.ASCIIEncoding
+System.Text.UTF7Encoding
+System.Text.UTF32Encoding
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Text.Encoding.Extensions@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Threading</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the fundamental synchronization primitives, including System.Threading.Monitor and System.Threading.Mutex, that are required when writing asynchronous code.
+
+Commonly Used Types:
+System.Threading.Monitor
+System.Threading.SynchronizationContext
+System.Threading.ManualResetEvent
+System.Threading.AutoResetEvent
+System.Threading.ThreadLocal<T>
+System.Threading.EventWaitHandle
+System.Threading.SemaphoreSlim
+System.Threading.Mutex
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Threading@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Threading.Tasks</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides types that simplify the work of writing concurrent and asynchronous code.
+
+Commonly Used Types:
+System.Threading.Tasks.Task<TResult>
+System.Runtime.CompilerServices.TaskAwaiter<TResult>
+System.Threading.Tasks.TaskCompletionSource<TResult>
+System.Threading.Tasks.Task
+System.OperationCanceledException
+System.AggregateException
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Threading.Tasks@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Threading.Thread</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the System.Threading.Thread class, which allows developers to create and control a thread, set its priority, and get its state.
+
+Commonly Used Types:
+System.Threading.Thread
+System.Threading.ThreadStart
+System.Threading.ParameterizedThreadStart
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Threading.Thread@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Threading.ThreadPool</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the System.Threading.ThreadPool class, which contains a pool of threads that can be used to execute tasks, post work items, wait on behalf of other threads, and process timers.
+
+Commonly Used Types:
+System.Threading.ThreadPool
+System.Threading.WaitOrTimerCallback
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Threading.ThreadPool@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+</bom>

--- a/CycloneDX.IntegrationTests/__snapshots__/Tests.CallingCycloneDX_WithProjectPath_GeneratesBom_FullFrameworkAndCore_FullFramework_csproj.snap
+++ b/CycloneDX.IntegrationTests/__snapshots__/Tests.CallingCycloneDX_WithProjectPath_GeneratesBom_FullFrameworkAndCore_FullFramework_csproj.snap
@@ -1,0 +1,174 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<bom version="1" xmlns="http://cyclonedx.org/schema/bom/1.1">
+  <components>
+    <component type="library">
+      <name>Newtonsoft.Json</name>
+      <version>9.0.1</version>
+      <description><![CDATA[Json.NET is a popular high-performance JSON framework for .NET]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.github.com/JamesNK/Newtonsoft.Json/master/LICENSE.md</url>
+        </license>
+      </licenses>
+      <purl>pkg:nuget/Newtonsoft.Json@9.0.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>http://www.newtonsoft.com/json</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.Common</name>
+      <version>5.2.0</version>
+      <description><![CDATA[NuGet client library.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.Common@5.2.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.Configuration</name>
+      <version>5.2.0</version>
+      <description><![CDATA[NuGet's client configuration settings implementation.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.Configuration@5.2.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.DependencyResolver.Core</name>
+      <version>5.2.0</version>
+      <description><![CDATA[NuGet client library.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.DependencyResolver.Core@5.2.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.Frameworks</name>
+      <version>5.2.0</version>
+      <description><![CDATA[The understanding of target frameworks for NuGet.Packaging.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.Frameworks@5.2.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.LibraryModel</name>
+      <version>5.2.0</version>
+      <description><![CDATA[NuGet client library.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.LibraryModel@5.2.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.Packaging</name>
+      <version>5.2.0</version>
+      <description><![CDATA[NuGet's implementation for reading nupkg package and nuspec package specification files.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.Packaging@5.2.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.ProjectModel</name>
+      <version>5.2.0</version>
+      <description><![CDATA[NuGet client library.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.ProjectModel@5.2.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.Protocol</name>
+      <version>5.2.0</version>
+      <description><![CDATA[NuGet client library.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.Protocol@5.2.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.Versioning</name>
+      <version>5.2.0</version>
+      <description><![CDATA[NuGet's implementation of Semantic Versioning.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.Versioning@5.2.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+</bom>

--- a/CycloneDX.IntegrationTests/__snapshots__/Tests.CallingCycloneDX_WithProjectPath_GeneratesBom_NoDependencies_NoDependencies.Tests_csproj.snap
+++ b/CycloneDX.IntegrationTests/__snapshots__/Tests.CallingCycloneDX_WithProjectPath_GeneratesBom_NoDependencies_NoDependencies.Tests_csproj.snap
@@ -1,0 +1,138 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<bom version="1" xmlns="http://cyclonedx.org/schema/bom/1.1">
+  <components>
+    <component type="library">
+      <name>Microsoft.NETCore.App</name>
+      <version>2.1.0</version>
+      <description><![CDATA[A set of .NET API's that are included in the default .NET Core application model. 
+caa7b7e2bad98e56a687fb5cbaf60825500800f7 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.NETCore.App@2.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.NETCore.DotNetAppHost</name>
+      <version>2.1.0</version>
+      <description><![CDATA[Provides the .NET Core app bootstrapper intended for use in the application directory 
+caa7b7e2bad98e56a687fb5cbaf60825500800f7 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.NETCore.DotNetAppHost@2.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.NETCore.DotNetHostPolicy</name>
+      <version>2.1.0</version>
+      <description><![CDATA[Provides a CoreCLR hosting policy implementation -- configuration settings, assembly paths and assembly servicing 
+caa7b7e2bad98e56a687fb5cbaf60825500800f7 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.NETCore.DotNetHostPolicy@2.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.NETCore.DotNetHostResolver</name>
+      <version>2.1.0</version>
+      <description><![CDATA[Provides an implementation of framework resolution strategy used by Microsoft.NETCore.DotNetHost 
+caa7b7e2bad98e56a687fb5cbaf60825500800f7 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.NETCore.DotNetHostResolver@2.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.NETCore.Platforms</name>
+      <version>2.1.0</version>
+      <description><![CDATA[Provides runtime information required to resolve target framework, platform, and runtime specific implementations of .NETCore packages. 
+30ab651fcb4354552bd4891619a0bdd81e0ebdbf 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/corefx/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.NETCore.Platforms@2.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.NETCore.Targets</name>
+      <version>2.1.0</version>
+      <description><![CDATA[Provides supporting infrastructure for portable projects: support identifiers that define framework and runtime for support targets and packages that reference the minimum supported package versions when targeting these. 
+30ab651fcb4354552bd4891619a0bdd81e0ebdbf 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/corefx/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.NETCore.Targets@2.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NETStandard.Library</name>
+      <version>2.0.3</version>
+      <description><![CDATA[A set of standard .NET APIs that are prescribed to be used and supported together. 
+18a36291e48808fa7ef2d00a764ceb1ec95645a5 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/standard/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>.NET Foundation and Contributors</copyright>
+      <purl>pkg:nuget/NETStandard.Library@2.0.3</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+</bom>

--- a/CycloneDX.IntegrationTests/__snapshots__/Tests.CallingCycloneDX_WithProjectPath_GeneratesBom_NoDependencies_NoDependencies_csproj.snap
+++ b/CycloneDX.IntegrationTests/__snapshots__/Tests.CallingCycloneDX_WithProjectPath_GeneratesBom_NoDependencies_NoDependencies_csproj.snap
@@ -1,0 +1,138 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<bom version="1" xmlns="http://cyclonedx.org/schema/bom/1.1">
+  <components>
+    <component type="library">
+      <name>Microsoft.NETCore.App</name>
+      <version>2.1.0</version>
+      <description><![CDATA[A set of .NET API's that are included in the default .NET Core application model. 
+caa7b7e2bad98e56a687fb5cbaf60825500800f7 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.NETCore.App@2.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.NETCore.DotNetAppHost</name>
+      <version>2.1.0</version>
+      <description><![CDATA[Provides the .NET Core app bootstrapper intended for use in the application directory 
+caa7b7e2bad98e56a687fb5cbaf60825500800f7 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.NETCore.DotNetAppHost@2.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.NETCore.DotNetHostPolicy</name>
+      <version>2.1.0</version>
+      <description><![CDATA[Provides a CoreCLR hosting policy implementation -- configuration settings, assembly paths and assembly servicing 
+caa7b7e2bad98e56a687fb5cbaf60825500800f7 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.NETCore.DotNetHostPolicy@2.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.NETCore.DotNetHostResolver</name>
+      <version>2.1.0</version>
+      <description><![CDATA[Provides an implementation of framework resolution strategy used by Microsoft.NETCore.DotNetHost 
+caa7b7e2bad98e56a687fb5cbaf60825500800f7 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.NETCore.DotNetHostResolver@2.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.NETCore.Platforms</name>
+      <version>2.1.0</version>
+      <description><![CDATA[Provides runtime information required to resolve target framework, platform, and runtime specific implementations of .NETCore packages. 
+30ab651fcb4354552bd4891619a0bdd81e0ebdbf 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/corefx/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.NETCore.Platforms@2.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.NETCore.Targets</name>
+      <version>2.1.0</version>
+      <description><![CDATA[Provides supporting infrastructure for portable projects: support identifiers that define framework and runtime for support targets and packages that reference the minimum supported package versions when targeting these. 
+30ab651fcb4354552bd4891619a0bdd81e0ebdbf 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/corefx/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.NETCore.Targets@2.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NETStandard.Library</name>
+      <version>2.0.3</version>
+      <description><![CDATA[A set of standard .NET APIs that are prescribed to be used and supported together. 
+18a36291e48808fa7ef2d00a764ceb1ec95645a5 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/standard/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>.NET Foundation and Contributors</copyright>
+      <purl>pkg:nuget/NETStandard.Library@2.0.3</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+</bom>

--- a/CycloneDX.IntegrationTests/__snapshots__/Tests.CallingCycloneDX_WithProjectPath_GeneratesBom_Vb_Vb_vbproj.snap
+++ b/CycloneDX.IntegrationTests/__snapshots__/Tests.CallingCycloneDX_WithProjectPath_GeneratesBom_Vb_Vb_vbproj.snap
@@ -1,0 +1,3891 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<bom version="1" xmlns="http://cyclonedx.org/schema/bom/1.1">
+  <components>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Antiforgery</name>
+      <version>2.0.0</version>
+      <description><![CDATA[An antiforgery system for ASP.NET Core designed to generate and validate tokens to prevent Cross-Site Request Forgery attacks.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Antiforgery@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Authentication.Abstractions</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core common types used by the various authentication components.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Authentication.Abstractions@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Authentication.Core</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core common types used by the various authentication middleware components.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Authentication.Core@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Authorization</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core authorization classes.
+Commonly used types:
+Microsoft.AspNetCore.Authorization.AllowAnonymousAttribute
+Microsoft.AspNetCore.Authorization.AuthorizeAttribute]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Authorization@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Authorization.Policy</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core authorization policy helper classes.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Authorization.Policy@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Cors</name>
+      <version>2.0.0</version>
+      <description><![CDATA[CORS middleware and policy for ASP.NET Core to enable cross-origin resource sharing.
+Commonly used types:
+Microsoft.AspNetCore.Cors.DisableCorsAttribute
+Microsoft.AspNetCore.Cors.EnableCorsAttribute]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Cors@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Cryptography.Internal</name>
+      <version>2.0.0</version>
+      <description><![CDATA[Infrastructure for ASP.NET Core cryptographic packages. Applications and libraries should not reference this package directly.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Cryptography.Internal@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.DataProtection</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core logic to protect and unprotect data, similar to DPAPI.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.DataProtection@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.DataProtection.Abstractions</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core data protection abstractions.
+Commonly used types:
+Microsoft.AspNetCore.DataProtection.IDataProtectionProvider
+Microsoft.AspNetCore.DataProtection.IDataProtector]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.DataProtection.Abstractions@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Diagnostics.Abstractions</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core diagnostics middleware abstractions and feature interface definitions.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Diagnostics.Abstractions@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Hosting.Abstractions</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core hosting and startup abstractions for web applications.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Hosting.Abstractions@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Hosting.Server.Abstractions</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core hosting server abstractions for web applications.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Hosting.Server.Abstractions@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Html.Abstractions</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core HTML abstractions used for building HTML content.
+Commonly used types:
+Microsoft.AspNetCore.Html.HtmlString
+Microsoft.AspNetCore.Html.IHtmlContent]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Html.Abstractions@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Http</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core default HTTP feature implementations.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Http@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Http.Abstractions</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core HTTP object model for HTTP requests and responses and also common extension methods for registering middleware in an IApplicationBuilder.
+Commonly used types:
+Microsoft.AspNetCore.Builder.IApplicationBuilder
+Microsoft.AspNetCore.Http.HttpContext
+Microsoft.AspNetCore.Http.HttpRequest
+Microsoft.AspNetCore.Http.HttpResponse]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Http.Abstractions@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Http.Extensions</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core common extension methods for HTTP abstractions, HTTP headers, HTTP request/response, and session state.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Http.Extensions@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Http.Features</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core HTTP feature interface definitions.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Http.Features@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.HttpOverrides</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core basic middleware for supporting HTTP method overrides. Includes:
+* X-Forwarded-* headers to forward headers from a proxy.
+* HTTP method override header.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.HttpOverrides@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.JsonPatch</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core support for JSON PATCH.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.JsonPatch@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Localization</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core middleware for automatically applying culture information to HTTP requests. Culture information can be specified in the HTTP header, query string, cookie, or custom source.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Localization@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Mvc</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core MVC is a web framework that gives you a powerful, patterns-based way to build dynamic websites and web APIs. ASP.NET Core MVC enables a clean separation of concerns and gives you full control over markup.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Mvc@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Mvc.Abstractions</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core MVC abstractions and interfaces for action invocation and dispatching, authorization, action filters, formatters, model binding, routing, validation, and more.
+Commonly used types:
+Microsoft.AspNetCore.Mvc.IActionResult]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Mvc.Abstractions@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Mvc.ApiExplorer</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core MVC API explorer functionality for discovering metadata such as the list of controllers and actions, and their URLs and allowed HTTP methods.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Mvc.ApiExplorer@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Mvc.Core</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core MVC core components. Contains common action result types, attribute routing, application model conventions, API explorer, application parts, filters, formatters, model binding, and more.
+Commonly used types:
+Microsoft.AspNetCore.Mvc.AreaAttribute
+Microsoft.AspNetCore.Mvc.BindAttribute
+Microsoft.AspNetCore.Mvc.ControllerBase
+Microsoft.AspNetCore.Mvc.FromBodyAttribute
+Microsoft.AspNetCore.Mvc.FromFormAttribute
+Microsoft.AspNetCore.Mvc.RequireHttpsAttribute
+Microsoft.AspNetCore.Mvc.RouteAttribute]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Mvc.Core@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Mvc.Cors</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core MVC cross-origin resource sharing (CORS) features.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Mvc.Cors@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Mvc.DataAnnotations</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core MVC metadata and validation system using System.ComponentModel.DataAnnotations.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Mvc.DataAnnotations@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Mvc.Formatters.Json</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core MVC formatters for JSON input and output and for JSON PATCH input using Json.NET.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Mvc.Formatters.Json@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Mvc.Localization</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core MVC features that enable globalization and localization of applications.
+Commonly used types:
+Microsoft.AspNetCore.Mvc.Localization.IHtmlLocalizer<TResource>
+Microsoft.AspNetCore.Mvc.Localization.IViewLocalizer]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Mvc.Localization@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Mvc.Razor</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core MVC Razor view engine for CSHTML files.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Mvc.Razor@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Mvc.Razor.Extensions</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core design time hosting infrastructure for the Razor view engine.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Mvc.Razor.Extensions@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Mvc.RazorPages</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core MVC Razor Pages.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Mvc.RazorPages@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Mvc.TagHelpers</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core MVC default tag helpers. Contains tag helpers for anchor tags, HTML input elements, caching, scripts, links (for CSS), and more.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Mvc.TagHelpers@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Mvc.ViewFeatures</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core MVC view rendering features. Contains common types used in most MVC applications as well as view rendering features such as view engines, views, view components, and HTML helpers.
+Commonly used types:
+Microsoft.AspNetCore.Mvc.Controller
+Microsoft.AspNetCore.Mvc.ValidateAntiForgeryTokenAttribute
+Microsoft.AspNetCore.Mvc.ViewComponent]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Mvc.ViewFeatures@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Razor</name>
+      <version>2.0.0</version>
+      <description><![CDATA[Razor is a markup syntax for adding server-side logic to web pages. This package contains the Razor parser and code generation infrastructure.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Razor@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Razor.Language</name>
+      <version>2.0.0</version>
+      <description><![CDATA[Razor is a markup syntax for adding server-side logic to web pages. This package contains the Razor parser and code generation infrastructure.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Razor.Language@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Razor.Runtime</name>
+      <version>2.0.0</version>
+      <description><![CDATA[Runtime components for rendering Razor pages and implementing tag helpers.
+
+Commonly used types:
+Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeNameAttribute
+Microsoft.AspNetCore.Razor.TagHelpers.HtmlTargetElementAttribute
+Microsoft.AspNetCore.Razor.TagHelpers.ITagHelper]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Razor.Runtime@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.ResponseCaching.Abstractions</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core response caching middleware abstractions and feature interface definitions.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.ResponseCaching.Abstractions@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Routing</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core middleware for routing requests to application logic and for generating links.
+Commonly used types:
+Microsoft.AspNetCore.Routing.Route
+Microsoft.AspNetCore.Routing.RouteCollection]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Routing@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Routing.Abstractions</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core abstractions for routing requests to application logic and for generating links.
+Commonly used types:
+Microsoft.AspNetCore.Routing.IRouter
+Microsoft.AspNetCore.Routing.RouteData]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Routing.Abstractions@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Server.IISIntegration</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core components for working with the IIS AspNetCoreModule.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Server.IISIntegration@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.WebUtilities</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core utilities, such as for working with forms, multipart messages, and query strings.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.WebUtilities@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.CodeAnalysis.Analyzers</name>
+      <version>1.1.0</version>
+      <description><![CDATA[Analyzers for .NET Compiler Platform ("Roslyn")]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=529443</url>
+        </license>
+      </licenses>
+      <purl>pkg:nuget/Microsoft.CodeAnalysis.Analyzers@1.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>http://msdn.com/roslyn</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.CodeAnalysis.Common</name>
+      <version>2.3.1</version>
+      <description><![CDATA[A shared package used by the Microsoft .NET Compiler Platform ("Roslyn").]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=529443</url>
+        </license>
+      </licenses>
+      <purl>pkg:nuget/Microsoft.CodeAnalysis.Common@2.3.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>http://msdn.com/roslyn</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.CodeAnalysis.CSharp</name>
+      <version>2.3.1</version>
+      <description><![CDATA[.NET Compiler Platform ("Roslyn") support for C#, Microsoft.CodeAnalysis.CSharp.dll.
+
+      More details at https://aka.ms/roslyn-packages]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=529443</url>
+        </license>
+      </licenses>
+      <purl>pkg:nuget/Microsoft.CodeAnalysis.CSharp@2.3.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>http://msdn.com/roslyn</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.CodeAnalysis.Razor</name>
+      <version>2.0.0</version>
+      <description><![CDATA[Razor is a markup syntax for adding server-side logic to web pages. This package contains the Razor design-time infrastructure.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.CodeAnalysis.Razor@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.CSharp</name>
+      <version>4.4.0</version>
+      <description><![CDATA[Provides support for compilation and code generation, including dynamic, using the C# language.
+
+Commonly Used Types:
+Microsoft.CSharp.RuntimeBinder.Binder
+Microsoft.CSharp.RuntimeBinder.RuntimeBinderException
+Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo
+Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags
+Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags
+ 
+8321c729934c0f8be754953439b88e6e1c120c24 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/corefx/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.CSharp@4.4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.DotNet.PlatformAbstractions</name>
+      <version>2.0.0</version>
+      <description><![CDATA[Abstractions for making code that uses file system and environment testable.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.DotNet.PlatformAbstractions@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.Extensions.Caching.Abstractions</name>
+      <version>2.0.0</version>
+      <description><![CDATA[Caching abstractions for in-memory cache and distributed cache.
+Commonly used types:
+Microsoft.Extensions.Caching.Distributed.IDistributedCache
+Microsoft.Extensions.Caching.Memory.IMemoryCache]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.Extensions.Caching.Abstractions@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.Extensions.Caching.Memory</name>
+      <version>2.0.0</version>
+      <description><![CDATA[In-memory cache implementation of Microsoft.Extensions.Caching.Memory.IMemoryCache.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.Extensions.Caching.Memory@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.Extensions.Configuration.Abstractions</name>
+      <version>2.0.0</version>
+      <description><![CDATA[Abstractions of key-value pair based configuration.
+Commonly used types:
+Microsoft.Extensions.Configuration.IConfiguration
+Microsoft.Extensions.Configuration.IConfigurationBuilder
+Microsoft.Extensions.Configuration.IConfigurationProvider
+Microsoft.Extensions.Configuration.IConfigurationRoot
+Microsoft.Extensions.Configuration.IConfigurationSection]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.Extensions.Configuration.Abstractions@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.Extensions.DependencyInjection</name>
+      <version>2.0.0</version>
+      <description><![CDATA[Default implementation of dependency injection for Microsoft.Extensions.DependencyInjection.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.Extensions.DependencyInjection@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.Extensions.DependencyInjection.Abstractions</name>
+      <version>2.0.0</version>
+      <description><![CDATA[Abstractions for dependency injection.
+Commonly used types:
+Microsoft.Extensions.DependencyInjection.IServiceCollection]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.Extensions.DependencyInjection.Abstractions@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.Extensions.DependencyModel</name>
+      <version>2.0.0</version>
+      <description><![CDATA[Abstractions for reading `.deps` files.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.Extensions.DependencyModel@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.Extensions.FileProviders.Abstractions</name>
+      <version>2.0.0</version>
+      <description><![CDATA[Abstractions of files and directories.
+Commonly used types:
+Microsoft.Extensions.FileProviders.IDirectoryContents
+Microsoft.Extensions.FileProviders.IFileInfo
+Microsoft.Extensions.FileProviders.IFileProvider]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.Extensions.FileProviders.Abstractions@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.Extensions.FileProviders.Composite</name>
+      <version>2.0.0</version>
+      <description><![CDATA[Composite file and directory providers for Microsoft.Extensions.FileProviders.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.Extensions.FileProviders.Composite@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.Extensions.FileSystemGlobbing</name>
+      <version>2.0.0</version>
+      <description><![CDATA[File system globbing to find files matching a specified pattern.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.Extensions.FileSystemGlobbing@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.Extensions.Hosting.Abstractions</name>
+      <version>2.0.0</version>
+      <description><![CDATA[.NET Core hosting and startup abstractions for applications.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.Extensions.Hosting.Abstractions@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.Extensions.Localization</name>
+      <version>2.0.0</version>
+      <description><![CDATA[Application localization services and default implementation based on ResourceManager to load localized assembly resources.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.Extensions.Localization@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.Extensions.Localization.Abstractions</name>
+      <version>2.0.0</version>
+      <description><![CDATA[Abstractions of application localization services.
+Commonly used types:
+Microsoft.Extensions.Localization.IStringLocalizer
+Microsoft.Extensions.Localization.IStringLocalizer<T>]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.Extensions.Localization.Abstractions@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.Extensions.Logging.Abstractions</name>
+      <version>2.0.0</version>
+      <description><![CDATA[Logging abstractions for Microsoft.Extensions.Logging.
+Commonly used types:
+Microsoft.Extensions.Logging.ILogger
+Microsoft.Extensions.Logging.ILoggerFactory
+Microsoft.Extensions.Logging.ILogger<TCategoryName>
+Microsoft.Extensions.Logging.LogLevel
+Microsoft.Extensions.Logging.Logger<T>
+Microsoft.Extensions.Logging.LoggerMessage
+Microsoft.Extensions.Logging.Abstractions.NullLogger]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.Extensions.Logging.Abstractions@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.Extensions.ObjectPool</name>
+      <version>2.0.0</version>
+      <description><![CDATA[A simple object pool implementation.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.Extensions.ObjectPool@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.Extensions.Options</name>
+      <version>2.0.0</version>
+      <description><![CDATA[Provides a strongly typed way of specifying and accessing settings using dependency injection.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.Extensions.Options@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.Extensions.Primitives</name>
+      <version>2.0.0</version>
+      <description><![CDATA[Primitives shared by framework extensions. Commonly used types include:
+Microsoft.Extensions.Primitives.IChangeToken
+Microsoft.Extensions.Primitives.StringValues
+Microsoft.Extensions.Primitives.StringSegment]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.Extensions.Primitives@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.Extensions.WebEncoders</name>
+      <version>2.0.0</version>
+      <description><![CDATA[Contains registration and configuration APIs to add the core framework encoders to a dependency injection container.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.Extensions.WebEncoders@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.Net.Http.Headers</name>
+      <version>2.0.0</version>
+      <description><![CDATA[HTTP header parser implementations.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.Net.Http.Headers@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.NETCore.App</name>
+      <version>2.1.0</version>
+      <description><![CDATA[A set of .NET API's that are included in the default .NET Core application model. 
+caa7b7e2bad98e56a687fb5cbaf60825500800f7 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.NETCore.App@2.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.NETCore.DotNetAppHost</name>
+      <version>2.1.0</version>
+      <description><![CDATA[Provides the .NET Core app bootstrapper intended for use in the application directory 
+caa7b7e2bad98e56a687fb5cbaf60825500800f7 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.NETCore.DotNetAppHost@2.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.NETCore.DotNetHostPolicy</name>
+      <version>2.1.0</version>
+      <description><![CDATA[Provides a CoreCLR hosting policy implementation -- configuration settings, assembly paths and assembly servicing 
+caa7b7e2bad98e56a687fb5cbaf60825500800f7 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.NETCore.DotNetHostPolicy@2.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.NETCore.DotNetHostResolver</name>
+      <version>2.1.0</version>
+      <description><![CDATA[Provides an implementation of framework resolution strategy used by Microsoft.NETCore.DotNetHost 
+caa7b7e2bad98e56a687fb5cbaf60825500800f7 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.NETCore.DotNetHostResolver@2.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.NETCore.Platforms</name>
+      <version>2.1.0</version>
+      <description><![CDATA[Provides runtime information required to resolve target framework, platform, and runtime specific implementations of .NETCore packages. 
+30ab651fcb4354552bd4891619a0bdd81e0ebdbf 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/corefx/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.NETCore.Platforms@2.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.NETCore.Targets</name>
+      <version>2.1.0</version>
+      <description><![CDATA[Provides supporting infrastructure for portable projects: support identifiers that define framework and runtime for support targets and packages that reference the minimum supported package versions when targeting these. 
+30ab651fcb4354552bd4891619a0bdd81e0ebdbf 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/corefx/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.NETCore.Targets@2.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.Win32.Primitives</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides common types for Win32-based libraries.
+
+Commonly Used Types:
+System.ComponentModel.Win32Exception
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.Win32.Primitives@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.Win32.Registry</name>
+      <version>4.4.0</version>
+      <description><![CDATA[Provides support for accessing and modifying the Windows Registry.
+
+Commonly Used Types:
+Microsoft.Win32.RegistryKey
+Microsoft.Win32.Registry
+Microsoft.Win32.RegistryValueKind
+Microsoft.Win32.RegistryHive
+Microsoft.Win32.RegistryView
+ 
+8321c729934c0f8be754953439b88e6e1c120c24 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/corefx/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.Win32.Registry@4.4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NETStandard.Library</name>
+      <version>2.0.3</version>
+      <description><![CDATA[A set of standard .NET APIs that are prescribed to be used and supported together. 
+18a36291e48808fa7ef2d00a764ceb1ec95645a5 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/standard/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>.NET Foundation and Contributors</copyright>
+      <purl>pkg:nuget/NETStandard.Library@2.0.3</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Newtonsoft.Json</name>
+      <version>10.0.1</version>
+      <description><![CDATA[Json.NET is a popular high-performance JSON framework for .NET]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.github.com/JamesNK/Newtonsoft.Json/master/LICENSE.md</url>
+        </license>
+      </licenses>
+      <purl>pkg:nuget/Newtonsoft.Json@10.0.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>http://www.newtonsoft.com/json</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Newtonsoft.Json.Bson</name>
+      <version>1.0.1</version>
+      <description><![CDATA[Json.NET BSON adds support for reading and writing BSON]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.github.com/JamesNK/Newtonsoft.Json.Bson/master/LICENSE.md</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © James Newton-King 2017</copyright>
+      <purl>pkg:nuget/Newtonsoft.Json.Bson@1.0.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>http://www.newtonsoft.com/json</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Internal implementation package not meant for direct consumption.  Please do not reference directly. 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Internal implementation package not meant for direct consumption.  Please do not reference directly. 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Internal implementation package not meant for direct consumption.  Please do not reference directly. 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>runtime.native.System</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Internal implementation package not meant for direct consumption.  Please do not reference directly. 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/runtime.native.System@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>runtime.native.System.IO.Compression</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Internal implementation package not meant for direct consumption.  Please do not reference directly. 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/runtime.native.System.IO.Compression@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>runtime.native.System.Net.Http</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Internal implementation package not meant for direct consumption.  Please do not reference directly. 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/runtime.native.System.Net.Http@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>runtime.native.System.Net.Security</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Internal implementation package not meant for direct consumption.  Please do not reference directly. 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/runtime.native.System.Net.Security@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>runtime.native.System.Security.Cryptography.Apple</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Internal implementation package not meant for direct consumption.  Please do not reference directly. 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/runtime.native.System.Security.Cryptography.Apple@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>runtime.native.System.Security.Cryptography.OpenSsl</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Internal implementation package not meant for direct consumption.  Please do not reference directly. 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/runtime.native.System.Security.Cryptography.OpenSsl@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Internal implementation package not meant for direct consumption.  Please do not reference directly. 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Internal implementation package not meant for direct consumption.  Please do not reference directly. 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Internal implementation package not meant for direct consumption.  Please do not reference directly. 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Internal implementation package not meant for direct consumption.  Please do not reference directly. 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Internal implementation package not meant for direct consumption.  Please do not reference directly. 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Internal implementation package not meant for direct consumption.  Please do not reference directly. 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Internal implementation package not meant for direct consumption.  Please do not reference directly. 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Internal implementation package not meant for direct consumption.  Please do not reference directly. 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.AppContext</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the System.AppContext class, which allows access to the BaseDirectory property and other application specific data.
+
+Commonly Used Types:
+System.AppContext
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.AppContext@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Buffers</name>
+      <version>4.4.0</version>
+      <description><![CDATA[Provides resource pooling of any type for performance-critical applications that allocate and deallocate objects frequently.
+
+Commonly Used Types:
+System.Buffers.ArrayPool<T>
+ 
+8321c729934c0f8be754953439b88e6e1c120c24 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/corefx/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Buffers@4.4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Collections</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes that define generic collections, which allow developers to create strongly typed collections that provide better type safety and performance than non-generic strongly typed collections.
+
+Commonly Used Types:
+System.Collections.Generic.List<T>
+System.Collections.Generic.Dictionary<TKey, TValue>
+System.Collections.Generic.Queue<T>
+System.Collections.Generic.Stack<T>
+System.Collections.Generic.HashSet<T>
+System.Collections.Generic.LinkedList<T>
+System.Collections.Generic.EqualityComparer<T>
+System.Collections.Generic.Comparer<T>
+System.Collections.Generic.SortedDictionary<TKey, TValue>
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Collections@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Collections.Concurrent</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides several thread-safe collection classes that should be used in place of the corresponding types in the System.Collections.NonGeneric and System.Collections packages whenever multiple threads are accessing the collection concurrently.
+
+Commonly Used Types:
+System.Collections.Concurrent.ConcurrentDictionary<TKey, TValue>
+System.Collections.Concurrent.ConcurrentQueue<T>
+System.Collections.Concurrent.ConcurrentBag<T>
+System.Collections.Concurrent.BlockingCollection<T>
+System.Collections.Concurrent.ConcurrentStack<T>
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Collections.Concurrent@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Collections.Immutable</name>
+      <version>1.3.1</version>
+      <description><![CDATA[This package provides collections that are thread safe and guaranteed to never change their contents, also known as immutable collections. Like strings, any methods that perform modifications will not change the existing instance but instead return a new instance. For efficiency reasons, the implementation uses a sharing mechanism to ensure that newly created instances share as much data as possible with the previous instance while ensuring that operations have a predictable time complexity.
+
+Commonly Used Types:
+System.Collections.Immutable.ImmutableArray
+System.Collections.Immutable.ImmutableArray<T>
+System.Collections.Immutable.ImmutableDictionary
+System.Collections.Immutable.ImmutableDictionary<TKey,TValue>
+System.Collections.Immutable.ImmutableHashSet
+System.Collections.Immutable.ImmutableHashSet<T>
+System.Collections.Immutable.ImmutableList
+System.Collections.Immutable.ImmutableList<T>
+System.Collections.Immutable.ImmutableQueue
+System.Collections.Immutable.ImmutableQueue<T>
+System.Collections.Immutable.ImmutableSortedDictionary
+System.Collections.Immutable.ImmutableSortedDictionary<TKey,TValue>
+System.Collections.Immutable.ImmutableSortedSet
+System.Collections.Immutable.ImmutableSortedSet<T>
+System.Collections.Immutable.ImmutableStack
+System.Collections.Immutable.ImmutableStack<T>]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Collections.Immutable@1.3.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Collections.NonGeneric</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes that define older non-generic collections of objects, such as lists, queues, hash tables and dictionaries. Developers should prefer the generic collections in the System.Collections package.
+
+Commonly Used Types:
+System.Collections.ArrayList
+System.Collections.Hashtable
+System.Collections.CollectionBase
+System.Collections.ReadOnlyCollectionBase
+System.Collections.Stack
+System.Collections.SortedList
+System.Collections.DictionaryBase
+System.Collections.Queue
+System.Collections.Comparer
+System.Collections.CaseInsensitiveComparer
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Collections.NonGeneric@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Collections.Specialized</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides older specialized non-generic collections; for example, a linked list dictionary, a bit vector, and collections that contain only strings.
+
+Commonly Used Types:
+System.Collections.Specialized.NameValueCollection
+System.Collections.Specialized.NameObjectCollectionBase
+System.Collections.Specialized.StringCollection
+System.Collections.Specialized.IOrderedDictionary
+System.Collections.Specialized.HybridDictionary
+System.Collections.Specialized.OrderedDictionary
+System.Collections.Specialized.ListDictionary
+System.Collections.Specialized.StringDictionary
+System.Collections.Specialized.BitVector32
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Collections.Specialized@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.ComponentModel</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides interfaces for the editing and change tracking of objects used as data sources.
+
+Commonly Used Types:
+System.ComponentModel.CancelEventArgs
+System.IServiceProvider
+System.ComponentModel.IEditableObject
+System.ComponentModel.IChangeTracking
+System.ComponentModel.IRevertibleChangeTracking
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.ComponentModel@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.ComponentModel.Annotations</name>
+      <version>4.4.0</version>
+      <description><![CDATA[Provides attributes that are used to define metadata for objects used as data sources.
+
+Commonly Used Types:
+System.ComponentModel.DataAnnotations.ValidationResult
+System.ComponentModel.DataAnnotations.IValidatableObject
+System.ComponentModel.DataAnnotations.ValidationAttribute
+System.ComponentModel.DataAnnotations.RequiredAttribute
+System.ComponentModel.DataAnnotations.StringLengthAttribute
+System.ComponentModel.DataAnnotations.DisplayAttribute
+System.ComponentModel.DataAnnotations.RegularExpressionAttribute
+System.ComponentModel.DataAnnotations.DataTypeAttribute
+System.ComponentModel.DataAnnotations.RangeAttribute
+System.ComponentModel.DataAnnotations.KeyAttribute
+ 
+8321c729934c0f8be754953439b88e6e1c120c24 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/corefx/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.ComponentModel.Annotations@4.4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.ComponentModel.Primitives</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides interfaces that are used to implement the run-time and design-time behavior of components.
+
+Commonly Used Types:
+System.ComponentModel.IComponent
+System.ComponentModel.IContainer
+System.ComponentModel.ISite
+System.ComponentModel.ComponentCollection
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.ComponentModel.Primitives@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.ComponentModel.TypeConverter</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the System.ComponentModel.TypeConverter class, which represents a unified way of converting types of values to other types.
+
+Commonly Used Types:
+System.ComponentModel.TypeConverter
+System.ComponentModel.TypeConverterAttribute
+System.ComponentModel.PropertyDescriptor
+System.ComponentModel.StringConverter
+System.ComponentModel.ITypeDescriptorContext
+System.ComponentModel.EnumConverter
+System.ComponentModel.TypeDescriptor
+System.ComponentModel.Int32Converter
+System.ComponentModel.BooleanConverter
+System.ComponentModel.DoubleConverter
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.ComponentModel.TypeConverter@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Console</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the System.Console class, which represents the standard input, output and error streams for console applications.
+
+Commonly Used Types:
+System.Console
+System.ConsoleColor
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Console@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Diagnostics.Debug</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes and attributes that allows basic interaction with a debugger.
+
+Commonly Used Types:
+System.Diagnostics.Debug
+System.Diagnostics.DebuggerStepThroughAttribute
+System.Diagnostics.Debugger
+System.Diagnostics.DebuggerDisplayAttribute
+System.Diagnostics.DebuggerBrowsableAttribute
+System.Diagnostics.DebuggerBrowsableState
+System.Diagnostics.DebuggerHiddenAttribute
+System.Diagnostics.DebuggerNonUserCodeAttribute
+System.Diagnostics.DebuggerTypeProxyAttribute
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Diagnostics.Debug@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Diagnostics.DiagnosticSource</name>
+      <version>4.4.1</version>
+      <description><![CDATA[Provides Classes that allow you to decouple code logging rich (unserializable) diagnostics/telemetry (e.g. framework) from code that consumes it (e.g. tools)
+
+Commonly Used Types:
+System.Diagnostics.DiagnosticListener
+System.Diagnostics.DiagnosticSource
+ 
+8321c729934c0f8be754953439b88e6e1c120c24]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/corefx/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Diagnostics.DiagnosticSource@4.4.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Diagnostics.FileVersionInfo</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the System.Diagnostics.FileVersionInfo class, which allows access to Win32 version resource information for a physical file on disk.
+
+Commonly Used Types:
+System.Diagnostics.FileVersionInfo
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Diagnostics.FileVersionInfo@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Diagnostics.StackTrace</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the System.Diagnostics.StackTrace class, which allows interaction with local and remote processes.
+
+Commonly Used Types:
+System.Diagnostics.StackFrame
+System.Diagnostics.StackTrace
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Diagnostics.StackTrace@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Diagnostics.Tools</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides attributes, such as GeneratedCodeAttribute and SuppresMessageAttribute, that are emitted or consumed by analysis tools.
+
+Commonly Used Types:
+System.CodeDom.Compiler.GeneratedCodeAttribute
+System.Diagnostics.CodeAnalysis.SuppressMessageAttribute
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Diagnostics.Tools@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Diagnostics.Tracing</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides class that enable you to create high performance tracing events to be captured by event tracing for Windows (ETW).
+
+Commonly Used Types:
+System.Diagnostics.Tracing.EventSource
+System.Diagnostics.Tracing.EventListener
+System.Diagnostics.Tracing.EventLevel
+System.Diagnostics.Tracing.EventKeywords
+System.Diagnostics.Tracing.EventWrittenEventArgs
+System.Diagnostics.Tracing.EventAttribute
+System.Diagnostics.Tracing.EventSourceAttribute
+System.Diagnostics.Tracing.NonEventAttribute
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Diagnostics.Tracing@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Dynamic.Runtime</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes and interfaces that support the Dynamic Language Runtime (DLR).
+
+Commonly Used Types:
+System.Runtime.CompilerServices.CallSite
+System.Runtime.CompilerServices.CallSite<T>
+System.Dynamic.IDynamicMetaObjectProvider
+System.Dynamic.DynamicMetaObject
+System.Dynamic.SetMemberBinder
+System.Dynamic.GetMemberBinder
+System.Dynamic.ExpandoObject
+System.Dynamic.DynamicObject
+System.Runtime.CompilerServices.CallSiteBinder
+System.Runtime.CompilerServices.ConditionalWeakTable<TKey, TValue>
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Dynamic.Runtime@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Globalization</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes that define culture-related information, including language, country/region, calendars in use, format patterns for dates, currency, and numbers, and sort order for strings.
+
+Commonly Used Types:
+System.Globalization.DateTimeFormatInfo
+System.Globalization.CultureInfo
+System.Globalization.NumberFormatInfo
+System.Globalization.CalendarWeekRule
+System.Globalization.TextInfo
+System.Globalization.Calendar
+System.Globalization.CompareInfo
+System.Globalization.CompareOptions
+System.Globalization.UnicodeCategory
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Globalization@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Globalization.Calendars</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes for performing date calculations using specific calendars, including the Gregorian, Julian, Hijri and Korean calendars.
+
+Commonly Used Types:
+System.Globalization.HijriCalendar
+System.Globalization.GregorianCalendar
+System.Globalization.HebrewCalendar
+System.Globalization.KoreanCalendar
+System.Globalization.ThaiBuddhistCalendar
+System.Globalization.TaiwanCalendar
+System.Globalization.JapaneseCalendar
+System.Globalization.GregorianCalendarTypes
+System.Globalization.PersianCalendar
+System.Globalization.UmAlQuraCalendar
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Globalization.Calendars@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Globalization.Extensions</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes for performing Unicode string normalization, culture-specific string comparisons and support the use of non-ASCII characters for Internet domain names.
+
+Commonly Used Types:
+System.StringNormalizationExtensions
+System.Text.NormalizationForm
+System.Globalization.IdnMapping
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Globalization.Extensions@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.IO</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides base input and output (I/O) types, including System.IO.Stream, System.IO.StreamReader and System.IO.StreamWriter, that allow reading and writing to data streams
+
+Commonly Used Types:
+System.IO.Stream
+System.IO.EndOfStreamException
+System.IO.MemoryStream
+System.IO.StreamReader
+System.IO.StreamWriter
+System.IO.StringWriter
+System.IO.TextWriter
+System.IO.TextReader
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.IO@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.IO.Compression</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes that support the compression and decompression of streams.
+
+Commonly Used Types:
+System.IO.Compression.DeflateStream
+System.IO.Compression.GZipStream
+System.IO.Compression.CompressionMode
+System.IO.Compression.CompressionLevel
+System.IO.Compression.ZipArchiveEntry
+System.IO.Compression.ZipArchive
+System.IO.Compression.ZipArchiveMode
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.IO.Compression@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.IO.FileSystem</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides types that allow reading and writing to files and types that provide basic file and directory support.
+
+Commonly Used Types:
+System.IO.FileStream
+System.IO.FileInfo
+System.IO.DirectoryInfo
+System.IO.FileSystemInfo
+System.IO.File
+System.IO.Directory
+System.IO.SearchOption
+System.IO.FileOptions
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.IO.FileSystem@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.IO.FileSystem.Primitives</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides common enumerations and exceptions for path-based I/O libraries.
+
+Commonly Used Types:
+System.IO.DirectoryNotFoundException
+System.IO.FileAccess
+System.IO.FileLoadException
+System.IO.PathTooLongException
+System.IO.FileMode
+System.IO.FileShare
+System.IO.FileAttributes
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.IO.FileSystem.Primitives@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Linq</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes and interfaces that supports queries that use Language-Integrated Query (LINQ).
+
+Commonly Used Types:
+System.Linq.Enumerable
+System.Linq.IGrouping<TKey, TElement>
+System.Linq.IOrderedEnumerable<TElement>
+System.Linq.ILookup<TKey, TElement>
+System.Linq.Lookup<TKey, TElement>
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Linq@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Linq.Expressions</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes, interfaces and enumerations that enable language-level code expressions to be represented as objects in the form of expression trees.
+
+Commonly Used Types:
+System.Linq.IQueryable<T>
+System.Linq.IQueryable
+System.Linq.Expressions.Expression<TDelegate>
+System.Linq.Expressions.Expression
+System.Linq.Expressions.ExpressionVisitor
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Linq.Expressions@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Net.Http</name>
+      <version>4.3.1</version>
+      <description><![CDATA[Provides a programming interface for modern HTTP applications, including HTTP client components that allow applications to consume web services over HTTP and HTTP components that can be used by both clients and servers for parsing HTTP headers.
+
+Commonly Used Types:
+System.Net.Http.HttpResponseMessage
+System.Net.Http.DelegatingHandler
+System.Net.Http.HttpRequestException
+System.Net.Http.HttpClient
+System.Net.Http.MultipartContent
+System.Net.Http.Headers.HttpContentHeaders
+System.Net.Http.HttpClientHandler
+System.Net.Http.StreamContent
+System.Net.Http.FormUrlEncodedContent
+System.Net.Http.HttpMessageHandler
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Net.Http@4.3.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Net.Primitives</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides common types for network-based libraries, including System.Net.IPAddress, System.Net.IPEndPoint, and System.Net.CookieContainer.
+
+Commonly Used Types:
+System.Net.HttpStatusCode
+System.Net.Sockets.SocketError
+System.Net.Cookie
+System.Net.Sockets.SocketException
+System.Net.IPEndPoint
+System.Net.ICredentials
+System.Net.NetworkCredential
+System.Net.IPAddress
+System.Net.CookieCollection
+System.Net.CookieContainer
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Net.Primitives@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Net.Security</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides types, such as System.Net.Security.SslStream, that uses SSL/TLS protocols to provide secure network communication between client and server endpoints.
+
+Commonly Used Types:
+System.Net.Security.SslStream
+System.Net.Security.ExtendedProtectionPolicy
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Net.Security@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.ObjectModel</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides types and interfaces that allow the creation of observable types that provide notifications to clients when changes are made to it.
+
+Commonly Used Types:
+System.ComponentModel.INotifyPropertyChanged
+System.Collections.ObjectModel.ObservableCollection<T>
+System.ComponentModel.PropertyChangedEventHandler
+System.Windows.Input.ICommand
+System.Collections.Specialized.INotifyCollectionChanged
+System.Collections.Specialized.NotifyCollectionChangedEventArgs
+System.Collections.Specialized.NotifyCollectionChangedEventHandler
+System.Collections.ObjectModel.KeyedCollection<TKey, TItem>
+System.ComponentModel.PropertyChangedEventArgs
+System.Collections.ObjectModel.ReadOnlyDictionary<TKey, TValue>
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.ObjectModel@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Reflection</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides types that retrieve information about assemblies, modules, members, parameters, and other entities in managed code by examining their metadata. These types also can be used to manipulate instances of loaded types, for example to hook up events or to invoke methods.
+
+Commonly Used Types:
+System.Reflection.MethodInfo
+System.Reflection.PropertyInfo
+System.Reflection.ParameterInfo
+System.Reflection.FieldInfo
+System.Reflection.ConstructorInfo
+System.Reflection.Assembly
+System.Reflection.MemberInfo
+System.Reflection.EventInfo
+System.Reflection.Module
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Reflection@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Reflection.Emit</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes that allow a compiler or tool to emit metadata and optionally generate a PE file on disk. The primary clients of these classes are script engines and compilers.
+
+Commonly Used Types:
+System.Reflection.Emit.AssemblyBuilder
+System.Reflection.Emit.FieldBuilder
+System.Reflection.Emit.TypeBuilder
+System.Reflection.Emit.MethodBuilder
+System.Reflection.Emit.ConstructorBuilder
+System.Reflection.Emit.GenericTypeParameterBuilder
+System.Reflection.Emit.ModuleBuilder
+System.Reflection.Emit.PropertyBuilder
+System.Reflection.Emit.AssemblyBuilderAccess
+System.Reflection.Emit.EventBuilder
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Reflection.Emit@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Reflection.Emit.ILGeneration</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes that allow a compiler or tool to emit Microsoft intermediate language (MSIL). The primary clients of these classes are script engines and compilers.
+
+Commonly Used Types:
+System.Reflection.Emit.ILGenerator
+System.Reflection.Emit.Label
+System.Reflection.Emit.CustomAttributeBuilder
+System.Reflection.Emit.LocalBuilder
+System.Reflection.Emit.ParameterBuilder
+System.Reflection.Emit.SignatureHelper
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Reflection.Emit.ILGeneration@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Reflection.Emit.Lightweight</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the System.Reflection.Emit.DynamicMethod class, which represents a dynamic method that can be compiled, executed, and discarded. Discarded methods are available for garbage collection.
+
+Commonly Used Types:
+System.Reflection.Emit.DynamicMethod
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Reflection.Emit.Lightweight@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Reflection.Extensions</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides custom attribute extension methods for System.Reflection types.
+
+Commonly Used Types:
+System.Reflection.InterfaceMapping
+System.Reflection.CustomAttributeExtensions
+System.Reflection.RuntimeReflectionExtensions
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Reflection.Extensions@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Reflection.Metadata</name>
+      <version>1.4.2</version>
+      <description><![CDATA[This packages provides a low-level .NET (ECMA-335) metadata reader. It's geared for performance and is the ideal choice for building higher-level libraries that intend to provide their own object model, such as compilers.
+
+Commonly Used Types:
+System.Reflection.Metadata.MetadataReader
+System.Reflection.PortableExecutable.PEReader]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Reflection.Metadata@1.4.2</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Reflection.Primitives</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides common enumerations for reflection-based libraries.
+
+Commonly Used Types:
+System.Reflection.FieldAttributes
+System.Reflection.Emit.OpCode
+System.Reflection.TypeAttributes
+System.Reflection.MethodAttributes
+System.Reflection.CallingConventions
+System.Reflection.PropertyAttributes
+System.Reflection.EventAttributes
+System.Reflection.ParameterAttributes
+System.Reflection.GenericParameterAttributes
+System.Reflection.MethodImplAttributes
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Reflection.Primitives@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Reflection.TypeExtensions</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides extensions methods for System.Type that are designed to be source-compatible with older framework reflection-based APIs.
+
+Commonly Used Types:
+System.Reflection.TypeExtensions
+System.Reflection.BindingFlags
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Reflection.TypeExtensions@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Resources.ResourceManager</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes and attributes that allow developers to create, store, and manage various culture-specific resources used in an application.
+
+Commonly Used Types:
+System.Resources.ResourceManager
+System.Resources.NeutralResourcesLanguageAttribute
+System.Resources.SatelliteContractVersionAttribute
+System.Resources.MissingManifestResourceException
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Resources.ResourceManager@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Runtime</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the fundamental primitives, classes and base classes that define commonly-used value and reference data types, events and event handlers, interfaces, attributes, and exceptions. This packages represents the core package, and provides the minimal set of types required to build a managed application.
+
+Commonly Used Types:
+System.Object
+System.Exception
+System.Int16
+System.Int32
+System.Int64
+System.Enum
+System.String
+System.Char
+System.Boolean
+System.SByte
+System.Byte
+System.DateTime
+System.DateTimeOffset
+System.Single
+System.Double
+System.UInt16
+System.UInt32
+System.UInt64
+System.IDisposable
+System.Uri
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Runtime@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Runtime.CompilerServices.Unsafe</name>
+      <version>4.4.0</version>
+      <description><![CDATA[Provides the System.Runtime.CompilerServices.Unsafe class, which provides generic, low-level functionality for manipulating pointers.
+
+Commonly Used Types:
+System.Runtime.CompilerServices.Unsafe
+ 
+8321c729934c0f8be754953439b88e6e1c120c24 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/corefx/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Runtime.CompilerServices.Unsafe@4.4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Runtime.Extensions</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides commonly-used classes for performing mathematical functions, conversions, string comparisons and querying environment information.
+
+Commonly Used Types:
+System.Math
+System.Environment
+System.Random
+System.Progress<T>
+System.Convert
+System.Diagnostics.Stopwatch
+System.Runtime.Versioning.FrameworkName
+System.StringComparer
+System.IO.Path
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Runtime.Extensions@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Runtime.Handles</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides base classes, including System.Runtime.InteropServices.CriticalHandle and System.Runtime.InteropServices.SafeHandle, for types that represent operating system handles.
+
+Commonly Used Types:
+System.Runtime.InteropServices.SafeHandle
+Microsoft.Win32.SafeHandles.SafeWaitHandle
+System.Runtime.InteropServices.CriticalHandle
+System.Threading.WaitHandleExtensions
+System.IO.HandleInheritability
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Runtime.Handles@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Runtime.InteropServices</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides types that support COM interop and platform invoke services.
+
+Commonly Used Types:
+System.Runtime.InteropServices.GCHandle
+System.Runtime.InteropServices.GuidAttribute
+System.Runtime.InteropServices.COMException
+System.DllNotFoundException
+System.Runtime.InteropServices.DllImportAttribute
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Runtime.InteropServices@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Runtime.InteropServices.RuntimeInformation</name>
+      <version>4.0.0</version>
+      <description><![CDATA[Provides APIs to query about runtime and OS information.
+
+Commonly Used Types:
+System.Runtime.InteropServices.RuntimeInformation
+System.Runtime.InteropServices.OSPlatform
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Runtime.InteropServices.RuntimeInformation@4.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Runtime.Numerics</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the numeric types System.Numerics.BigInteger and System.Numerics.Complex, which complement the numeric primitives, such as System.Byte, System.Double and System.Int32.
+
+Commonly Used Types:
+System.Numerics.BigInteger
+System.Numerics.Complex
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Runtime.Numerics@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Runtime.Serialization.Formatters</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides common types for libraries that support runtime serialization.
+
+Commonly Used Types:
+System.SerializableAttribute
+System.Runtime.Serialization.ISerializable
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Runtime.Serialization.Formatters@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Runtime.Serialization.Primitives</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides common types, including System.Runtime.Serialization.DataContractAttribute, for libraries that support data contract serialization.
+
+Commonly Used Types:
+System.Runtime.Serialization.StreamingContext
+System.Runtime.Serialization.OnDeserializingAttribute
+System.Runtime.Serialization.OnDeserializedAttribute
+System.Runtime.Serialization.OnSerializingAttribute
+System.Runtime.Serialization.OnSerializedAttribute
+System.Runtime.Serialization.EnumMemberAttribute
+System.Runtime.Serialization.DataMemberAttribute
+System.Runtime.Serialization.DataContractAttribute
+System.Runtime.Serialization.IgnoreDataMemberAttribute
+System.Runtime.Serialization.SerializationException
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Runtime.Serialization.Primitives@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Security.AccessControl</name>
+      <version>4.4.0</version>
+      <description><![CDATA[Provides base classes that enable managing access and audit control lists on securable objects.
+
+Commonly Used Types:
+System.Security.AccessControl.AccessRule
+System.Security.AccessControl.AuditRule
+System.Security.AccessControl.ObjectAccessRule
+System.Security.AccessControl.ObjectAuditRule
+System.Security.AccessControl.ObjectSecurity
+ 
+8321c729934c0f8be754953439b88e6e1c120c24 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/corefx/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Security.AccessControl@4.4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Security.Claims</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes that implement claims-based identity in the .NET Framework, including classes that represent claims, claims-based identities, and claims-based principals.
+
+Commonly Used Types:
+System.Security.Principal.GenericIdentity
+System.Security.Claims.Claim
+System.Security.Claims.ClaimsIdentity
+System.Security.Claims.ClaimsPrincipal
+System.Security.Principal.GenericPrincipal
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Security.Claims@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Security.Cryptography.Algorithms</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides base types for cryptographic algorithms, including hashing, encryption, and signing operations.
+
+Commonly Used Types:
+System.Security.Cryptography.Aes
+System.Security.Cryptography.RSA
+System.Security.Cryptography.RSAParameters
+System.Security.Cryptography.HMACSHA1
+System.Security.Cryptography.SHA256
+System.Security.Cryptography.SHA1
+System.Security.Cryptography.SHA512
+System.Security.Cryptography.SHA384
+System.Security.Cryptography.HMACSHA256
+System.Security.Cryptography.MD5
+System.Security.Cryptography.HMACSHA384
+System.Security.Cryptography.HMACSHA512
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Security.Cryptography.Algorithms@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Security.Cryptography.Cng</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides cryptographic algorithm implementations and key management with Windows Cryptographic Next Generation API (CNG).
+
+Commonly Used Types:
+System.Security.Cryptography.RSACng
+System.Security.Cryptography.ECDsaCng
+System.Security.Cryptography.CngKey
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Security.Cryptography.Cng@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Security.Cryptography.Csp</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides cryptographic algorithm implementations and key management with Windows Cryptographic API (CryptoAPI).
+
+Commonly Used Types:
+System.Security.Cryptography.RSACryptoServiceProvider
+System.Security.Cryptography.CspParameters
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Security.Cryptography.Csp@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Security.Cryptography.Encoding</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides types for representing Abstract Syntax Notation One (ASN.1)-encoded data.
+
+Commonly Used Types:
+System.Security.Cryptography.AsnEncodedData
+System.Security.Cryptography.Oid
+System.Security.Cryptography.OidCollection
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Security.Cryptography.Encoding@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Security.Cryptography.OpenSsl</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides cryptographic algorithm implementations and key management for non-Windows systems with OpenSSL.
+
+Commonly Used Types:
+System.Security.Cryptography.RSAOpenSsl
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Security.Cryptography.OpenSsl@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Security.Cryptography.Primitives</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides common types for the cryptographic libraries.
+
+Commonly Used Types:
+System.Security.Cryptography.ICryptoTransform
+System.Security.Cryptography.AsymmetricAlgorithm
+System.Security.Cryptography.SymmetricAlgorithm
+System.Security.Cryptography.HashAlgorithm
+System.Security.Cryptography.KeyedHashAlgorithm
+System.Security.Cryptography.HMAC
+System.Security.Cryptography.KeySizes
+System.Security.Cryptography.CryptographicException
+System.Security.Cryptography.CipherMode
+System.Security.Cryptography.PaddingMode
+System.Security.Cryptography.CryptoStream
+System.Security.Cryptography.CryptoStreamMode
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Security.Cryptography.Primitives@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Security.Cryptography.X509Certificates</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides types for reading, exporting and verifying Authenticode X.509 v3 certificates. These certificates are signed with a private key that uniquely and positively identifies the holder of the certificate.
+
+Commonly Used Types:
+System.Security.Cryptography.X509Certificates.X509Certificate2
+System.Security.Cryptography.X509Certificates.X509Certificate
+System.Security.Cryptography.X509Certificates.X509ContentType
+System.Security.Cryptography.X509Certificates.StoreLocation
+System.Security.Cryptography.X509Certificates.StoreName
+System.Security.Cryptography.X509Certificates.X509FindType
+System.Security.Cryptography.X509Certificates.X509ChainStatus
+System.Security.Cryptography.X509Certificates.X509Certificate2Collection
+System.Security.Cryptography.X509Certificates.X509EnhancedKeyUsageExtension
+System.Security.Cryptography.X509Certificates.X509Chain
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Security.Cryptography.X509Certificates@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Security.Cryptography.Xml</name>
+      <version>4.4.0</version>
+      <description><![CDATA[Provides classes to support the creation and validation of XML digital signatures. The classes in this namespace implement the World Wide Web Consortium Recommendation, "XML-Signature Syntax and Processing", described at http://www.w3.org/TR/xmldsig-core/.
+
+Commonly Used Types:
+System.Security.Cryptography.Xml.CipherData
+System.Security.Cryptography.Xml.CipherReference
+System.Security.Cryptography.Xml.DataObject
+System.Security.Cryptography.Xml.DataReference
+System.Security.Cryptography.Xml.DSAKeyValue
+System.Security.Cryptography.Xml.EncryptedData
+System.Security.Cryptography.Xml.EncryptedKey
+System.Security.Cryptography.Xml.EncryptedReference
+System.Security.Cryptography.Xml.EncryptedType
+System.Security.Cryptography.Xml.EncryptedXml
+System.Security.Cryptography.Xml.EncryptionMethod
+System.Security.Cryptography.Xml.EncryptionProperty
+System.Security.Cryptography.Xml.EncryptionPropertyCollection
+System.Security.Cryptography.Xml.KeyInfo
+System.Security.Cryptography.Xml.KeyInfoClause
+System.Security.Cryptography.Xml.KeyInfoEncryptedKey
+System.Security.Cryptography.Xml.KeyInfoName
+System.Security.Cryptography.Xml.KeyInfoNode
+System.Security.Cryptography.Xml.KeyInfoRetrievalMethod
+System.Security.Cryptography.Xml.KeyInfoX509Data
+System.Security.Cryptography.Xml.KeyReference
+System.Security.Cryptography.Xml.Reference
+System.Security.Cryptography.Xml.ReferenceList
+System.Security.Cryptography.Xml.RSAKeyValue
+System.Security.Cryptography.Xml.Signature
+System.Security.Cryptography.Xml.SignedInfo
+System.Security.Cryptography.Xml.SignedXml
+System.Security.Cryptography.Xml.Transform
+System.Security.Cryptography.Xml.TransformChain
+System.Security.Cryptography.Xml.XmlDecryptionTransform
+System.Security.Cryptography.Xml.XmlDsigBase64Transform
+System.Security.Cryptography.Xml.XmlDsigC14NTransform
+System.Security.Cryptography.Xml.XmlDsigC14NWithCommentsTransform
+System.Security.Cryptography.Xml.XmlDsigEnvelopedSignatureTransform
+System.Security.Cryptography.Xml.XmlDsigExcC14NTransform
+System.Security.Cryptography.Xml.XmlDsigExcC14NWithCommentsTransform
+System.Security.Cryptography.Xml.XmlDsigXPathTransform
+System.Security.Cryptography.Xml.XmlDsigXsltTransform
+System.Security.Cryptography.Xml.XmlLicenseTransform
+ 
+8321c729934c0f8be754953439b88e6e1c120c24 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/corefx/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Security.Cryptography.Xml@4.4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Security.Principal</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the base interfaces for principal and identity objects that represents the security context under which code is running.
+
+Commonly Used Types:
+System.Security.Principal.IPrincipal
+System.Security.Principal.IIdentity
+System.Security.Principal.TokenImpersonationLevel
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Security.Principal@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Security.Principal.Windows</name>
+      <version>4.4.0</version>
+      <description><![CDATA[Provides classes for retrieving the current Windows user and for interacting with Windows users and groups.
+
+Commonly Used Types:
+System.Security.Principal.WindowsIdentity
+System.Security.Principal.SecurityIdentifier
+System.Security.Principal.NTAccount
+System.Security.Principal.WindowsPrincipal
+System.Security.Principal.IdentityReference
+System.Security.Principal.IdentityNotMappedException
+System.Security.Principal.WindowsBuiltInRole
+System.Security.Principal.WellKnownSidType
+ 
+8321c729934c0f8be754953439b88e6e1c120c24 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/corefx/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Security.Principal.Windows@4.4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Text.Encoding</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides base abstract encoding classes for converting blocks of characters to and from blocks of bytes.
+
+Commonly Used Types:
+System.Text.Encoding
+System.Text.DecoderFallbackException
+System.Text.Decoder
+System.Text.EncoderFallbackException
+System.Text.Encoder
+System.Text.EncoderFallback
+System.Text.EncoderFallbackBuffer
+System.Text.DecoderFallback
+System.Text.DecoderFallbackBuffer
+System.Text.DecoderExceptionFallback
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Text.Encoding@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Text.Encoding.CodePages</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides support for code-page based encodings, including Windows-1252, Shift-JIS, and GB2312.
+
+Commonly Used Types:
+System.Text.CodePagesEncodingProvider
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Text.Encoding.CodePages@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Text.Encoding.Extensions</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides support for specific encodings, including ASCII, UTF-7, UTF-8, UTF-16, and UTF-32.
+
+Commonly Used Types:
+System.Text.UTF8Encoding
+System.Text.UnicodeEncoding
+System.Text.ASCIIEncoding
+System.Text.UTF7Encoding
+System.Text.UTF32Encoding
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Text.Encoding.Extensions@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Text.Encodings.Web</name>
+      <version>4.4.0</version>
+      <description><![CDATA[Provides types for encoding and escaping strings for use in JavaScript, HyperText Markup Language (HTML), and uniform resource locators (URL).
+
+Commonly Used Types:
+System.Text.Encodings.Web.HtmlEncoder
+System.Text.Encodings.Web.UrlEncoder
+System.Text.Encodings.Web.JavaScriptEncoder
+ 
+8321c729934c0f8be754953439b88e6e1c120c24 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/corefx/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Text.Encodings.Web@4.4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Text.RegularExpressions</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the System.Text.RegularExpressions.Regex class, an implementation of a regular expression engine.
+
+Commonly Used Types:
+System.Text.RegularExpressions.Regex
+System.Text.RegularExpressions.RegexOptions
+System.Text.RegularExpressions.Match
+System.Text.RegularExpressions.Group
+System.Text.RegularExpressions.Capture
+System.Text.RegularExpressions.MatchEvaluator
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Text.RegularExpressions@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Threading</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the fundamental synchronization primitives, including System.Threading.Monitor and System.Threading.Mutex, that are required when writing asynchronous code.
+
+Commonly Used Types:
+System.Threading.Monitor
+System.Threading.SynchronizationContext
+System.Threading.ManualResetEvent
+System.Threading.AutoResetEvent
+System.Threading.ThreadLocal<T>
+System.Threading.EventWaitHandle
+System.Threading.SemaphoreSlim
+System.Threading.Mutex
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Threading@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Threading.Tasks</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides types that simplify the work of writing concurrent and asynchronous code.
+
+Commonly Used Types:
+System.Threading.Tasks.Task<TResult>
+System.Runtime.CompilerServices.TaskAwaiter<TResult>
+System.Threading.Tasks.TaskCompletionSource<TResult>
+System.Threading.Tasks.Task
+System.OperationCanceledException
+System.AggregateException
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Threading.Tasks@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Threading.Tasks.Extensions</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides additional types that simplify the work of writing concurrent and asynchronous code.
+
+Commonly Used Types:
+System.Threading.Tasks.ValueTask<TResult>]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Threading.Tasks.Extensions@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Threading.Tasks.Parallel</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the System.Threading.Tasks.Parallel class, which adds support for running loops and iterators in parallel.
+
+Commonly Used Types:
+System.Threading.Tasks.Parallel
+System.Threading.Tasks.ParallelLoopState
+System.Threading.Tasks.ParallelLoopResult
+System.Threading.Tasks.ParallelOptions
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Threading.Tasks.Parallel@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Threading.Thread</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the System.Threading.Thread class, which allows developers to create and control a thread, set its priority, and get its state.
+
+Commonly Used Types:
+System.Threading.Thread
+System.Threading.ThreadStart
+System.Threading.ParameterizedThreadStart
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Threading.Thread@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Threading.ThreadPool</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the System.Threading.ThreadPool class, which contains a pool of threads that can be used to execute tasks, post work items, wait on behalf of other threads, and process timers.
+
+Commonly Used Types:
+System.Threading.ThreadPool
+System.Threading.WaitOrTimerCallback
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Threading.ThreadPool@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.ValueTuple</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the System.ValueTuple structs, which implement the underlying types for C# 7 tuples.
+
+Commonly Used Types:
+System.ValueTuple
+System.ValueTuple<T1>
+System.ValueTuple<T1, T2>
+System.ValueTuple<T1, T2, T3>
+System.ValueTuple<T1, T2, T3, T4>
+System.ValueTuple<T1, T2, T3, T4, T5>
+System.ValueTuple<T1, T2, T3, T4, T5, T6>
+System.ValueTuple<T1, T2, T3, T4, T5, T6, T7>
+System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.ValueTuple@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Xml.ReaderWriter</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides provides a fast, non-cached, forward-only way to read and write Extensible Markup Language (XML) data.
+
+Commonly Used Types:
+System.Xml.XmlNodeType
+System.Xml.XmlException
+System.Xml.XmlReader
+System.Xml.XmlWriter
+System.Xml.IXmlLineInfo
+System.Xml.XmlNameTable
+System.Xml.IXmlNamespaceResolver
+System.Xml.XmlNamespaceManager
+System.Xml.XmlQualifiedName
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Xml.ReaderWriter@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Xml.XDocument</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the classes for Language-Integrated Query (LINQ) to Extensible Markup Language (XML). LINQ to XML is an in-memory XML programming interface that enables you to modify XML documents efficiently and easily.
+
+Commonly Used Types:
+System.Xml.Linq.XElement
+System.Xml.Linq.XAttribute
+System.Xml.Linq.XDocument
+System.Xml.Linq.XText
+System.Xml.Linq.XNode
+System.Xml.Linq.XContainer
+System.Xml.Linq.XComment
+System.Xml.Linq.XObject
+System.Xml.Linq.XProcessingInstruction
+System.Xml.Linq.XDocumentType
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Xml.XDocument@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Xml.XmlDocument</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides an older in-memory Extensible Markup Language (XML) programming interface that enables you to modify XML documents. Developers should prefer the classes in the System.Xml.XDocument package.
+
+Commonly Used Types:
+System.Xml.XmlNode
+System.Xml.XmlElement
+System.Xml.XmlAttribute
+System.Xml.XmlDocument
+System.Xml.XmlDeclaration
+System.Xml.XmlText
+System.Xml.XmlComment
+System.Xml.XmlNodeList
+System.Xml.XmlWhitespace
+System.Xml.XmlCDataSection
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Xml.XmlDocument@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Xml.XPath</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the classes that define a cursor model for navigating and editing Extensible Markup Language (XML) information items as instances of the XQuery 1.0 and XPath 2.0 Data Model.
+
+Commonly Used Types:
+System.Xml.XPath.XPathNavigator
+System.Xml.XPath.IXPathNavigable
+System.Xml.XPath.XPathNodeType
+System.Xml.XPath.XPathNodeIterator
+System.Xml.XPath.XPathExpression
+System.Xml.XPath.XPathResultType
+System.Xml.XPath.XPathException
+System.Xml.XPath.XPathDocument
+System.Xml.XPath.XPathItem
+System.Xml.XPath.XPathNamespaceScope
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Xml.XPath@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Xml.XPath.XDocument</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides extension methods that add System.Xml.XPath support to the System.Xml.XDocument package.
+
+Commonly Used Types:
+System.Xml.XPath.Extensions
+System.Xml.XPath.XDocumentExtensions
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Xml.XPath.XDocument@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+</bom>

--- a/CycloneDX.IntegrationTests/__snapshots__/Tests.CallingCycloneDX_WithSolutionFilePath_GeneratesBom_CSharp.snap
+++ b/CycloneDX.IntegrationTests/__snapshots__/Tests.CallingCycloneDX_WithSolutionFilePath_GeneratesBom_CSharp.snap
@@ -1,0 +1,1241 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<bom version="1" xmlns="http://cyclonedx.org/schema/bom/1.1">
+  <components>
+    <component type="library">
+      <name>Microsoft.NETCore.App</name>
+      <version>2.1.0</version>
+      <description><![CDATA[A set of .NET API's that are included in the default .NET Core application model. 
+caa7b7e2bad98e56a687fb5cbaf60825500800f7 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.NETCore.App@2.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.NETCore.DotNetAppHost</name>
+      <version>2.1.0</version>
+      <description><![CDATA[Provides the .NET Core app bootstrapper intended for use in the application directory 
+caa7b7e2bad98e56a687fb5cbaf60825500800f7 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.NETCore.DotNetAppHost@2.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.NETCore.DotNetHostPolicy</name>
+      <version>2.1.0</version>
+      <description><![CDATA[Provides a CoreCLR hosting policy implementation -- configuration settings, assembly paths and assembly servicing 
+caa7b7e2bad98e56a687fb5cbaf60825500800f7 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.NETCore.DotNetHostPolicy@2.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.NETCore.DotNetHostResolver</name>
+      <version>2.1.0</version>
+      <description><![CDATA[Provides an implementation of framework resolution strategy used by Microsoft.NETCore.DotNetHost 
+caa7b7e2bad98e56a687fb5cbaf60825500800f7 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.NETCore.DotNetHostResolver@2.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.NETCore.Platforms</name>
+      <version>2.1.0</version>
+      <description><![CDATA[Provides runtime information required to resolve target framework, platform, and runtime specific implementations of .NETCore packages. 
+30ab651fcb4354552bd4891619a0bdd81e0ebdbf 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/corefx/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.NETCore.Platforms@2.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.NETCore.Targets</name>
+      <version>2.1.0</version>
+      <description><![CDATA[Provides supporting infrastructure for portable projects: support identifiers that define framework and runtime for support targets and packages that reference the minimum supported package versions when targeting these. 
+30ab651fcb4354552bd4891619a0bdd81e0ebdbf 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/corefx/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.NETCore.Targets@2.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.Win32.Primitives</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides common types for Win32-based libraries.
+
+Commonly Used Types:
+System.ComponentModel.Win32Exception
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.Win32.Primitives@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.Win32.Registry</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides support for accessing and modifying the Windows Registry.
+
+Commonly Used Types:
+Microsoft.Win32.RegistryKey
+Microsoft.Win32.Registry
+Microsoft.Win32.RegistryValueKind
+Microsoft.Win32.RegistryHive
+Microsoft.Win32.RegistryView
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.Win32.Registry@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NETStandard.Library</name>
+      <version>2.0.3</version>
+      <description><![CDATA[A set of standard .NET APIs that are prescribed to be used and supported together. 
+18a36291e48808fa7ef2d00a764ceb1ec95645a5 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/standard/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>.NET Foundation and Contributors</copyright>
+      <purl>pkg:nuget/NETStandard.Library@2.0.3</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Newtonsoft.Json</name>
+      <version>12.0.3</version>
+      <description><![CDATA[Json.NET is a popular high-performance JSON framework for .NET]]></description>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <copyright>Copyright © James Newton-King 2008</copyright>
+      <purl>pkg:nuget/Newtonsoft.Json@12.0.3</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://www.newtonsoft.com/json</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.Common</name>
+      <version>5.4.0</version>
+      <description><![CDATA[NuGet client library.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.Common@5.4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.Configuration</name>
+      <version>5.4.0</version>
+      <description><![CDATA[NuGet's client configuration settings implementation.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.Configuration@5.4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.DependencyResolver.Core</name>
+      <version>5.4.0</version>
+      <description><![CDATA[NuGet client library.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.DependencyResolver.Core@5.4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.Frameworks</name>
+      <version>5.4.0</version>
+      <description><![CDATA[The understanding of target frameworks for NuGet.Packaging.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.Frameworks@5.4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.LibraryModel</name>
+      <version>5.4.0</version>
+      <description><![CDATA[NuGet client library.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.LibraryModel@5.4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.Packaging</name>
+      <version>5.4.0</version>
+      <description><![CDATA[NuGet's implementation for reading nupkg package and nuspec package specification files.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.Packaging@5.4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.ProjectModel</name>
+      <version>5.4.0</version>
+      <description><![CDATA[NuGet client library.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.ProjectModel@5.4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.Protocol</name>
+      <version>5.4.0</version>
+      <description><![CDATA[NuGet client library.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.Protocol@5.4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.Versioning</name>
+      <version>5.4.0</version>
+      <description><![CDATA[NuGet's implementation of Semantic Versioning.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.Versioning@5.4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>runtime.native.System</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Internal implementation package not meant for direct consumption.  Please do not reference directly. 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/runtime.native.System@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Collections</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes that define generic collections, which allow developers to create strongly typed collections that provide better type safety and performance than non-generic strongly typed collections.
+
+Commonly Used Types:
+System.Collections.Generic.List<T>
+System.Collections.Generic.Dictionary<TKey, TValue>
+System.Collections.Generic.Queue<T>
+System.Collections.Generic.Stack<T>
+System.Collections.Generic.HashSet<T>
+System.Collections.Generic.LinkedList<T>
+System.Collections.Generic.EqualityComparer<T>
+System.Collections.Generic.Comparer<T>
+System.Collections.Generic.SortedDictionary<TKey, TValue>
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Collections@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Diagnostics.Debug</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes and attributes that allows basic interaction with a debugger.
+
+Commonly Used Types:
+System.Diagnostics.Debug
+System.Diagnostics.DebuggerStepThroughAttribute
+System.Diagnostics.Debugger
+System.Diagnostics.DebuggerDisplayAttribute
+System.Diagnostics.DebuggerBrowsableAttribute
+System.Diagnostics.DebuggerBrowsableState
+System.Diagnostics.DebuggerHiddenAttribute
+System.Diagnostics.DebuggerNonUserCodeAttribute
+System.Diagnostics.DebuggerTypeProxyAttribute
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Diagnostics.Debug@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Diagnostics.Process</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the System.Diagnostics.Process class, which allows interaction with local and remote processes.
+
+Commonly Used Types:
+System.Diagnostics.Process
+System.Diagnostics.ProcessModule
+System.Diagnostics.ProcessStartInfo
+System.Diagnostics.ProcessThread
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Diagnostics.Process@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Dynamic.Runtime</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes and interfaces that support the Dynamic Language Runtime (DLR).
+
+Commonly Used Types:
+System.Runtime.CompilerServices.CallSite
+System.Runtime.CompilerServices.CallSite<T>
+System.Dynamic.IDynamicMetaObjectProvider
+System.Dynamic.DynamicMetaObject
+System.Dynamic.SetMemberBinder
+System.Dynamic.GetMemberBinder
+System.Dynamic.ExpandoObject
+System.Dynamic.DynamicObject
+System.Runtime.CompilerServices.CallSiteBinder
+System.Runtime.CompilerServices.ConditionalWeakTable<TKey, TValue>
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Dynamic.Runtime@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Globalization</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes that define culture-related information, including language, country/region, calendars in use, format patterns for dates, currency, and numbers, and sort order for strings.
+
+Commonly Used Types:
+System.Globalization.DateTimeFormatInfo
+System.Globalization.CultureInfo
+System.Globalization.NumberFormatInfo
+System.Globalization.CalendarWeekRule
+System.Globalization.TextInfo
+System.Globalization.Calendar
+System.Globalization.CompareInfo
+System.Globalization.CompareOptions
+System.Globalization.UnicodeCategory
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Globalization@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.IO</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides base input and output (I/O) types, including System.IO.Stream, System.IO.StreamReader and System.IO.StreamWriter, that allow reading and writing to data streams
+
+Commonly Used Types:
+System.IO.Stream
+System.IO.EndOfStreamException
+System.IO.MemoryStream
+System.IO.StreamReader
+System.IO.StreamWriter
+System.IO.StringWriter
+System.IO.TextWriter
+System.IO.TextReader
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.IO@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.IO.FileSystem</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides types that allow reading and writing to files and types that provide basic file and directory support.
+
+Commonly Used Types:
+System.IO.FileStream
+System.IO.FileInfo
+System.IO.DirectoryInfo
+System.IO.FileSystemInfo
+System.IO.File
+System.IO.Directory
+System.IO.SearchOption
+System.IO.FileOptions
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.IO.FileSystem@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.IO.FileSystem.Primitives</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides common enumerations and exceptions for path-based I/O libraries.
+
+Commonly Used Types:
+System.IO.DirectoryNotFoundException
+System.IO.FileAccess
+System.IO.FileLoadException
+System.IO.PathTooLongException
+System.IO.FileMode
+System.IO.FileShare
+System.IO.FileAttributes
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.IO.FileSystem.Primitives@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Linq</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes and interfaces that supports queries that use Language-Integrated Query (LINQ).
+
+Commonly Used Types:
+System.Linq.Enumerable
+System.Linq.IGrouping<TKey, TElement>
+System.Linq.IOrderedEnumerable<TElement>
+System.Linq.ILookup<TKey, TElement>
+System.Linq.Lookup<TKey, TElement>
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Linq@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Linq.Expressions</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes, interfaces and enumerations that enable language-level code expressions to be represented as objects in the form of expression trees.
+
+Commonly Used Types:
+System.Linq.IQueryable<T>
+System.Linq.IQueryable
+System.Linq.Expressions.Expression<TDelegate>
+System.Linq.Expressions.Expression
+System.Linq.Expressions.ExpressionVisitor
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Linq.Expressions@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.ObjectModel</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides types and interfaces that allow the creation of observable types that provide notifications to clients when changes are made to it.
+
+Commonly Used Types:
+System.ComponentModel.INotifyPropertyChanged
+System.Collections.ObjectModel.ObservableCollection<T>
+System.ComponentModel.PropertyChangedEventHandler
+System.Windows.Input.ICommand
+System.Collections.Specialized.INotifyCollectionChanged
+System.Collections.Specialized.NotifyCollectionChangedEventArgs
+System.Collections.Specialized.NotifyCollectionChangedEventHandler
+System.Collections.ObjectModel.KeyedCollection<TKey, TItem>
+System.ComponentModel.PropertyChangedEventArgs
+System.Collections.ObjectModel.ReadOnlyDictionary<TKey, TValue>
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.ObjectModel@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Reflection</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides types that retrieve information about assemblies, modules, members, parameters, and other entities in managed code by examining their metadata. These types also can be used to manipulate instances of loaded types, for example to hook up events or to invoke methods.
+
+Commonly Used Types:
+System.Reflection.MethodInfo
+System.Reflection.PropertyInfo
+System.Reflection.ParameterInfo
+System.Reflection.FieldInfo
+System.Reflection.ConstructorInfo
+System.Reflection.Assembly
+System.Reflection.MemberInfo
+System.Reflection.EventInfo
+System.Reflection.Module
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Reflection@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Reflection.Emit</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes that allow a compiler or tool to emit metadata and optionally generate a PE file on disk. The primary clients of these classes are script engines and compilers.
+
+Commonly Used Types:
+System.Reflection.Emit.AssemblyBuilder
+System.Reflection.Emit.FieldBuilder
+System.Reflection.Emit.TypeBuilder
+System.Reflection.Emit.MethodBuilder
+System.Reflection.Emit.ConstructorBuilder
+System.Reflection.Emit.GenericTypeParameterBuilder
+System.Reflection.Emit.ModuleBuilder
+System.Reflection.Emit.PropertyBuilder
+System.Reflection.Emit.AssemblyBuilderAccess
+System.Reflection.Emit.EventBuilder
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Reflection.Emit@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Reflection.Emit.ILGeneration</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes that allow a compiler or tool to emit Microsoft intermediate language (MSIL). The primary clients of these classes are script engines and compilers.
+
+Commonly Used Types:
+System.Reflection.Emit.ILGenerator
+System.Reflection.Emit.Label
+System.Reflection.Emit.CustomAttributeBuilder
+System.Reflection.Emit.LocalBuilder
+System.Reflection.Emit.ParameterBuilder
+System.Reflection.Emit.SignatureHelper
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Reflection.Emit.ILGeneration@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Reflection.Emit.Lightweight</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the System.Reflection.Emit.DynamicMethod class, which represents a dynamic method that can be compiled, executed, and discarded. Discarded methods are available for garbage collection.
+
+Commonly Used Types:
+System.Reflection.Emit.DynamicMethod
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Reflection.Emit.Lightweight@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Reflection.Extensions</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides custom attribute extension methods for System.Reflection types.
+
+Commonly Used Types:
+System.Reflection.InterfaceMapping
+System.Reflection.CustomAttributeExtensions
+System.Reflection.RuntimeReflectionExtensions
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Reflection.Extensions@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Reflection.Primitives</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides common enumerations for reflection-based libraries.
+
+Commonly Used Types:
+System.Reflection.FieldAttributes
+System.Reflection.Emit.OpCode
+System.Reflection.TypeAttributes
+System.Reflection.MethodAttributes
+System.Reflection.CallingConventions
+System.Reflection.PropertyAttributes
+System.Reflection.EventAttributes
+System.Reflection.ParameterAttributes
+System.Reflection.GenericParameterAttributes
+System.Reflection.MethodImplAttributes
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Reflection.Primitives@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Reflection.TypeExtensions</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides extensions methods for System.Type that are designed to be source-compatible with older framework reflection-based APIs.
+
+Commonly Used Types:
+System.Reflection.TypeExtensions
+System.Reflection.BindingFlags
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Reflection.TypeExtensions@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Resources.ResourceManager</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes and attributes that allow developers to create, store, and manage various culture-specific resources used in an application.
+
+Commonly Used Types:
+System.Resources.ResourceManager
+System.Resources.NeutralResourcesLanguageAttribute
+System.Resources.SatelliteContractVersionAttribute
+System.Resources.MissingManifestResourceException
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Resources.ResourceManager@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Runtime</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the fundamental primitives, classes and base classes that define commonly-used value and reference data types, events and event handlers, interfaces, attributes, and exceptions. This packages represents the core package, and provides the minimal set of types required to build a managed application.
+
+Commonly Used Types:
+System.Object
+System.Exception
+System.Int16
+System.Int32
+System.Int64
+System.Enum
+System.String
+System.Char
+System.Boolean
+System.SByte
+System.Byte
+System.DateTime
+System.DateTimeOffset
+System.Single
+System.Double
+System.UInt16
+System.UInt32
+System.UInt64
+System.IDisposable
+System.Uri
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Runtime@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Runtime.Extensions</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides commonly-used classes for performing mathematical functions, conversions, string comparisons and querying environment information.
+
+Commonly Used Types:
+System.Math
+System.Environment
+System.Random
+System.Progress<T>
+System.Convert
+System.Diagnostics.Stopwatch
+System.Runtime.Versioning.FrameworkName
+System.StringComparer
+System.IO.Path
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Runtime.Extensions@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Runtime.Handles</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides base classes, including System.Runtime.InteropServices.CriticalHandle and System.Runtime.InteropServices.SafeHandle, for types that represent operating system handles.
+
+Commonly Used Types:
+System.Runtime.InteropServices.SafeHandle
+Microsoft.Win32.SafeHandles.SafeWaitHandle
+System.Runtime.InteropServices.CriticalHandle
+System.Threading.WaitHandleExtensions
+System.IO.HandleInheritability
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Runtime.Handles@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Runtime.InteropServices</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides types that support COM interop and platform invoke services.
+
+Commonly Used Types:
+System.Runtime.InteropServices.GCHandle
+System.Runtime.InteropServices.GuidAttribute
+System.Runtime.InteropServices.COMException
+System.DllNotFoundException
+System.Runtime.InteropServices.DllImportAttribute
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Runtime.InteropServices@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Security.Cryptography.Primitives</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides common types for the cryptographic libraries.
+
+Commonly Used Types:
+System.Security.Cryptography.ICryptoTransform
+System.Security.Cryptography.AsymmetricAlgorithm
+System.Security.Cryptography.SymmetricAlgorithm
+System.Security.Cryptography.HashAlgorithm
+System.Security.Cryptography.KeyedHashAlgorithm
+System.Security.Cryptography.HMAC
+System.Security.Cryptography.KeySizes
+System.Security.Cryptography.CryptographicException
+System.Security.Cryptography.CipherMode
+System.Security.Cryptography.PaddingMode
+System.Security.Cryptography.CryptoStream
+System.Security.Cryptography.CryptoStreamMode
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Security.Cryptography.Primitives@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Security.Cryptography.ProtectedData</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides access to Windows Data Protection Api.
+
+Commonly Used Types:
+System.Security.Cryptography.DataProtectionScope
+System.Security.Cryptography.ProtectedData
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Security.Cryptography.ProtectedData@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Text.Encoding</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides base abstract encoding classes for converting blocks of characters to and from blocks of bytes.
+
+Commonly Used Types:
+System.Text.Encoding
+System.Text.DecoderFallbackException
+System.Text.Decoder
+System.Text.EncoderFallbackException
+System.Text.Encoder
+System.Text.EncoderFallback
+System.Text.EncoderFallbackBuffer
+System.Text.DecoderFallback
+System.Text.DecoderFallbackBuffer
+System.Text.DecoderExceptionFallback
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Text.Encoding@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Text.Encoding.Extensions</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides support for specific encodings, including ASCII, UTF-7, UTF-8, UTF-16, and UTF-32.
+
+Commonly Used Types:
+System.Text.UTF8Encoding
+System.Text.UnicodeEncoding
+System.Text.ASCIIEncoding
+System.Text.UTF7Encoding
+System.Text.UTF32Encoding
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Text.Encoding.Extensions@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Threading</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the fundamental synchronization primitives, including System.Threading.Monitor and System.Threading.Mutex, that are required when writing asynchronous code.
+
+Commonly Used Types:
+System.Threading.Monitor
+System.Threading.SynchronizationContext
+System.Threading.ManualResetEvent
+System.Threading.AutoResetEvent
+System.Threading.ThreadLocal<T>
+System.Threading.EventWaitHandle
+System.Threading.SemaphoreSlim
+System.Threading.Mutex
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Threading@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Threading.Tasks</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides types that simplify the work of writing concurrent and asynchronous code.
+
+Commonly Used Types:
+System.Threading.Tasks.Task<TResult>
+System.Runtime.CompilerServices.TaskAwaiter<TResult>
+System.Threading.Tasks.TaskCompletionSource<TResult>
+System.Threading.Tasks.Task
+System.OperationCanceledException
+System.AggregateException
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Threading.Tasks@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Threading.Thread</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the System.Threading.Thread class, which allows developers to create and control a thread, set its priority, and get its state.
+
+Commonly Used Types:
+System.Threading.Thread
+System.Threading.ThreadStart
+System.Threading.ParameterizedThreadStart
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Threading.Thread@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Threading.ThreadPool</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the System.Threading.ThreadPool class, which contains a pool of threads that can be used to execute tasks, post work items, wait on behalf of other threads, and process timers.
+
+Commonly Used Types:
+System.Threading.ThreadPool
+System.Threading.WaitOrTimerCallback
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Threading.ThreadPool@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+</bom>

--- a/CycloneDX.IntegrationTests/__snapshots__/Tests.CallingCycloneDX_WithSolutionFilePath_GeneratesBom_FullFrameworkAndCore.snap
+++ b/CycloneDX.IntegrationTests/__snapshots__/Tests.CallingCycloneDX_WithSolutionFilePath_GeneratesBom_FullFrameworkAndCore.snap
@@ -1,0 +1,1410 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<bom version="1" xmlns="http://cyclonedx.org/schema/bom/1.1">
+  <components>
+    <component type="library">
+      <name>Microsoft.NETCore.App</name>
+      <version>2.1.0</version>
+      <description><![CDATA[A set of .NET API's that are included in the default .NET Core application model. 
+caa7b7e2bad98e56a687fb5cbaf60825500800f7 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.NETCore.App@2.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.NETCore.DotNetAppHost</name>
+      <version>2.1.0</version>
+      <description><![CDATA[Provides the .NET Core app bootstrapper intended for use in the application directory 
+caa7b7e2bad98e56a687fb5cbaf60825500800f7 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.NETCore.DotNetAppHost@2.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.NETCore.DotNetHostPolicy</name>
+      <version>2.1.0</version>
+      <description><![CDATA[Provides a CoreCLR hosting policy implementation -- configuration settings, assembly paths and assembly servicing 
+caa7b7e2bad98e56a687fb5cbaf60825500800f7 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.NETCore.DotNetHostPolicy@2.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.NETCore.DotNetHostResolver</name>
+      <version>2.1.0</version>
+      <description><![CDATA[Provides an implementation of framework resolution strategy used by Microsoft.NETCore.DotNetHost 
+caa7b7e2bad98e56a687fb5cbaf60825500800f7 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.NETCore.DotNetHostResolver@2.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.NETCore.Platforms</name>
+      <version>2.1.0</version>
+      <description><![CDATA[Provides runtime information required to resolve target framework, platform, and runtime specific implementations of .NETCore packages. 
+30ab651fcb4354552bd4891619a0bdd81e0ebdbf 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/corefx/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.NETCore.Platforms@2.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.NETCore.Targets</name>
+      <version>2.1.0</version>
+      <description><![CDATA[Provides supporting infrastructure for portable projects: support identifiers that define framework and runtime for support targets and packages that reference the minimum supported package versions when targeting these. 
+30ab651fcb4354552bd4891619a0bdd81e0ebdbf 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/corefx/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.NETCore.Targets@2.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.Win32.Primitives</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides common types for Win32-based libraries.
+
+Commonly Used Types:
+System.ComponentModel.Win32Exception
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.Win32.Primitives@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.Win32.Registry</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides support for accessing and modifying the Windows Registry.
+
+Commonly Used Types:
+Microsoft.Win32.RegistryKey
+Microsoft.Win32.Registry
+Microsoft.Win32.RegistryValueKind
+Microsoft.Win32.RegistryHive
+Microsoft.Win32.RegistryView
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.Win32.Registry@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NETStandard.Library</name>
+      <version>2.0.3</version>
+      <description><![CDATA[A set of standard .NET APIs that are prescribed to be used and supported together. 
+18a36291e48808fa7ef2d00a764ceb1ec95645a5 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/standard/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>.NET Foundation and Contributors</copyright>
+      <purl>pkg:nuget/NETStandard.Library@2.0.3</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Newtonsoft.Json</name>
+      <version>12.0.3</version>
+      <description><![CDATA[Json.NET is a popular high-performance JSON framework for .NET]]></description>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <copyright>Copyright © James Newton-King 2008</copyright>
+      <purl>pkg:nuget/Newtonsoft.Json@12.0.3</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://www.newtonsoft.com/json</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Newtonsoft.Json</name>
+      <version>9.0.1</version>
+      <description><![CDATA[Json.NET is a popular high-performance JSON framework for .NET]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.github.com/JamesNK/Newtonsoft.Json/master/LICENSE.md</url>
+        </license>
+      </licenses>
+      <purl>pkg:nuget/Newtonsoft.Json@9.0.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>http://www.newtonsoft.com/json</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.Common</name>
+      <version>5.2.0</version>
+      <description><![CDATA[NuGet client library.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.Common@5.2.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.Common</name>
+      <version>5.4.0</version>
+      <description><![CDATA[NuGet client library.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.Common@5.4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.Configuration</name>
+      <version>5.2.0</version>
+      <description><![CDATA[NuGet's client configuration settings implementation.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.Configuration@5.2.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.Configuration</name>
+      <version>5.4.0</version>
+      <description><![CDATA[NuGet's client configuration settings implementation.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.Configuration@5.4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.DependencyResolver.Core</name>
+      <version>5.2.0</version>
+      <description><![CDATA[NuGet client library.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.DependencyResolver.Core@5.2.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.DependencyResolver.Core</name>
+      <version>5.4.0</version>
+      <description><![CDATA[NuGet client library.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.DependencyResolver.Core@5.4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.Frameworks</name>
+      <version>5.2.0</version>
+      <description><![CDATA[The understanding of target frameworks for NuGet.Packaging.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.Frameworks@5.2.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.Frameworks</name>
+      <version>5.4.0</version>
+      <description><![CDATA[The understanding of target frameworks for NuGet.Packaging.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.Frameworks@5.4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.LibraryModel</name>
+      <version>5.2.0</version>
+      <description><![CDATA[NuGet client library.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.LibraryModel@5.2.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.LibraryModel</name>
+      <version>5.4.0</version>
+      <description><![CDATA[NuGet client library.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.LibraryModel@5.4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.Packaging</name>
+      <version>5.2.0</version>
+      <description><![CDATA[NuGet's implementation for reading nupkg package and nuspec package specification files.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.Packaging@5.2.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.Packaging</name>
+      <version>5.4.0</version>
+      <description><![CDATA[NuGet's implementation for reading nupkg package and nuspec package specification files.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.Packaging@5.4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.ProjectModel</name>
+      <version>5.2.0</version>
+      <description><![CDATA[NuGet client library.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.ProjectModel@5.2.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.ProjectModel</name>
+      <version>5.4.0</version>
+      <description><![CDATA[NuGet client library.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.ProjectModel@5.4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.Protocol</name>
+      <version>5.2.0</version>
+      <description><![CDATA[NuGet client library.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.Protocol@5.2.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.Protocol</name>
+      <version>5.4.0</version>
+      <description><![CDATA[NuGet client library.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.Protocol@5.4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.Versioning</name>
+      <version>5.2.0</version>
+      <description><![CDATA[NuGet's implementation of Semantic Versioning.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.Versioning@5.2.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NuGet.Versioning</name>
+      <version>5.4.0</version>
+      <description><![CDATA[NuGet's implementation of Semantic Versioning.]]></description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/NuGet.Versioning@5.4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://aka.ms/nugetprj</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>runtime.native.System</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Internal implementation package not meant for direct consumption.  Please do not reference directly. 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/runtime.native.System@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Collections</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes that define generic collections, which allow developers to create strongly typed collections that provide better type safety and performance than non-generic strongly typed collections.
+
+Commonly Used Types:
+System.Collections.Generic.List<T>
+System.Collections.Generic.Dictionary<TKey, TValue>
+System.Collections.Generic.Queue<T>
+System.Collections.Generic.Stack<T>
+System.Collections.Generic.HashSet<T>
+System.Collections.Generic.LinkedList<T>
+System.Collections.Generic.EqualityComparer<T>
+System.Collections.Generic.Comparer<T>
+System.Collections.Generic.SortedDictionary<TKey, TValue>
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Collections@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Diagnostics.Debug</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes and attributes that allows basic interaction with a debugger.
+
+Commonly Used Types:
+System.Diagnostics.Debug
+System.Diagnostics.DebuggerStepThroughAttribute
+System.Diagnostics.Debugger
+System.Diagnostics.DebuggerDisplayAttribute
+System.Diagnostics.DebuggerBrowsableAttribute
+System.Diagnostics.DebuggerBrowsableState
+System.Diagnostics.DebuggerHiddenAttribute
+System.Diagnostics.DebuggerNonUserCodeAttribute
+System.Diagnostics.DebuggerTypeProxyAttribute
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Diagnostics.Debug@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Diagnostics.Process</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the System.Diagnostics.Process class, which allows interaction with local and remote processes.
+
+Commonly Used Types:
+System.Diagnostics.Process
+System.Diagnostics.ProcessModule
+System.Diagnostics.ProcessStartInfo
+System.Diagnostics.ProcessThread
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Diagnostics.Process@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Dynamic.Runtime</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes and interfaces that support the Dynamic Language Runtime (DLR).
+
+Commonly Used Types:
+System.Runtime.CompilerServices.CallSite
+System.Runtime.CompilerServices.CallSite<T>
+System.Dynamic.IDynamicMetaObjectProvider
+System.Dynamic.DynamicMetaObject
+System.Dynamic.SetMemberBinder
+System.Dynamic.GetMemberBinder
+System.Dynamic.ExpandoObject
+System.Dynamic.DynamicObject
+System.Runtime.CompilerServices.CallSiteBinder
+System.Runtime.CompilerServices.ConditionalWeakTable<TKey, TValue>
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Dynamic.Runtime@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Globalization</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes that define culture-related information, including language, country/region, calendars in use, format patterns for dates, currency, and numbers, and sort order for strings.
+
+Commonly Used Types:
+System.Globalization.DateTimeFormatInfo
+System.Globalization.CultureInfo
+System.Globalization.NumberFormatInfo
+System.Globalization.CalendarWeekRule
+System.Globalization.TextInfo
+System.Globalization.Calendar
+System.Globalization.CompareInfo
+System.Globalization.CompareOptions
+System.Globalization.UnicodeCategory
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Globalization@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.IO</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides base input and output (I/O) types, including System.IO.Stream, System.IO.StreamReader and System.IO.StreamWriter, that allow reading and writing to data streams
+
+Commonly Used Types:
+System.IO.Stream
+System.IO.EndOfStreamException
+System.IO.MemoryStream
+System.IO.StreamReader
+System.IO.StreamWriter
+System.IO.StringWriter
+System.IO.TextWriter
+System.IO.TextReader
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.IO@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.IO.FileSystem</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides types that allow reading and writing to files and types that provide basic file and directory support.
+
+Commonly Used Types:
+System.IO.FileStream
+System.IO.FileInfo
+System.IO.DirectoryInfo
+System.IO.FileSystemInfo
+System.IO.File
+System.IO.Directory
+System.IO.SearchOption
+System.IO.FileOptions
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.IO.FileSystem@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.IO.FileSystem.Primitives</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides common enumerations and exceptions for path-based I/O libraries.
+
+Commonly Used Types:
+System.IO.DirectoryNotFoundException
+System.IO.FileAccess
+System.IO.FileLoadException
+System.IO.PathTooLongException
+System.IO.FileMode
+System.IO.FileShare
+System.IO.FileAttributes
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.IO.FileSystem.Primitives@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Linq</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes and interfaces that supports queries that use Language-Integrated Query (LINQ).
+
+Commonly Used Types:
+System.Linq.Enumerable
+System.Linq.IGrouping<TKey, TElement>
+System.Linq.IOrderedEnumerable<TElement>
+System.Linq.ILookup<TKey, TElement>
+System.Linq.Lookup<TKey, TElement>
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Linq@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Linq.Expressions</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes, interfaces and enumerations that enable language-level code expressions to be represented as objects in the form of expression trees.
+
+Commonly Used Types:
+System.Linq.IQueryable<T>
+System.Linq.IQueryable
+System.Linq.Expressions.Expression<TDelegate>
+System.Linq.Expressions.Expression
+System.Linq.Expressions.ExpressionVisitor
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Linq.Expressions@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.ObjectModel</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides types and interfaces that allow the creation of observable types that provide notifications to clients when changes are made to it.
+
+Commonly Used Types:
+System.ComponentModel.INotifyPropertyChanged
+System.Collections.ObjectModel.ObservableCollection<T>
+System.ComponentModel.PropertyChangedEventHandler
+System.Windows.Input.ICommand
+System.Collections.Specialized.INotifyCollectionChanged
+System.Collections.Specialized.NotifyCollectionChangedEventArgs
+System.Collections.Specialized.NotifyCollectionChangedEventHandler
+System.Collections.ObjectModel.KeyedCollection<TKey, TItem>
+System.ComponentModel.PropertyChangedEventArgs
+System.Collections.ObjectModel.ReadOnlyDictionary<TKey, TValue>
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.ObjectModel@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Reflection</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides types that retrieve information about assemblies, modules, members, parameters, and other entities in managed code by examining their metadata. These types also can be used to manipulate instances of loaded types, for example to hook up events or to invoke methods.
+
+Commonly Used Types:
+System.Reflection.MethodInfo
+System.Reflection.PropertyInfo
+System.Reflection.ParameterInfo
+System.Reflection.FieldInfo
+System.Reflection.ConstructorInfo
+System.Reflection.Assembly
+System.Reflection.MemberInfo
+System.Reflection.EventInfo
+System.Reflection.Module
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Reflection@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Reflection.Emit</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes that allow a compiler or tool to emit metadata and optionally generate a PE file on disk. The primary clients of these classes are script engines and compilers.
+
+Commonly Used Types:
+System.Reflection.Emit.AssemblyBuilder
+System.Reflection.Emit.FieldBuilder
+System.Reflection.Emit.TypeBuilder
+System.Reflection.Emit.MethodBuilder
+System.Reflection.Emit.ConstructorBuilder
+System.Reflection.Emit.GenericTypeParameterBuilder
+System.Reflection.Emit.ModuleBuilder
+System.Reflection.Emit.PropertyBuilder
+System.Reflection.Emit.AssemblyBuilderAccess
+System.Reflection.Emit.EventBuilder
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Reflection.Emit@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Reflection.Emit.ILGeneration</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes that allow a compiler or tool to emit Microsoft intermediate language (MSIL). The primary clients of these classes are script engines and compilers.
+
+Commonly Used Types:
+System.Reflection.Emit.ILGenerator
+System.Reflection.Emit.Label
+System.Reflection.Emit.CustomAttributeBuilder
+System.Reflection.Emit.LocalBuilder
+System.Reflection.Emit.ParameterBuilder
+System.Reflection.Emit.SignatureHelper
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Reflection.Emit.ILGeneration@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Reflection.Emit.Lightweight</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the System.Reflection.Emit.DynamicMethod class, which represents a dynamic method that can be compiled, executed, and discarded. Discarded methods are available for garbage collection.
+
+Commonly Used Types:
+System.Reflection.Emit.DynamicMethod
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Reflection.Emit.Lightweight@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Reflection.Extensions</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides custom attribute extension methods for System.Reflection types.
+
+Commonly Used Types:
+System.Reflection.InterfaceMapping
+System.Reflection.CustomAttributeExtensions
+System.Reflection.RuntimeReflectionExtensions
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Reflection.Extensions@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Reflection.Primitives</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides common enumerations for reflection-based libraries.
+
+Commonly Used Types:
+System.Reflection.FieldAttributes
+System.Reflection.Emit.OpCode
+System.Reflection.TypeAttributes
+System.Reflection.MethodAttributes
+System.Reflection.CallingConventions
+System.Reflection.PropertyAttributes
+System.Reflection.EventAttributes
+System.Reflection.ParameterAttributes
+System.Reflection.GenericParameterAttributes
+System.Reflection.MethodImplAttributes
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Reflection.Primitives@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Reflection.TypeExtensions</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides extensions methods for System.Type that are designed to be source-compatible with older framework reflection-based APIs.
+
+Commonly Used Types:
+System.Reflection.TypeExtensions
+System.Reflection.BindingFlags
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Reflection.TypeExtensions@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Resources.ResourceManager</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes and attributes that allow developers to create, store, and manage various culture-specific resources used in an application.
+
+Commonly Used Types:
+System.Resources.ResourceManager
+System.Resources.NeutralResourcesLanguageAttribute
+System.Resources.SatelliteContractVersionAttribute
+System.Resources.MissingManifestResourceException
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Resources.ResourceManager@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Runtime</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the fundamental primitives, classes and base classes that define commonly-used value and reference data types, events and event handlers, interfaces, attributes, and exceptions. This packages represents the core package, and provides the minimal set of types required to build a managed application.
+
+Commonly Used Types:
+System.Object
+System.Exception
+System.Int16
+System.Int32
+System.Int64
+System.Enum
+System.String
+System.Char
+System.Boolean
+System.SByte
+System.Byte
+System.DateTime
+System.DateTimeOffset
+System.Single
+System.Double
+System.UInt16
+System.UInt32
+System.UInt64
+System.IDisposable
+System.Uri
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Runtime@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Runtime.Extensions</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides commonly-used classes for performing mathematical functions, conversions, string comparisons and querying environment information.
+
+Commonly Used Types:
+System.Math
+System.Environment
+System.Random
+System.Progress<T>
+System.Convert
+System.Diagnostics.Stopwatch
+System.Runtime.Versioning.FrameworkName
+System.StringComparer
+System.IO.Path
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Runtime.Extensions@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Runtime.Handles</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides base classes, including System.Runtime.InteropServices.CriticalHandle and System.Runtime.InteropServices.SafeHandle, for types that represent operating system handles.
+
+Commonly Used Types:
+System.Runtime.InteropServices.SafeHandle
+Microsoft.Win32.SafeHandles.SafeWaitHandle
+System.Runtime.InteropServices.CriticalHandle
+System.Threading.WaitHandleExtensions
+System.IO.HandleInheritability
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Runtime.Handles@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Runtime.InteropServices</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides types that support COM interop and platform invoke services.
+
+Commonly Used Types:
+System.Runtime.InteropServices.GCHandle
+System.Runtime.InteropServices.GuidAttribute
+System.Runtime.InteropServices.COMException
+System.DllNotFoundException
+System.Runtime.InteropServices.DllImportAttribute
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Runtime.InteropServices@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Security.Cryptography.Primitives</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides common types for the cryptographic libraries.
+
+Commonly Used Types:
+System.Security.Cryptography.ICryptoTransform
+System.Security.Cryptography.AsymmetricAlgorithm
+System.Security.Cryptography.SymmetricAlgorithm
+System.Security.Cryptography.HashAlgorithm
+System.Security.Cryptography.KeyedHashAlgorithm
+System.Security.Cryptography.HMAC
+System.Security.Cryptography.KeySizes
+System.Security.Cryptography.CryptographicException
+System.Security.Cryptography.CipherMode
+System.Security.Cryptography.PaddingMode
+System.Security.Cryptography.CryptoStream
+System.Security.Cryptography.CryptoStreamMode
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Security.Cryptography.Primitives@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Security.Cryptography.ProtectedData</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides access to Windows Data Protection Api.
+
+Commonly Used Types:
+System.Security.Cryptography.DataProtectionScope
+System.Security.Cryptography.ProtectedData
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Security.Cryptography.ProtectedData@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Text.Encoding</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides base abstract encoding classes for converting blocks of characters to and from blocks of bytes.
+
+Commonly Used Types:
+System.Text.Encoding
+System.Text.DecoderFallbackException
+System.Text.Decoder
+System.Text.EncoderFallbackException
+System.Text.Encoder
+System.Text.EncoderFallback
+System.Text.EncoderFallbackBuffer
+System.Text.DecoderFallback
+System.Text.DecoderFallbackBuffer
+System.Text.DecoderExceptionFallback
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Text.Encoding@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Text.Encoding.Extensions</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides support for specific encodings, including ASCII, UTF-7, UTF-8, UTF-16, and UTF-32.
+
+Commonly Used Types:
+System.Text.UTF8Encoding
+System.Text.UnicodeEncoding
+System.Text.ASCIIEncoding
+System.Text.UTF7Encoding
+System.Text.UTF32Encoding
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Text.Encoding.Extensions@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Threading</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the fundamental synchronization primitives, including System.Threading.Monitor and System.Threading.Mutex, that are required when writing asynchronous code.
+
+Commonly Used Types:
+System.Threading.Monitor
+System.Threading.SynchronizationContext
+System.Threading.ManualResetEvent
+System.Threading.AutoResetEvent
+System.Threading.ThreadLocal<T>
+System.Threading.EventWaitHandle
+System.Threading.SemaphoreSlim
+System.Threading.Mutex
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Threading@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Threading.Tasks</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides types that simplify the work of writing concurrent and asynchronous code.
+
+Commonly Used Types:
+System.Threading.Tasks.Task<TResult>
+System.Runtime.CompilerServices.TaskAwaiter<TResult>
+System.Threading.Tasks.TaskCompletionSource<TResult>
+System.Threading.Tasks.Task
+System.OperationCanceledException
+System.AggregateException
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Threading.Tasks@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Threading.Thread</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the System.Threading.Thread class, which allows developers to create and control a thread, set its priority, and get its state.
+
+Commonly Used Types:
+System.Threading.Thread
+System.Threading.ThreadStart
+System.Threading.ParameterizedThreadStart
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Threading.Thread@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Threading.ThreadPool</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the System.Threading.ThreadPool class, which contains a pool of threads that can be used to execute tasks, post work items, wait on behalf of other threads, and process timers.
+
+Commonly Used Types:
+System.Threading.ThreadPool
+System.Threading.WaitOrTimerCallback
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Threading.ThreadPool@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+</bom>

--- a/CycloneDX.IntegrationTests/__snapshots__/Tests.CallingCycloneDX_WithSolutionFilePath_GeneratesBom_NoDependencies.snap
+++ b/CycloneDX.IntegrationTests/__snapshots__/Tests.CallingCycloneDX_WithSolutionFilePath_GeneratesBom_NoDependencies.snap
@@ -1,0 +1,138 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<bom version="1" xmlns="http://cyclonedx.org/schema/bom/1.1">
+  <components>
+    <component type="library">
+      <name>Microsoft.NETCore.App</name>
+      <version>2.1.0</version>
+      <description><![CDATA[A set of .NET API's that are included in the default .NET Core application model. 
+caa7b7e2bad98e56a687fb5cbaf60825500800f7 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.NETCore.App@2.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.NETCore.DotNetAppHost</name>
+      <version>2.1.0</version>
+      <description><![CDATA[Provides the .NET Core app bootstrapper intended for use in the application directory 
+caa7b7e2bad98e56a687fb5cbaf60825500800f7 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.NETCore.DotNetAppHost@2.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.NETCore.DotNetHostPolicy</name>
+      <version>2.1.0</version>
+      <description><![CDATA[Provides a CoreCLR hosting policy implementation -- configuration settings, assembly paths and assembly servicing 
+caa7b7e2bad98e56a687fb5cbaf60825500800f7 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.NETCore.DotNetHostPolicy@2.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.NETCore.DotNetHostResolver</name>
+      <version>2.1.0</version>
+      <description><![CDATA[Provides an implementation of framework resolution strategy used by Microsoft.NETCore.DotNetHost 
+caa7b7e2bad98e56a687fb5cbaf60825500800f7 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.NETCore.DotNetHostResolver@2.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.NETCore.Platforms</name>
+      <version>2.1.0</version>
+      <description><![CDATA[Provides runtime information required to resolve target framework, platform, and runtime specific implementations of .NETCore packages. 
+30ab651fcb4354552bd4891619a0bdd81e0ebdbf 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/corefx/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.NETCore.Platforms@2.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.NETCore.Targets</name>
+      <version>2.1.0</version>
+      <description><![CDATA[Provides supporting infrastructure for portable projects: support identifiers that define framework and runtime for support targets and packages that reference the minimum supported package versions when targeting these. 
+30ab651fcb4354552bd4891619a0bdd81e0ebdbf 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/corefx/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.NETCore.Targets@2.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NETStandard.Library</name>
+      <version>2.0.3</version>
+      <description><![CDATA[A set of standard .NET APIs that are prescribed to be used and supported together. 
+18a36291e48808fa7ef2d00a764ceb1ec95645a5 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/standard/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>.NET Foundation and Contributors</copyright>
+      <purl>pkg:nuget/NETStandard.Library@2.0.3</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+</bom>

--- a/CycloneDX.IntegrationTests/__snapshots__/Tests.CallingCycloneDX_WithSolutionFilePath_GeneratesBom_Vb.snap
+++ b/CycloneDX.IntegrationTests/__snapshots__/Tests.CallingCycloneDX_WithSolutionFilePath_GeneratesBom_Vb.snap
@@ -1,0 +1,3891 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<bom version="1" xmlns="http://cyclonedx.org/schema/bom/1.1">
+  <components>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Antiforgery</name>
+      <version>2.0.0</version>
+      <description><![CDATA[An antiforgery system for ASP.NET Core designed to generate and validate tokens to prevent Cross-Site Request Forgery attacks.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Antiforgery@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Authentication.Abstractions</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core common types used by the various authentication components.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Authentication.Abstractions@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Authentication.Core</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core common types used by the various authentication middleware components.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Authentication.Core@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Authorization</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core authorization classes.
+Commonly used types:
+Microsoft.AspNetCore.Authorization.AllowAnonymousAttribute
+Microsoft.AspNetCore.Authorization.AuthorizeAttribute]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Authorization@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Authorization.Policy</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core authorization policy helper classes.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Authorization.Policy@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Cors</name>
+      <version>2.0.0</version>
+      <description><![CDATA[CORS middleware and policy for ASP.NET Core to enable cross-origin resource sharing.
+Commonly used types:
+Microsoft.AspNetCore.Cors.DisableCorsAttribute
+Microsoft.AspNetCore.Cors.EnableCorsAttribute]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Cors@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Cryptography.Internal</name>
+      <version>2.0.0</version>
+      <description><![CDATA[Infrastructure for ASP.NET Core cryptographic packages. Applications and libraries should not reference this package directly.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Cryptography.Internal@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.DataProtection</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core logic to protect and unprotect data, similar to DPAPI.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.DataProtection@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.DataProtection.Abstractions</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core data protection abstractions.
+Commonly used types:
+Microsoft.AspNetCore.DataProtection.IDataProtectionProvider
+Microsoft.AspNetCore.DataProtection.IDataProtector]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.DataProtection.Abstractions@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Diagnostics.Abstractions</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core diagnostics middleware abstractions and feature interface definitions.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Diagnostics.Abstractions@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Hosting.Abstractions</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core hosting and startup abstractions for web applications.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Hosting.Abstractions@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Hosting.Server.Abstractions</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core hosting server abstractions for web applications.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Hosting.Server.Abstractions@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Html.Abstractions</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core HTML abstractions used for building HTML content.
+Commonly used types:
+Microsoft.AspNetCore.Html.HtmlString
+Microsoft.AspNetCore.Html.IHtmlContent]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Html.Abstractions@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Http</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core default HTTP feature implementations.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Http@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Http.Abstractions</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core HTTP object model for HTTP requests and responses and also common extension methods for registering middleware in an IApplicationBuilder.
+Commonly used types:
+Microsoft.AspNetCore.Builder.IApplicationBuilder
+Microsoft.AspNetCore.Http.HttpContext
+Microsoft.AspNetCore.Http.HttpRequest
+Microsoft.AspNetCore.Http.HttpResponse]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Http.Abstractions@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Http.Extensions</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core common extension methods for HTTP abstractions, HTTP headers, HTTP request/response, and session state.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Http.Extensions@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Http.Features</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core HTTP feature interface definitions.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Http.Features@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.HttpOverrides</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core basic middleware for supporting HTTP method overrides. Includes:
+* X-Forwarded-* headers to forward headers from a proxy.
+* HTTP method override header.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.HttpOverrides@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.JsonPatch</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core support for JSON PATCH.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.JsonPatch@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Localization</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core middleware for automatically applying culture information to HTTP requests. Culture information can be specified in the HTTP header, query string, cookie, or custom source.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Localization@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Mvc</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core MVC is a web framework that gives you a powerful, patterns-based way to build dynamic websites and web APIs. ASP.NET Core MVC enables a clean separation of concerns and gives you full control over markup.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Mvc@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Mvc.Abstractions</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core MVC abstractions and interfaces for action invocation and dispatching, authorization, action filters, formatters, model binding, routing, validation, and more.
+Commonly used types:
+Microsoft.AspNetCore.Mvc.IActionResult]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Mvc.Abstractions@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Mvc.ApiExplorer</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core MVC API explorer functionality for discovering metadata such as the list of controllers and actions, and their URLs and allowed HTTP methods.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Mvc.ApiExplorer@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Mvc.Core</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core MVC core components. Contains common action result types, attribute routing, application model conventions, API explorer, application parts, filters, formatters, model binding, and more.
+Commonly used types:
+Microsoft.AspNetCore.Mvc.AreaAttribute
+Microsoft.AspNetCore.Mvc.BindAttribute
+Microsoft.AspNetCore.Mvc.ControllerBase
+Microsoft.AspNetCore.Mvc.FromBodyAttribute
+Microsoft.AspNetCore.Mvc.FromFormAttribute
+Microsoft.AspNetCore.Mvc.RequireHttpsAttribute
+Microsoft.AspNetCore.Mvc.RouteAttribute]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Mvc.Core@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Mvc.Cors</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core MVC cross-origin resource sharing (CORS) features.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Mvc.Cors@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Mvc.DataAnnotations</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core MVC metadata and validation system using System.ComponentModel.DataAnnotations.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Mvc.DataAnnotations@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Mvc.Formatters.Json</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core MVC formatters for JSON input and output and for JSON PATCH input using Json.NET.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Mvc.Formatters.Json@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Mvc.Localization</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core MVC features that enable globalization and localization of applications.
+Commonly used types:
+Microsoft.AspNetCore.Mvc.Localization.IHtmlLocalizer<TResource>
+Microsoft.AspNetCore.Mvc.Localization.IViewLocalizer]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Mvc.Localization@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Mvc.Razor</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core MVC Razor view engine for CSHTML files.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Mvc.Razor@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Mvc.Razor.Extensions</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core design time hosting infrastructure for the Razor view engine.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Mvc.Razor.Extensions@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Mvc.RazorPages</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core MVC Razor Pages.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Mvc.RazorPages@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Mvc.TagHelpers</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core MVC default tag helpers. Contains tag helpers for anchor tags, HTML input elements, caching, scripts, links (for CSS), and more.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Mvc.TagHelpers@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Mvc.ViewFeatures</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core MVC view rendering features. Contains common types used in most MVC applications as well as view rendering features such as view engines, views, view components, and HTML helpers.
+Commonly used types:
+Microsoft.AspNetCore.Mvc.Controller
+Microsoft.AspNetCore.Mvc.ValidateAntiForgeryTokenAttribute
+Microsoft.AspNetCore.Mvc.ViewComponent]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Mvc.ViewFeatures@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Razor</name>
+      <version>2.0.0</version>
+      <description><![CDATA[Razor is a markup syntax for adding server-side logic to web pages. This package contains the Razor parser and code generation infrastructure.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Razor@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Razor.Language</name>
+      <version>2.0.0</version>
+      <description><![CDATA[Razor is a markup syntax for adding server-side logic to web pages. This package contains the Razor parser and code generation infrastructure.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Razor.Language@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Razor.Runtime</name>
+      <version>2.0.0</version>
+      <description><![CDATA[Runtime components for rendering Razor pages and implementing tag helpers.
+
+Commonly used types:
+Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeNameAttribute
+Microsoft.AspNetCore.Razor.TagHelpers.HtmlTargetElementAttribute
+Microsoft.AspNetCore.Razor.TagHelpers.ITagHelper]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Razor.Runtime@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.ResponseCaching.Abstractions</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core response caching middleware abstractions and feature interface definitions.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.ResponseCaching.Abstractions@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Routing</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core middleware for routing requests to application logic and for generating links.
+Commonly used types:
+Microsoft.AspNetCore.Routing.Route
+Microsoft.AspNetCore.Routing.RouteCollection]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Routing@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Routing.Abstractions</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core abstractions for routing requests to application logic and for generating links.
+Commonly used types:
+Microsoft.AspNetCore.Routing.IRouter
+Microsoft.AspNetCore.Routing.RouteData]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Routing.Abstractions@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.Server.IISIntegration</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core components for working with the IIS AspNetCoreModule.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.Server.IISIntegration@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.AspNetCore.WebUtilities</name>
+      <version>2.0.0</version>
+      <description><![CDATA[ASP.NET Core utilities, such as for working with forms, multipart messages, and query strings.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.AspNetCore.WebUtilities@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.CodeAnalysis.Analyzers</name>
+      <version>1.1.0</version>
+      <description><![CDATA[Analyzers for .NET Compiler Platform ("Roslyn")]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=529443</url>
+        </license>
+      </licenses>
+      <purl>pkg:nuget/Microsoft.CodeAnalysis.Analyzers@1.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>http://msdn.com/roslyn</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.CodeAnalysis.Common</name>
+      <version>2.3.1</version>
+      <description><![CDATA[A shared package used by the Microsoft .NET Compiler Platform ("Roslyn").]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=529443</url>
+        </license>
+      </licenses>
+      <purl>pkg:nuget/Microsoft.CodeAnalysis.Common@2.3.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>http://msdn.com/roslyn</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.CodeAnalysis.CSharp</name>
+      <version>2.3.1</version>
+      <description><![CDATA[.NET Compiler Platform ("Roslyn") support for C#, Microsoft.CodeAnalysis.CSharp.dll.
+
+      More details at https://aka.ms/roslyn-packages]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=529443</url>
+        </license>
+      </licenses>
+      <purl>pkg:nuget/Microsoft.CodeAnalysis.CSharp@2.3.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>http://msdn.com/roslyn</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.CodeAnalysis.Razor</name>
+      <version>2.0.0</version>
+      <description><![CDATA[Razor is a markup syntax for adding server-side logic to web pages. This package contains the Razor design-time infrastructure.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.CodeAnalysis.Razor@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.CSharp</name>
+      <version>4.4.0</version>
+      <description><![CDATA[Provides support for compilation and code generation, including dynamic, using the C# language.
+
+Commonly Used Types:
+Microsoft.CSharp.RuntimeBinder.Binder
+Microsoft.CSharp.RuntimeBinder.RuntimeBinderException
+Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo
+Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags
+Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags
+ 
+8321c729934c0f8be754953439b88e6e1c120c24 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/corefx/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.CSharp@4.4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.DotNet.PlatformAbstractions</name>
+      <version>2.0.0</version>
+      <description><![CDATA[Abstractions for making code that uses file system and environment testable.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.DotNet.PlatformAbstractions@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.Extensions.Caching.Abstractions</name>
+      <version>2.0.0</version>
+      <description><![CDATA[Caching abstractions for in-memory cache and distributed cache.
+Commonly used types:
+Microsoft.Extensions.Caching.Distributed.IDistributedCache
+Microsoft.Extensions.Caching.Memory.IMemoryCache]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.Extensions.Caching.Abstractions@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.Extensions.Caching.Memory</name>
+      <version>2.0.0</version>
+      <description><![CDATA[In-memory cache implementation of Microsoft.Extensions.Caching.Memory.IMemoryCache.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.Extensions.Caching.Memory@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.Extensions.Configuration.Abstractions</name>
+      <version>2.0.0</version>
+      <description><![CDATA[Abstractions of key-value pair based configuration.
+Commonly used types:
+Microsoft.Extensions.Configuration.IConfiguration
+Microsoft.Extensions.Configuration.IConfigurationBuilder
+Microsoft.Extensions.Configuration.IConfigurationProvider
+Microsoft.Extensions.Configuration.IConfigurationRoot
+Microsoft.Extensions.Configuration.IConfigurationSection]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.Extensions.Configuration.Abstractions@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.Extensions.DependencyInjection</name>
+      <version>2.0.0</version>
+      <description><![CDATA[Default implementation of dependency injection for Microsoft.Extensions.DependencyInjection.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.Extensions.DependencyInjection@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.Extensions.DependencyInjection.Abstractions</name>
+      <version>2.0.0</version>
+      <description><![CDATA[Abstractions for dependency injection.
+Commonly used types:
+Microsoft.Extensions.DependencyInjection.IServiceCollection]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.Extensions.DependencyInjection.Abstractions@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.Extensions.DependencyModel</name>
+      <version>2.0.0</version>
+      <description><![CDATA[Abstractions for reading `.deps` files.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.Extensions.DependencyModel@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.Extensions.FileProviders.Abstractions</name>
+      <version>2.0.0</version>
+      <description><![CDATA[Abstractions of files and directories.
+Commonly used types:
+Microsoft.Extensions.FileProviders.IDirectoryContents
+Microsoft.Extensions.FileProviders.IFileInfo
+Microsoft.Extensions.FileProviders.IFileProvider]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.Extensions.FileProviders.Abstractions@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.Extensions.FileProviders.Composite</name>
+      <version>2.0.0</version>
+      <description><![CDATA[Composite file and directory providers for Microsoft.Extensions.FileProviders.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.Extensions.FileProviders.Composite@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.Extensions.FileSystemGlobbing</name>
+      <version>2.0.0</version>
+      <description><![CDATA[File system globbing to find files matching a specified pattern.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.Extensions.FileSystemGlobbing@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.Extensions.Hosting.Abstractions</name>
+      <version>2.0.0</version>
+      <description><![CDATA[.NET Core hosting and startup abstractions for applications.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.Extensions.Hosting.Abstractions@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.Extensions.Localization</name>
+      <version>2.0.0</version>
+      <description><![CDATA[Application localization services and default implementation based on ResourceManager to load localized assembly resources.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.Extensions.Localization@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.Extensions.Localization.Abstractions</name>
+      <version>2.0.0</version>
+      <description><![CDATA[Abstractions of application localization services.
+Commonly used types:
+Microsoft.Extensions.Localization.IStringLocalizer
+Microsoft.Extensions.Localization.IStringLocalizer<T>]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.Extensions.Localization.Abstractions@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.Extensions.Logging.Abstractions</name>
+      <version>2.0.0</version>
+      <description><![CDATA[Logging abstractions for Microsoft.Extensions.Logging.
+Commonly used types:
+Microsoft.Extensions.Logging.ILogger
+Microsoft.Extensions.Logging.ILoggerFactory
+Microsoft.Extensions.Logging.ILogger<TCategoryName>
+Microsoft.Extensions.Logging.LogLevel
+Microsoft.Extensions.Logging.Logger<T>
+Microsoft.Extensions.Logging.LoggerMessage
+Microsoft.Extensions.Logging.Abstractions.NullLogger]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.Extensions.Logging.Abstractions@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.Extensions.ObjectPool</name>
+      <version>2.0.0</version>
+      <description><![CDATA[A simple object pool implementation.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.Extensions.ObjectPool@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.Extensions.Options</name>
+      <version>2.0.0</version>
+      <description><![CDATA[Provides a strongly typed way of specifying and accessing settings using dependency injection.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.Extensions.Options@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.Extensions.Primitives</name>
+      <version>2.0.0</version>
+      <description><![CDATA[Primitives shared by framework extensions. Commonly used types include:
+Microsoft.Extensions.Primitives.IChangeToken
+Microsoft.Extensions.Primitives.StringValues
+Microsoft.Extensions.Primitives.StringSegment]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.Extensions.Primitives@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.Extensions.WebEncoders</name>
+      <version>2.0.0</version>
+      <description><![CDATA[Contains registration and configuration APIs to add the core framework encoders to a dependency injection container.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.Extensions.WebEncoders@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.Net.Http.Headers</name>
+      <version>2.0.0</version>
+      <description><![CDATA[HTTP header parser implementations.]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © Microsoft Corporation</copyright>
+      <purl>pkg:nuget/Microsoft.Net.Http.Headers@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://asp.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.NETCore.App</name>
+      <version>2.1.0</version>
+      <description><![CDATA[A set of .NET API's that are included in the default .NET Core application model. 
+caa7b7e2bad98e56a687fb5cbaf60825500800f7 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.NETCore.App@2.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.NETCore.DotNetAppHost</name>
+      <version>2.1.0</version>
+      <description><![CDATA[Provides the .NET Core app bootstrapper intended for use in the application directory 
+caa7b7e2bad98e56a687fb5cbaf60825500800f7 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.NETCore.DotNetAppHost@2.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.NETCore.DotNetHostPolicy</name>
+      <version>2.1.0</version>
+      <description><![CDATA[Provides a CoreCLR hosting policy implementation -- configuration settings, assembly paths and assembly servicing 
+caa7b7e2bad98e56a687fb5cbaf60825500800f7 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.NETCore.DotNetHostPolicy@2.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.NETCore.DotNetHostResolver</name>
+      <version>2.1.0</version>
+      <description><![CDATA[Provides an implementation of framework resolution strategy used by Microsoft.NETCore.DotNetHost 
+caa7b7e2bad98e56a687fb5cbaf60825500800f7 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.NETCore.DotNetHostResolver@2.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.NETCore.Platforms</name>
+      <version>2.1.0</version>
+      <description><![CDATA[Provides runtime information required to resolve target framework, platform, and runtime specific implementations of .NETCore packages. 
+30ab651fcb4354552bd4891619a0bdd81e0ebdbf 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/corefx/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.NETCore.Platforms@2.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.NETCore.Targets</name>
+      <version>2.1.0</version>
+      <description><![CDATA[Provides supporting infrastructure for portable projects: support identifiers that define framework and runtime for support targets and packages that reference the minimum supported package versions when targeting these. 
+30ab651fcb4354552bd4891619a0bdd81e0ebdbf 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/corefx/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.NETCore.Targets@2.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.Win32.Primitives</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides common types for Win32-based libraries.
+
+Commonly Used Types:
+System.ComponentModel.Win32Exception
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.Win32.Primitives@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Microsoft.Win32.Registry</name>
+      <version>4.4.0</version>
+      <description><![CDATA[Provides support for accessing and modifying the Windows Registry.
+
+Commonly Used Types:
+Microsoft.Win32.RegistryKey
+Microsoft.Win32.Registry
+Microsoft.Win32.RegistryValueKind
+Microsoft.Win32.RegistryHive
+Microsoft.Win32.RegistryView
+ 
+8321c729934c0f8be754953439b88e6e1c120c24 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/corefx/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.Win32.Registry@4.4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>NETStandard.Library</name>
+      <version>2.0.3</version>
+      <description><![CDATA[A set of standard .NET APIs that are prescribed to be used and supported together. 
+18a36291e48808fa7ef2d00a764ceb1ec95645a5 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/standard/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>.NET Foundation and Contributors</copyright>
+      <purl>pkg:nuget/NETStandard.Library@2.0.3</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Newtonsoft.Json</name>
+      <version>10.0.1</version>
+      <description><![CDATA[Json.NET is a popular high-performance JSON framework for .NET]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.github.com/JamesNK/Newtonsoft.Json/master/LICENSE.md</url>
+        </license>
+      </licenses>
+      <purl>pkg:nuget/Newtonsoft.Json@10.0.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>http://www.newtonsoft.com/json</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>Newtonsoft.Json.Bson</name>
+      <version>1.0.1</version>
+      <description><![CDATA[Json.NET BSON adds support for reading and writing BSON]]></description>
+      <licenses>
+        <license>
+          <url>https://raw.github.com/JamesNK/Newtonsoft.Json.Bson/master/LICENSE.md</url>
+        </license>
+      </licenses>
+      <copyright>Copyright © James Newton-King 2017</copyright>
+      <purl>pkg:nuget/Newtonsoft.Json.Bson@1.0.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>http://www.newtonsoft.com/json</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Internal implementation package not meant for direct consumption.  Please do not reference directly. 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Internal implementation package not meant for direct consumption.  Please do not reference directly. 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Internal implementation package not meant for direct consumption.  Please do not reference directly. 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>runtime.native.System</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Internal implementation package not meant for direct consumption.  Please do not reference directly. 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/runtime.native.System@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>runtime.native.System.IO.Compression</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Internal implementation package not meant for direct consumption.  Please do not reference directly. 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/runtime.native.System.IO.Compression@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>runtime.native.System.Net.Http</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Internal implementation package not meant for direct consumption.  Please do not reference directly. 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/runtime.native.System.Net.Http@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>runtime.native.System.Net.Security</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Internal implementation package not meant for direct consumption.  Please do not reference directly. 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/runtime.native.System.Net.Security@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>runtime.native.System.Security.Cryptography.Apple</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Internal implementation package not meant for direct consumption.  Please do not reference directly. 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/runtime.native.System.Security.Cryptography.Apple@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>runtime.native.System.Security.Cryptography.OpenSsl</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Internal implementation package not meant for direct consumption.  Please do not reference directly. 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/runtime.native.System.Security.Cryptography.OpenSsl@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Internal implementation package not meant for direct consumption.  Please do not reference directly. 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Internal implementation package not meant for direct consumption.  Please do not reference directly. 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Internal implementation package not meant for direct consumption.  Please do not reference directly. 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Internal implementation package not meant for direct consumption.  Please do not reference directly. 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Internal implementation package not meant for direct consumption.  Please do not reference directly. 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Internal implementation package not meant for direct consumption.  Please do not reference directly. 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Internal implementation package not meant for direct consumption.  Please do not reference directly. 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Internal implementation package not meant for direct consumption.  Please do not reference directly. 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.AppContext</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the System.AppContext class, which allows access to the BaseDirectory property and other application specific data.
+
+Commonly Used Types:
+System.AppContext
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.AppContext@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Buffers</name>
+      <version>4.4.0</version>
+      <description><![CDATA[Provides resource pooling of any type for performance-critical applications that allocate and deallocate objects frequently.
+
+Commonly Used Types:
+System.Buffers.ArrayPool<T>
+ 
+8321c729934c0f8be754953439b88e6e1c120c24 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/corefx/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Buffers@4.4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Collections</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes that define generic collections, which allow developers to create strongly typed collections that provide better type safety and performance than non-generic strongly typed collections.
+
+Commonly Used Types:
+System.Collections.Generic.List<T>
+System.Collections.Generic.Dictionary<TKey, TValue>
+System.Collections.Generic.Queue<T>
+System.Collections.Generic.Stack<T>
+System.Collections.Generic.HashSet<T>
+System.Collections.Generic.LinkedList<T>
+System.Collections.Generic.EqualityComparer<T>
+System.Collections.Generic.Comparer<T>
+System.Collections.Generic.SortedDictionary<TKey, TValue>
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Collections@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Collections.Concurrent</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides several thread-safe collection classes that should be used in place of the corresponding types in the System.Collections.NonGeneric and System.Collections packages whenever multiple threads are accessing the collection concurrently.
+
+Commonly Used Types:
+System.Collections.Concurrent.ConcurrentDictionary<TKey, TValue>
+System.Collections.Concurrent.ConcurrentQueue<T>
+System.Collections.Concurrent.ConcurrentBag<T>
+System.Collections.Concurrent.BlockingCollection<T>
+System.Collections.Concurrent.ConcurrentStack<T>
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Collections.Concurrent@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Collections.Immutable</name>
+      <version>1.3.1</version>
+      <description><![CDATA[This package provides collections that are thread safe and guaranteed to never change their contents, also known as immutable collections. Like strings, any methods that perform modifications will not change the existing instance but instead return a new instance. For efficiency reasons, the implementation uses a sharing mechanism to ensure that newly created instances share as much data as possible with the previous instance while ensuring that operations have a predictable time complexity.
+
+Commonly Used Types:
+System.Collections.Immutable.ImmutableArray
+System.Collections.Immutable.ImmutableArray<T>
+System.Collections.Immutable.ImmutableDictionary
+System.Collections.Immutable.ImmutableDictionary<TKey,TValue>
+System.Collections.Immutable.ImmutableHashSet
+System.Collections.Immutable.ImmutableHashSet<T>
+System.Collections.Immutable.ImmutableList
+System.Collections.Immutable.ImmutableList<T>
+System.Collections.Immutable.ImmutableQueue
+System.Collections.Immutable.ImmutableQueue<T>
+System.Collections.Immutable.ImmutableSortedDictionary
+System.Collections.Immutable.ImmutableSortedDictionary<TKey,TValue>
+System.Collections.Immutable.ImmutableSortedSet
+System.Collections.Immutable.ImmutableSortedSet<T>
+System.Collections.Immutable.ImmutableStack
+System.Collections.Immutable.ImmutableStack<T>]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Collections.Immutable@1.3.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Collections.NonGeneric</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes that define older non-generic collections of objects, such as lists, queues, hash tables and dictionaries. Developers should prefer the generic collections in the System.Collections package.
+
+Commonly Used Types:
+System.Collections.ArrayList
+System.Collections.Hashtable
+System.Collections.CollectionBase
+System.Collections.ReadOnlyCollectionBase
+System.Collections.Stack
+System.Collections.SortedList
+System.Collections.DictionaryBase
+System.Collections.Queue
+System.Collections.Comparer
+System.Collections.CaseInsensitiveComparer
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Collections.NonGeneric@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Collections.Specialized</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides older specialized non-generic collections; for example, a linked list dictionary, a bit vector, and collections that contain only strings.
+
+Commonly Used Types:
+System.Collections.Specialized.NameValueCollection
+System.Collections.Specialized.NameObjectCollectionBase
+System.Collections.Specialized.StringCollection
+System.Collections.Specialized.IOrderedDictionary
+System.Collections.Specialized.HybridDictionary
+System.Collections.Specialized.OrderedDictionary
+System.Collections.Specialized.ListDictionary
+System.Collections.Specialized.StringDictionary
+System.Collections.Specialized.BitVector32
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Collections.Specialized@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.ComponentModel</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides interfaces for the editing and change tracking of objects used as data sources.
+
+Commonly Used Types:
+System.ComponentModel.CancelEventArgs
+System.IServiceProvider
+System.ComponentModel.IEditableObject
+System.ComponentModel.IChangeTracking
+System.ComponentModel.IRevertibleChangeTracking
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.ComponentModel@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.ComponentModel.Annotations</name>
+      <version>4.4.0</version>
+      <description><![CDATA[Provides attributes that are used to define metadata for objects used as data sources.
+
+Commonly Used Types:
+System.ComponentModel.DataAnnotations.ValidationResult
+System.ComponentModel.DataAnnotations.IValidatableObject
+System.ComponentModel.DataAnnotations.ValidationAttribute
+System.ComponentModel.DataAnnotations.RequiredAttribute
+System.ComponentModel.DataAnnotations.StringLengthAttribute
+System.ComponentModel.DataAnnotations.DisplayAttribute
+System.ComponentModel.DataAnnotations.RegularExpressionAttribute
+System.ComponentModel.DataAnnotations.DataTypeAttribute
+System.ComponentModel.DataAnnotations.RangeAttribute
+System.ComponentModel.DataAnnotations.KeyAttribute
+ 
+8321c729934c0f8be754953439b88e6e1c120c24 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/corefx/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.ComponentModel.Annotations@4.4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.ComponentModel.Primitives</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides interfaces that are used to implement the run-time and design-time behavior of components.
+
+Commonly Used Types:
+System.ComponentModel.IComponent
+System.ComponentModel.IContainer
+System.ComponentModel.ISite
+System.ComponentModel.ComponentCollection
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.ComponentModel.Primitives@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.ComponentModel.TypeConverter</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the System.ComponentModel.TypeConverter class, which represents a unified way of converting types of values to other types.
+
+Commonly Used Types:
+System.ComponentModel.TypeConverter
+System.ComponentModel.TypeConverterAttribute
+System.ComponentModel.PropertyDescriptor
+System.ComponentModel.StringConverter
+System.ComponentModel.ITypeDescriptorContext
+System.ComponentModel.EnumConverter
+System.ComponentModel.TypeDescriptor
+System.ComponentModel.Int32Converter
+System.ComponentModel.BooleanConverter
+System.ComponentModel.DoubleConverter
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.ComponentModel.TypeConverter@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Console</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the System.Console class, which represents the standard input, output and error streams for console applications.
+
+Commonly Used Types:
+System.Console
+System.ConsoleColor
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Console@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Diagnostics.Debug</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes and attributes that allows basic interaction with a debugger.
+
+Commonly Used Types:
+System.Diagnostics.Debug
+System.Diagnostics.DebuggerStepThroughAttribute
+System.Diagnostics.Debugger
+System.Diagnostics.DebuggerDisplayAttribute
+System.Diagnostics.DebuggerBrowsableAttribute
+System.Diagnostics.DebuggerBrowsableState
+System.Diagnostics.DebuggerHiddenAttribute
+System.Diagnostics.DebuggerNonUserCodeAttribute
+System.Diagnostics.DebuggerTypeProxyAttribute
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Diagnostics.Debug@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Diagnostics.DiagnosticSource</name>
+      <version>4.4.1</version>
+      <description><![CDATA[Provides Classes that allow you to decouple code logging rich (unserializable) diagnostics/telemetry (e.g. framework) from code that consumes it (e.g. tools)
+
+Commonly Used Types:
+System.Diagnostics.DiagnosticListener
+System.Diagnostics.DiagnosticSource
+ 
+8321c729934c0f8be754953439b88e6e1c120c24]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/corefx/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Diagnostics.DiagnosticSource@4.4.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Diagnostics.FileVersionInfo</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the System.Diagnostics.FileVersionInfo class, which allows access to Win32 version resource information for a physical file on disk.
+
+Commonly Used Types:
+System.Diagnostics.FileVersionInfo
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Diagnostics.FileVersionInfo@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Diagnostics.StackTrace</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the System.Diagnostics.StackTrace class, which allows interaction with local and remote processes.
+
+Commonly Used Types:
+System.Diagnostics.StackFrame
+System.Diagnostics.StackTrace
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Diagnostics.StackTrace@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Diagnostics.Tools</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides attributes, such as GeneratedCodeAttribute and SuppresMessageAttribute, that are emitted or consumed by analysis tools.
+
+Commonly Used Types:
+System.CodeDom.Compiler.GeneratedCodeAttribute
+System.Diagnostics.CodeAnalysis.SuppressMessageAttribute
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Diagnostics.Tools@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Diagnostics.Tracing</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides class that enable you to create high performance tracing events to be captured by event tracing for Windows (ETW).
+
+Commonly Used Types:
+System.Diagnostics.Tracing.EventSource
+System.Diagnostics.Tracing.EventListener
+System.Diagnostics.Tracing.EventLevel
+System.Diagnostics.Tracing.EventKeywords
+System.Diagnostics.Tracing.EventWrittenEventArgs
+System.Diagnostics.Tracing.EventAttribute
+System.Diagnostics.Tracing.EventSourceAttribute
+System.Diagnostics.Tracing.NonEventAttribute
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Diagnostics.Tracing@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Dynamic.Runtime</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes and interfaces that support the Dynamic Language Runtime (DLR).
+
+Commonly Used Types:
+System.Runtime.CompilerServices.CallSite
+System.Runtime.CompilerServices.CallSite<T>
+System.Dynamic.IDynamicMetaObjectProvider
+System.Dynamic.DynamicMetaObject
+System.Dynamic.SetMemberBinder
+System.Dynamic.GetMemberBinder
+System.Dynamic.ExpandoObject
+System.Dynamic.DynamicObject
+System.Runtime.CompilerServices.CallSiteBinder
+System.Runtime.CompilerServices.ConditionalWeakTable<TKey, TValue>
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Dynamic.Runtime@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Globalization</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes that define culture-related information, including language, country/region, calendars in use, format patterns for dates, currency, and numbers, and sort order for strings.
+
+Commonly Used Types:
+System.Globalization.DateTimeFormatInfo
+System.Globalization.CultureInfo
+System.Globalization.NumberFormatInfo
+System.Globalization.CalendarWeekRule
+System.Globalization.TextInfo
+System.Globalization.Calendar
+System.Globalization.CompareInfo
+System.Globalization.CompareOptions
+System.Globalization.UnicodeCategory
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Globalization@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Globalization.Calendars</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes for performing date calculations using specific calendars, including the Gregorian, Julian, Hijri and Korean calendars.
+
+Commonly Used Types:
+System.Globalization.HijriCalendar
+System.Globalization.GregorianCalendar
+System.Globalization.HebrewCalendar
+System.Globalization.KoreanCalendar
+System.Globalization.ThaiBuddhistCalendar
+System.Globalization.TaiwanCalendar
+System.Globalization.JapaneseCalendar
+System.Globalization.GregorianCalendarTypes
+System.Globalization.PersianCalendar
+System.Globalization.UmAlQuraCalendar
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Globalization.Calendars@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Globalization.Extensions</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes for performing Unicode string normalization, culture-specific string comparisons and support the use of non-ASCII characters for Internet domain names.
+
+Commonly Used Types:
+System.StringNormalizationExtensions
+System.Text.NormalizationForm
+System.Globalization.IdnMapping
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Globalization.Extensions@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.IO</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides base input and output (I/O) types, including System.IO.Stream, System.IO.StreamReader and System.IO.StreamWriter, that allow reading and writing to data streams
+
+Commonly Used Types:
+System.IO.Stream
+System.IO.EndOfStreamException
+System.IO.MemoryStream
+System.IO.StreamReader
+System.IO.StreamWriter
+System.IO.StringWriter
+System.IO.TextWriter
+System.IO.TextReader
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.IO@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.IO.Compression</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes that support the compression and decompression of streams.
+
+Commonly Used Types:
+System.IO.Compression.DeflateStream
+System.IO.Compression.GZipStream
+System.IO.Compression.CompressionMode
+System.IO.Compression.CompressionLevel
+System.IO.Compression.ZipArchiveEntry
+System.IO.Compression.ZipArchive
+System.IO.Compression.ZipArchiveMode
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.IO.Compression@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.IO.FileSystem</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides types that allow reading and writing to files and types that provide basic file and directory support.
+
+Commonly Used Types:
+System.IO.FileStream
+System.IO.FileInfo
+System.IO.DirectoryInfo
+System.IO.FileSystemInfo
+System.IO.File
+System.IO.Directory
+System.IO.SearchOption
+System.IO.FileOptions
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.IO.FileSystem@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.IO.FileSystem.Primitives</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides common enumerations and exceptions for path-based I/O libraries.
+
+Commonly Used Types:
+System.IO.DirectoryNotFoundException
+System.IO.FileAccess
+System.IO.FileLoadException
+System.IO.PathTooLongException
+System.IO.FileMode
+System.IO.FileShare
+System.IO.FileAttributes
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.IO.FileSystem.Primitives@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Linq</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes and interfaces that supports queries that use Language-Integrated Query (LINQ).
+
+Commonly Used Types:
+System.Linq.Enumerable
+System.Linq.IGrouping<TKey, TElement>
+System.Linq.IOrderedEnumerable<TElement>
+System.Linq.ILookup<TKey, TElement>
+System.Linq.Lookup<TKey, TElement>
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Linq@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Linq.Expressions</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes, interfaces and enumerations that enable language-level code expressions to be represented as objects in the form of expression trees.
+
+Commonly Used Types:
+System.Linq.IQueryable<T>
+System.Linq.IQueryable
+System.Linq.Expressions.Expression<TDelegate>
+System.Linq.Expressions.Expression
+System.Linq.Expressions.ExpressionVisitor
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Linq.Expressions@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Net.Http</name>
+      <version>4.3.1</version>
+      <description><![CDATA[Provides a programming interface for modern HTTP applications, including HTTP client components that allow applications to consume web services over HTTP and HTTP components that can be used by both clients and servers for parsing HTTP headers.
+
+Commonly Used Types:
+System.Net.Http.HttpResponseMessage
+System.Net.Http.DelegatingHandler
+System.Net.Http.HttpRequestException
+System.Net.Http.HttpClient
+System.Net.Http.MultipartContent
+System.Net.Http.Headers.HttpContentHeaders
+System.Net.Http.HttpClientHandler
+System.Net.Http.StreamContent
+System.Net.Http.FormUrlEncodedContent
+System.Net.Http.HttpMessageHandler
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Net.Http@4.3.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Net.Primitives</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides common types for network-based libraries, including System.Net.IPAddress, System.Net.IPEndPoint, and System.Net.CookieContainer.
+
+Commonly Used Types:
+System.Net.HttpStatusCode
+System.Net.Sockets.SocketError
+System.Net.Cookie
+System.Net.Sockets.SocketException
+System.Net.IPEndPoint
+System.Net.ICredentials
+System.Net.NetworkCredential
+System.Net.IPAddress
+System.Net.CookieCollection
+System.Net.CookieContainer
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Net.Primitives@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Net.Security</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides types, such as System.Net.Security.SslStream, that uses SSL/TLS protocols to provide secure network communication between client and server endpoints.
+
+Commonly Used Types:
+System.Net.Security.SslStream
+System.Net.Security.ExtendedProtectionPolicy
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Net.Security@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.ObjectModel</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides types and interfaces that allow the creation of observable types that provide notifications to clients when changes are made to it.
+
+Commonly Used Types:
+System.ComponentModel.INotifyPropertyChanged
+System.Collections.ObjectModel.ObservableCollection<T>
+System.ComponentModel.PropertyChangedEventHandler
+System.Windows.Input.ICommand
+System.Collections.Specialized.INotifyCollectionChanged
+System.Collections.Specialized.NotifyCollectionChangedEventArgs
+System.Collections.Specialized.NotifyCollectionChangedEventHandler
+System.Collections.ObjectModel.KeyedCollection<TKey, TItem>
+System.ComponentModel.PropertyChangedEventArgs
+System.Collections.ObjectModel.ReadOnlyDictionary<TKey, TValue>
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.ObjectModel@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Reflection</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides types that retrieve information about assemblies, modules, members, parameters, and other entities in managed code by examining their metadata. These types also can be used to manipulate instances of loaded types, for example to hook up events or to invoke methods.
+
+Commonly Used Types:
+System.Reflection.MethodInfo
+System.Reflection.PropertyInfo
+System.Reflection.ParameterInfo
+System.Reflection.FieldInfo
+System.Reflection.ConstructorInfo
+System.Reflection.Assembly
+System.Reflection.MemberInfo
+System.Reflection.EventInfo
+System.Reflection.Module
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Reflection@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Reflection.Emit</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes that allow a compiler or tool to emit metadata and optionally generate a PE file on disk. The primary clients of these classes are script engines and compilers.
+
+Commonly Used Types:
+System.Reflection.Emit.AssemblyBuilder
+System.Reflection.Emit.FieldBuilder
+System.Reflection.Emit.TypeBuilder
+System.Reflection.Emit.MethodBuilder
+System.Reflection.Emit.ConstructorBuilder
+System.Reflection.Emit.GenericTypeParameterBuilder
+System.Reflection.Emit.ModuleBuilder
+System.Reflection.Emit.PropertyBuilder
+System.Reflection.Emit.AssemblyBuilderAccess
+System.Reflection.Emit.EventBuilder
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Reflection.Emit@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Reflection.Emit.ILGeneration</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes that allow a compiler or tool to emit Microsoft intermediate language (MSIL). The primary clients of these classes are script engines and compilers.
+
+Commonly Used Types:
+System.Reflection.Emit.ILGenerator
+System.Reflection.Emit.Label
+System.Reflection.Emit.CustomAttributeBuilder
+System.Reflection.Emit.LocalBuilder
+System.Reflection.Emit.ParameterBuilder
+System.Reflection.Emit.SignatureHelper
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Reflection.Emit.ILGeneration@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Reflection.Emit.Lightweight</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the System.Reflection.Emit.DynamicMethod class, which represents a dynamic method that can be compiled, executed, and discarded. Discarded methods are available for garbage collection.
+
+Commonly Used Types:
+System.Reflection.Emit.DynamicMethod
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Reflection.Emit.Lightweight@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Reflection.Extensions</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides custom attribute extension methods for System.Reflection types.
+
+Commonly Used Types:
+System.Reflection.InterfaceMapping
+System.Reflection.CustomAttributeExtensions
+System.Reflection.RuntimeReflectionExtensions
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Reflection.Extensions@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Reflection.Metadata</name>
+      <version>1.4.2</version>
+      <description><![CDATA[This packages provides a low-level .NET (ECMA-335) metadata reader. It's geared for performance and is the ideal choice for building higher-level libraries that intend to provide their own object model, such as compilers.
+
+Commonly Used Types:
+System.Reflection.Metadata.MetadataReader
+System.Reflection.PortableExecutable.PEReader]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Reflection.Metadata@1.4.2</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Reflection.Primitives</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides common enumerations for reflection-based libraries.
+
+Commonly Used Types:
+System.Reflection.FieldAttributes
+System.Reflection.Emit.OpCode
+System.Reflection.TypeAttributes
+System.Reflection.MethodAttributes
+System.Reflection.CallingConventions
+System.Reflection.PropertyAttributes
+System.Reflection.EventAttributes
+System.Reflection.ParameterAttributes
+System.Reflection.GenericParameterAttributes
+System.Reflection.MethodImplAttributes
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Reflection.Primitives@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Reflection.TypeExtensions</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides extensions methods for System.Type that are designed to be source-compatible with older framework reflection-based APIs.
+
+Commonly Used Types:
+System.Reflection.TypeExtensions
+System.Reflection.BindingFlags
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Reflection.TypeExtensions@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Resources.ResourceManager</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes and attributes that allow developers to create, store, and manage various culture-specific resources used in an application.
+
+Commonly Used Types:
+System.Resources.ResourceManager
+System.Resources.NeutralResourcesLanguageAttribute
+System.Resources.SatelliteContractVersionAttribute
+System.Resources.MissingManifestResourceException
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Resources.ResourceManager@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Runtime</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the fundamental primitives, classes and base classes that define commonly-used value and reference data types, events and event handlers, interfaces, attributes, and exceptions. This packages represents the core package, and provides the minimal set of types required to build a managed application.
+
+Commonly Used Types:
+System.Object
+System.Exception
+System.Int16
+System.Int32
+System.Int64
+System.Enum
+System.String
+System.Char
+System.Boolean
+System.SByte
+System.Byte
+System.DateTime
+System.DateTimeOffset
+System.Single
+System.Double
+System.UInt16
+System.UInt32
+System.UInt64
+System.IDisposable
+System.Uri
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Runtime@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Runtime.CompilerServices.Unsafe</name>
+      <version>4.4.0</version>
+      <description><![CDATA[Provides the System.Runtime.CompilerServices.Unsafe class, which provides generic, low-level functionality for manipulating pointers.
+
+Commonly Used Types:
+System.Runtime.CompilerServices.Unsafe
+ 
+8321c729934c0f8be754953439b88e6e1c120c24 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/corefx/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Runtime.CompilerServices.Unsafe@4.4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Runtime.Extensions</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides commonly-used classes for performing mathematical functions, conversions, string comparisons and querying environment information.
+
+Commonly Used Types:
+System.Math
+System.Environment
+System.Random
+System.Progress<T>
+System.Convert
+System.Diagnostics.Stopwatch
+System.Runtime.Versioning.FrameworkName
+System.StringComparer
+System.IO.Path
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Runtime.Extensions@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Runtime.Handles</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides base classes, including System.Runtime.InteropServices.CriticalHandle and System.Runtime.InteropServices.SafeHandle, for types that represent operating system handles.
+
+Commonly Used Types:
+System.Runtime.InteropServices.SafeHandle
+Microsoft.Win32.SafeHandles.SafeWaitHandle
+System.Runtime.InteropServices.CriticalHandle
+System.Threading.WaitHandleExtensions
+System.IO.HandleInheritability
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Runtime.Handles@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Runtime.InteropServices</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides types that support COM interop and platform invoke services.
+
+Commonly Used Types:
+System.Runtime.InteropServices.GCHandle
+System.Runtime.InteropServices.GuidAttribute
+System.Runtime.InteropServices.COMException
+System.DllNotFoundException
+System.Runtime.InteropServices.DllImportAttribute
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Runtime.InteropServices@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Runtime.InteropServices.RuntimeInformation</name>
+      <version>4.0.0</version>
+      <description><![CDATA[Provides APIs to query about runtime and OS information.
+
+Commonly Used Types:
+System.Runtime.InteropServices.RuntimeInformation
+System.Runtime.InteropServices.OSPlatform
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Runtime.InteropServices.RuntimeInformation@4.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Runtime.Numerics</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the numeric types System.Numerics.BigInteger and System.Numerics.Complex, which complement the numeric primitives, such as System.Byte, System.Double and System.Int32.
+
+Commonly Used Types:
+System.Numerics.BigInteger
+System.Numerics.Complex
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Runtime.Numerics@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Runtime.Serialization.Formatters</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides common types for libraries that support runtime serialization.
+
+Commonly Used Types:
+System.SerializableAttribute
+System.Runtime.Serialization.ISerializable
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Runtime.Serialization.Formatters@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Runtime.Serialization.Primitives</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides common types, including System.Runtime.Serialization.DataContractAttribute, for libraries that support data contract serialization.
+
+Commonly Used Types:
+System.Runtime.Serialization.StreamingContext
+System.Runtime.Serialization.OnDeserializingAttribute
+System.Runtime.Serialization.OnDeserializedAttribute
+System.Runtime.Serialization.OnSerializingAttribute
+System.Runtime.Serialization.OnSerializedAttribute
+System.Runtime.Serialization.EnumMemberAttribute
+System.Runtime.Serialization.DataMemberAttribute
+System.Runtime.Serialization.DataContractAttribute
+System.Runtime.Serialization.IgnoreDataMemberAttribute
+System.Runtime.Serialization.SerializationException
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Runtime.Serialization.Primitives@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Security.AccessControl</name>
+      <version>4.4.0</version>
+      <description><![CDATA[Provides base classes that enable managing access and audit control lists on securable objects.
+
+Commonly Used Types:
+System.Security.AccessControl.AccessRule
+System.Security.AccessControl.AuditRule
+System.Security.AccessControl.ObjectAccessRule
+System.Security.AccessControl.ObjectAuditRule
+System.Security.AccessControl.ObjectSecurity
+ 
+8321c729934c0f8be754953439b88e6e1c120c24 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/corefx/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Security.AccessControl@4.4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Security.Claims</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides classes that implement claims-based identity in the .NET Framework, including classes that represent claims, claims-based identities, and claims-based principals.
+
+Commonly Used Types:
+System.Security.Principal.GenericIdentity
+System.Security.Claims.Claim
+System.Security.Claims.ClaimsIdentity
+System.Security.Claims.ClaimsPrincipal
+System.Security.Principal.GenericPrincipal
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Security.Claims@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Security.Cryptography.Algorithms</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides base types for cryptographic algorithms, including hashing, encryption, and signing operations.
+
+Commonly Used Types:
+System.Security.Cryptography.Aes
+System.Security.Cryptography.RSA
+System.Security.Cryptography.RSAParameters
+System.Security.Cryptography.HMACSHA1
+System.Security.Cryptography.SHA256
+System.Security.Cryptography.SHA1
+System.Security.Cryptography.SHA512
+System.Security.Cryptography.SHA384
+System.Security.Cryptography.HMACSHA256
+System.Security.Cryptography.MD5
+System.Security.Cryptography.HMACSHA384
+System.Security.Cryptography.HMACSHA512
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Security.Cryptography.Algorithms@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Security.Cryptography.Cng</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides cryptographic algorithm implementations and key management with Windows Cryptographic Next Generation API (CNG).
+
+Commonly Used Types:
+System.Security.Cryptography.RSACng
+System.Security.Cryptography.ECDsaCng
+System.Security.Cryptography.CngKey
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Security.Cryptography.Cng@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Security.Cryptography.Csp</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides cryptographic algorithm implementations and key management with Windows Cryptographic API (CryptoAPI).
+
+Commonly Used Types:
+System.Security.Cryptography.RSACryptoServiceProvider
+System.Security.Cryptography.CspParameters
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Security.Cryptography.Csp@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Security.Cryptography.Encoding</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides types for representing Abstract Syntax Notation One (ASN.1)-encoded data.
+
+Commonly Used Types:
+System.Security.Cryptography.AsnEncodedData
+System.Security.Cryptography.Oid
+System.Security.Cryptography.OidCollection
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Security.Cryptography.Encoding@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Security.Cryptography.OpenSsl</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides cryptographic algorithm implementations and key management for non-Windows systems with OpenSSL.
+
+Commonly Used Types:
+System.Security.Cryptography.RSAOpenSsl
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Security.Cryptography.OpenSsl@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Security.Cryptography.Primitives</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides common types for the cryptographic libraries.
+
+Commonly Used Types:
+System.Security.Cryptography.ICryptoTransform
+System.Security.Cryptography.AsymmetricAlgorithm
+System.Security.Cryptography.SymmetricAlgorithm
+System.Security.Cryptography.HashAlgorithm
+System.Security.Cryptography.KeyedHashAlgorithm
+System.Security.Cryptography.HMAC
+System.Security.Cryptography.KeySizes
+System.Security.Cryptography.CryptographicException
+System.Security.Cryptography.CipherMode
+System.Security.Cryptography.PaddingMode
+System.Security.Cryptography.CryptoStream
+System.Security.Cryptography.CryptoStreamMode
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Security.Cryptography.Primitives@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Security.Cryptography.X509Certificates</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides types for reading, exporting and verifying Authenticode X.509 v3 certificates. These certificates are signed with a private key that uniquely and positively identifies the holder of the certificate.
+
+Commonly Used Types:
+System.Security.Cryptography.X509Certificates.X509Certificate2
+System.Security.Cryptography.X509Certificates.X509Certificate
+System.Security.Cryptography.X509Certificates.X509ContentType
+System.Security.Cryptography.X509Certificates.StoreLocation
+System.Security.Cryptography.X509Certificates.StoreName
+System.Security.Cryptography.X509Certificates.X509FindType
+System.Security.Cryptography.X509Certificates.X509ChainStatus
+System.Security.Cryptography.X509Certificates.X509Certificate2Collection
+System.Security.Cryptography.X509Certificates.X509EnhancedKeyUsageExtension
+System.Security.Cryptography.X509Certificates.X509Chain
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Security.Cryptography.X509Certificates@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Security.Cryptography.Xml</name>
+      <version>4.4.0</version>
+      <description><![CDATA[Provides classes to support the creation and validation of XML digital signatures. The classes in this namespace implement the World Wide Web Consortium Recommendation, "XML-Signature Syntax and Processing", described at http://www.w3.org/TR/xmldsig-core/.
+
+Commonly Used Types:
+System.Security.Cryptography.Xml.CipherData
+System.Security.Cryptography.Xml.CipherReference
+System.Security.Cryptography.Xml.DataObject
+System.Security.Cryptography.Xml.DataReference
+System.Security.Cryptography.Xml.DSAKeyValue
+System.Security.Cryptography.Xml.EncryptedData
+System.Security.Cryptography.Xml.EncryptedKey
+System.Security.Cryptography.Xml.EncryptedReference
+System.Security.Cryptography.Xml.EncryptedType
+System.Security.Cryptography.Xml.EncryptedXml
+System.Security.Cryptography.Xml.EncryptionMethod
+System.Security.Cryptography.Xml.EncryptionProperty
+System.Security.Cryptography.Xml.EncryptionPropertyCollection
+System.Security.Cryptography.Xml.KeyInfo
+System.Security.Cryptography.Xml.KeyInfoClause
+System.Security.Cryptography.Xml.KeyInfoEncryptedKey
+System.Security.Cryptography.Xml.KeyInfoName
+System.Security.Cryptography.Xml.KeyInfoNode
+System.Security.Cryptography.Xml.KeyInfoRetrievalMethod
+System.Security.Cryptography.Xml.KeyInfoX509Data
+System.Security.Cryptography.Xml.KeyReference
+System.Security.Cryptography.Xml.Reference
+System.Security.Cryptography.Xml.ReferenceList
+System.Security.Cryptography.Xml.RSAKeyValue
+System.Security.Cryptography.Xml.Signature
+System.Security.Cryptography.Xml.SignedInfo
+System.Security.Cryptography.Xml.SignedXml
+System.Security.Cryptography.Xml.Transform
+System.Security.Cryptography.Xml.TransformChain
+System.Security.Cryptography.Xml.XmlDecryptionTransform
+System.Security.Cryptography.Xml.XmlDsigBase64Transform
+System.Security.Cryptography.Xml.XmlDsigC14NTransform
+System.Security.Cryptography.Xml.XmlDsigC14NWithCommentsTransform
+System.Security.Cryptography.Xml.XmlDsigEnvelopedSignatureTransform
+System.Security.Cryptography.Xml.XmlDsigExcC14NTransform
+System.Security.Cryptography.Xml.XmlDsigExcC14NWithCommentsTransform
+System.Security.Cryptography.Xml.XmlDsigXPathTransform
+System.Security.Cryptography.Xml.XmlDsigXsltTransform
+System.Security.Cryptography.Xml.XmlLicenseTransform
+ 
+8321c729934c0f8be754953439b88e6e1c120c24 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/corefx/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Security.Cryptography.Xml@4.4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Security.Principal</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the base interfaces for principal and identity objects that represents the security context under which code is running.
+
+Commonly Used Types:
+System.Security.Principal.IPrincipal
+System.Security.Principal.IIdentity
+System.Security.Principal.TokenImpersonationLevel
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Security.Principal@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Security.Principal.Windows</name>
+      <version>4.4.0</version>
+      <description><![CDATA[Provides classes for retrieving the current Windows user and for interacting with Windows users and groups.
+
+Commonly Used Types:
+System.Security.Principal.WindowsIdentity
+System.Security.Principal.SecurityIdentifier
+System.Security.Principal.NTAccount
+System.Security.Principal.WindowsPrincipal
+System.Security.Principal.IdentityReference
+System.Security.Principal.IdentityNotMappedException
+System.Security.Principal.WindowsBuiltInRole
+System.Security.Principal.WellKnownSidType
+ 
+8321c729934c0f8be754953439b88e6e1c120c24 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/corefx/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Security.Principal.Windows@4.4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Text.Encoding</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides base abstract encoding classes for converting blocks of characters to and from blocks of bytes.
+
+Commonly Used Types:
+System.Text.Encoding
+System.Text.DecoderFallbackException
+System.Text.Decoder
+System.Text.EncoderFallbackException
+System.Text.Encoder
+System.Text.EncoderFallback
+System.Text.EncoderFallbackBuffer
+System.Text.DecoderFallback
+System.Text.DecoderFallbackBuffer
+System.Text.DecoderExceptionFallback
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Text.Encoding@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Text.Encoding.CodePages</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides support for code-page based encodings, including Windows-1252, Shift-JIS, and GB2312.
+
+Commonly Used Types:
+System.Text.CodePagesEncodingProvider
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Text.Encoding.CodePages@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Text.Encoding.Extensions</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides support for specific encodings, including ASCII, UTF-7, UTF-8, UTF-16, and UTF-32.
+
+Commonly Used Types:
+System.Text.UTF8Encoding
+System.Text.UnicodeEncoding
+System.Text.ASCIIEncoding
+System.Text.UTF7Encoding
+System.Text.UTF32Encoding
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Text.Encoding.Extensions@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Text.Encodings.Web</name>
+      <version>4.4.0</version>
+      <description><![CDATA[Provides types for encoding and escaping strings for use in JavaScript, HyperText Markup Language (HTML), and uniform resource locators (URL).
+
+Commonly Used Types:
+System.Text.Encodings.Web.HtmlEncoder
+System.Text.Encodings.Web.UrlEncoder
+System.Text.Encodings.Web.JavaScriptEncoder
+ 
+8321c729934c0f8be754953439b88e6e1c120c24 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>https://github.com/dotnet/corefx/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Text.Encodings.Web@4.4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Text.RegularExpressions</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the System.Text.RegularExpressions.Regex class, an implementation of a regular expression engine.
+
+Commonly Used Types:
+System.Text.RegularExpressions.Regex
+System.Text.RegularExpressions.RegexOptions
+System.Text.RegularExpressions.Match
+System.Text.RegularExpressions.Group
+System.Text.RegularExpressions.Capture
+System.Text.RegularExpressions.MatchEvaluator
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Text.RegularExpressions@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Threading</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the fundamental synchronization primitives, including System.Threading.Monitor and System.Threading.Mutex, that are required when writing asynchronous code.
+
+Commonly Used Types:
+System.Threading.Monitor
+System.Threading.SynchronizationContext
+System.Threading.ManualResetEvent
+System.Threading.AutoResetEvent
+System.Threading.ThreadLocal<T>
+System.Threading.EventWaitHandle
+System.Threading.SemaphoreSlim
+System.Threading.Mutex
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Threading@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Threading.Tasks</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides types that simplify the work of writing concurrent and asynchronous code.
+
+Commonly Used Types:
+System.Threading.Tasks.Task<TResult>
+System.Runtime.CompilerServices.TaskAwaiter<TResult>
+System.Threading.Tasks.TaskCompletionSource<TResult>
+System.Threading.Tasks.Task
+System.OperationCanceledException
+System.AggregateException
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Threading.Tasks@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Threading.Tasks.Extensions</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides additional types that simplify the work of writing concurrent and asynchronous code.
+
+Commonly Used Types:
+System.Threading.Tasks.ValueTask<TResult>]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Threading.Tasks.Extensions@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Threading.Tasks.Parallel</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the System.Threading.Tasks.Parallel class, which adds support for running loops and iterators in parallel.
+
+Commonly Used Types:
+System.Threading.Tasks.Parallel
+System.Threading.Tasks.ParallelLoopState
+System.Threading.Tasks.ParallelLoopResult
+System.Threading.Tasks.ParallelOptions
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Threading.Tasks.Parallel@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Threading.Thread</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the System.Threading.Thread class, which allows developers to create and control a thread, set its priority, and get its state.
+
+Commonly Used Types:
+System.Threading.Thread
+System.Threading.ThreadStart
+System.Threading.ParameterizedThreadStart
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Threading.Thread@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Threading.ThreadPool</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the System.Threading.ThreadPool class, which contains a pool of threads that can be used to execute tasks, post work items, wait on behalf of other threads, and process timers.
+
+Commonly Used Types:
+System.Threading.ThreadPool
+System.Threading.WaitOrTimerCallback
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Threading.ThreadPool@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.ValueTuple</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the System.ValueTuple structs, which implement the underlying types for C# 7 tuples.
+
+Commonly Used Types:
+System.ValueTuple
+System.ValueTuple<T1>
+System.ValueTuple<T1, T2>
+System.ValueTuple<T1, T2, T3>
+System.ValueTuple<T1, T2, T3, T4>
+System.ValueTuple<T1, T2, T3, T4, T5>
+System.ValueTuple<T1, T2, T3, T4, T5, T6>
+System.ValueTuple<T1, T2, T3, T4, T5, T6, T7>
+System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.ValueTuple@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Xml.ReaderWriter</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides provides a fast, non-cached, forward-only way to read and write Extensible Markup Language (XML) data.
+
+Commonly Used Types:
+System.Xml.XmlNodeType
+System.Xml.XmlException
+System.Xml.XmlReader
+System.Xml.XmlWriter
+System.Xml.IXmlLineInfo
+System.Xml.XmlNameTable
+System.Xml.IXmlNamespaceResolver
+System.Xml.XmlNamespaceManager
+System.Xml.XmlQualifiedName
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Xml.ReaderWriter@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Xml.XDocument</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the classes for Language-Integrated Query (LINQ) to Extensible Markup Language (XML). LINQ to XML is an in-memory XML programming interface that enables you to modify XML documents efficiently and easily.
+
+Commonly Used Types:
+System.Xml.Linq.XElement
+System.Xml.Linq.XAttribute
+System.Xml.Linq.XDocument
+System.Xml.Linq.XText
+System.Xml.Linq.XNode
+System.Xml.Linq.XContainer
+System.Xml.Linq.XComment
+System.Xml.Linq.XObject
+System.Xml.Linq.XProcessingInstruction
+System.Xml.Linq.XDocumentType
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Xml.XDocument@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Xml.XmlDocument</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides an older in-memory Extensible Markup Language (XML) programming interface that enables you to modify XML documents. Developers should prefer the classes in the System.Xml.XDocument package.
+
+Commonly Used Types:
+System.Xml.XmlNode
+System.Xml.XmlElement
+System.Xml.XmlAttribute
+System.Xml.XmlDocument
+System.Xml.XmlDeclaration
+System.Xml.XmlText
+System.Xml.XmlComment
+System.Xml.XmlNodeList
+System.Xml.XmlWhitespace
+System.Xml.XmlCDataSection
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Xml.XmlDocument@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Xml.XPath</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides the classes that define a cursor model for navigating and editing Extensible Markup Language (XML) information items as instances of the XQuery 1.0 and XPath 2.0 Data Model.
+
+Commonly Used Types:
+System.Xml.XPath.XPathNavigator
+System.Xml.XPath.IXPathNavigable
+System.Xml.XPath.XPathNodeType
+System.Xml.XPath.XPathNodeIterator
+System.Xml.XPath.XPathExpression
+System.Xml.XPath.XPathResultType
+System.Xml.XPath.XPathException
+System.Xml.XPath.XPathDocument
+System.Xml.XPath.XPathItem
+System.Xml.XPath.XPathNamespaceScope
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Xml.XPath@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library">
+      <name>System.Xml.XPath.XDocument</name>
+      <version>4.3.0</version>
+      <description><![CDATA[Provides extension methods that add System.Xml.XPath support to the System.Xml.XDocument package.
+
+Commonly Used Types:
+System.Xml.XPath.Extensions
+System.Xml.XPath.XDocumentExtensions
+ 
+When using NuGet 3.x this package requires at least version 3.4.]]></description>
+      <licenses>
+        <license>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Xml.XPath.XDocument@4.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+</bom>

--- a/CycloneDX.Tests/ComponentServiceTests.cs
+++ b/CycloneDX.Tests/ComponentServiceTests.cs
@@ -33,9 +33,9 @@ namespace CycloneDX.Tests
             var mockNugetService = new Mock<INugetService>();
             mockNugetService
                 .SetupSequence(service => service.GetComponentAsync(It.IsAny<NugetPackage>()))
-                .Returns(Task.FromResult(new Component { Name = "Package1", Version = "1.0.0" }))
-                .Returns(Task.FromResult(new Component { Name = "Package2", Version = "1.0.0" }))
-                .Returns(Task.FromResult(new Component { Name = "Package3", Version = "1.0.0" }));
+                .ReturnsAsync(new Component { Name = "Package1", Version = "1.0.0" })
+                .ReturnsAsync(new Component { Name = "Package2", Version = "1.0.0" })
+                .ReturnsAsync(new Component { Name = "Package3", Version = "1.0.0" });
             var nugetService = mockNugetService.Object;
             var componentService = new ComponentService(nugetService);
             var nugetPackages = new List<NugetPackage>
@@ -61,7 +61,7 @@ namespace CycloneDX.Tests
             var mockNugetService = new Mock<INugetService>();
             mockNugetService
                 .SetupSequence(service => service.GetComponentAsync(It.IsAny<NugetPackage>()))
-                .Returns(Task.FromResult(new Component {
+                .ReturnsAsync(new Component {
                     Name = "Package1",
                     Version = "1.0.0" ,
                     Dependencies = new HashSet<NugetPackage>
@@ -72,8 +72,8 @@ namespace CycloneDX.Tests
                             Version = "1.0.0"
                         }
                     }
-                }))
-                .Returns(Task.FromResult(new Component { Name = "Dependency1", Version = "1.0.0" }));
+                })
+                .ReturnsAsync(new Component { Name = "Dependency1", Version = "1.0.0" });
             var nugetService = mockNugetService.Object;
             var componentService = new ComponentService(nugetService);
             var nugetPackages = new List<NugetPackage>

--- a/CycloneDX.Tests/DotnetUtilsServiceTests.cs
+++ b/CycloneDX.Tests/DotnetUtilsServiceTests.cs
@@ -1,0 +1,174 @@
+// This file is part of the CycloneDX Tool for .NET
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright (c) Steve Springett. All Rights Reserved.
+
+using System;
+using System.Collections.Generic;
+using System.IO.Abstractions;
+using System.IO.Abstractions.TestingHelpers;
+using XFS = System.IO.Abstractions.TestingHelpers.MockUnixSupport;
+using System.Threading.Tasks;
+using Xunit;
+using Moq;
+using CycloneDX.Models;
+using CycloneDX.Services;
+
+namespace CycloneDX.Tests
+{
+    public class DotnetUtilsServiceTests
+    {
+        [Fact]
+        public void GetNuGetFallbackFolderPath_ReturnsCorrectFallbackPath()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.Directory
+                .CreateDirectory(XFS.Path(@"c:\dotnet\sdk\NuGetFallbackFolder"));
+
+            var dotnetCommandService = new Mock<IDotnetCommandService>();
+            dotnetCommandService
+                .Setup(m => m.Run("--list-sdks"))
+                .Returns(new DotnetCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut = @"2.2.402 [" + XFS.Path(@"c:\dotnet\sdk") + "]"
+                });
+            
+            var dotnetUtilsService = new DotnetUtilsService(
+                fileSystem, dotnetCommandService.Object);
+
+            // act
+            var fallbackPath = dotnetUtilsService.GetNuGetFallbackFolderPath();
+
+            Assert.Equal(
+                XFS.Path(@"c:\dotnet\sdk\NuGetFallbackFolder"),
+                fallbackPath.Result);
+        }
+
+        // some SDKs don't have a NugetFallbackFolder
+        [Fact]
+        public void GetNuGetFallbackFolderPath_ReturnsNullFallbackPath()
+        {
+            var fileSystem = new MockFileSystem();
+
+            var dotnetCommandService = new Mock<IDotnetCommandService>();
+            dotnetCommandService
+                .Setup(m => m.Run("--list-sdks"))
+                .Returns(new DotnetCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut = @"2.2.402 [" + XFS.Path(@"c:\dotnet\sdk") + "]"
+                });
+            
+            var dotnetUtilsService = new DotnetUtilsService(
+                fileSystem, dotnetCommandService.Object);
+
+            // act
+            var fallbackPath = dotnetUtilsService.GetNuGetFallbackFolderPath();
+
+            Assert.True(fallbackPath.Success);
+            Assert.Null(fallbackPath.Result);
+        }
+
+        [Fact]
+        public void GetGlobalPackagesCacheLocation_ReturnsCorrectCachePath()
+        {
+            var dotnetCommandService = new Mock<IDotnetCommandService>();
+            dotnetCommandService
+                .Setup(m => m.Run("nuget locals global-packages --list"))
+                .Returns(new DotnetCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut = @"info : global-packages: " + XFS.Path(@"c:\user\.nuget\packages")
+                });
+            
+            var dotnetUtilsService = new DotnetUtilsService(
+                new MockFileSystem(), dotnetCommandService.Object);
+
+            // act
+            var fallbackPath = dotnetUtilsService.GetGlobalPackagesCacheLocation();
+
+            Assert.Equal(
+                XFS.Path(@"c:\user\.nuget\packages"),
+                fallbackPath.Result);
+        }
+
+        [Fact]
+        public void GetPackageCachePaths_ReturnsGlobalCacheAndFallbackCachePaths()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.Directory
+                .CreateDirectory(XFS.Path(@"c:\dotnet\sdk\NuGetFallbackFolder"));
+
+            var dotnetCommandService = new Mock<IDotnetCommandService>();
+            dotnetCommandService
+                .Setup(m => m.Run("--list-sdks"))
+                .Returns(new DotnetCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut = @"2.2.402 [" + XFS.Path(@"c:\dotnet\sdk") + "]"
+                });
+            dotnetCommandService
+                .Setup(m => m.Run("nuget locals global-packages --list"))
+                .Returns(new DotnetCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut = @"info : global-packages: " + XFS.Path(@"c:\user\.nuget\packages")
+                });
+            
+            var dotnetUtilsService = new DotnetUtilsService(
+                fileSystem, dotnetCommandService.Object);
+
+            // act
+            var cachePaths = dotnetUtilsService.GetPackageCachePaths();
+
+            Assert.Collection(
+                cachePaths.Result,
+                path => Assert.Equal(XFS.Path(@"c:\user\.nuget\packages"), path),
+                path => Assert.Equal(XFS.Path(@"c:\dotnet\sdk\NuGetFallbackFolder"), path));
+        }
+
+        [Fact]
+        public void GetPackageCachePaths_ReturnsGlobalCacheWithoutFallbackCachePath()
+        {
+            var fileSystem = new MockFileSystem();
+
+            var dotnetCommandService = new Mock<IDotnetCommandService>();
+            dotnetCommandService
+                .Setup(m => m.Run("--list-sdks"))
+                .Returns(new DotnetCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut = @"2.2.402 [" + XFS.Path(@"c:\dotnet\sdk") + "]"
+                });
+            dotnetCommandService
+                .Setup(m => m.Run("nuget locals global-packages --list"))
+                .Returns(new DotnetCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut = @"info : global-packages: " + XFS.Path(@"c:\user\.nuget\packages")
+                });
+            
+            var dotnetUtilsService = new DotnetUtilsService(
+                fileSystem, dotnetCommandService.Object);
+
+            // act
+            var cachePaths = dotnetUtilsService.GetPackageCachePaths();
+
+            Assert.Collection(
+                cachePaths.Result,
+                path => Assert.Equal(XFS.Path(@"c:\user\.nuget\packages"), path));
+        }
+    }
+}

--- a/CycloneDX.Tests/Helpers.cs
+++ b/CycloneDX.Tests/Helpers.cs
@@ -103,5 +103,10 @@ namespace CycloneDX.Tests
         {
             return GetProjectFileWithReferences(projects, null);
         }
+
+        public static MockFileData GetEmptyProjectFile()
+        {
+            return GetProjectFileWithReferences(null, null);
+        }
     }
 }

--- a/CycloneDX/CycloneDX.csproj
+++ b/CycloneDX/CycloneDX.csproj
@@ -36,6 +36,7 @@
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.4.4" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="nuget.projectmodel" Version="5.4.0" />
     <PackageReference Include="System.IO.Abstractions" Version="7.0.7" />
   </ItemGroup>
 

--- a/CycloneDX/ExitCode.cs
+++ b/CycloneDX/ExitCode.cs
@@ -8,6 +8,7 @@ namespace CycloneDX
         OutputDirectoryParameterMissing,
         GitHubParameterMissing,
         InvalidGitHubApiCredentials,
-        GitHubApiRateLimitExceeded
+        GitHubApiRateLimitExceeded,
+        LocalPackageCacheError
     }
 }

--- a/CycloneDX/Extensions/HttpClientExtensions.cs
+++ b/CycloneDX/Extensions/HttpClientExtensions.cs
@@ -14,19 +14,19 @@
 //
 // Copyright (c) Steve Springett. All Rights Reserved.
 
+using System.IO;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
-using System.Xml;
 
 namespace CycloneDX.Extensions
 {
     public static class HttpClientExtensions
     {
         /*
-         * Simple extension method to retrieve an XmlDocument from a URL.
+         * Simple extension method to retrieve an xml stream from a URL.
          */
-        public static async Task<XmlDocument> GetXmlAsync(this HttpClient httpClient, string url)
+        public static async Task<Stream> GetXmlStreamAsync(this HttpClient httpClient, string url)
         {
             httpClient.DefaultRequestHeaders.Accept.Clear();
             httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/xml"));
@@ -36,10 +36,8 @@ namespace CycloneDX.Extensions
             if (response.StatusCode == System.Net.HttpStatusCode.NotFound) return null;
             
             response.EnsureSuccessStatusCode();
-            var contentAsString = await response.Content.ReadAsStringAsync();
-            var doc = new XmlDocument();
-            doc.LoadXml(contentAsString);
-            return doc;
+            var contentStream = await response.Content.ReadAsStreamAsync();
+            return contentStream;
         }
     }
 }

--- a/CycloneDX/Models/Component.cs
+++ b/CycloneDX/Models/Component.cs
@@ -69,7 +69,7 @@ namespace CycloneDX.Models
             }
             else
             {
-                var nameComparison = this.Name.CompareTo(other.Name);
+                var nameComparison = this.Name.ToLowerInvariant().CompareTo(other.Name.ToLowerInvariant());
                 return nameComparison == 0
                     ? this.Version.CompareTo(other.Version)
                     : nameComparison;

--- a/CycloneDX/Models/DotnetCommandResult.cs
+++ b/CycloneDX/Models/DotnetCommandResult.cs
@@ -1,0 +1,27 @@
+// This file is part of the CycloneDX Tool for .NET
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright (c) Steve Springett. All Rights Reserved.
+
+namespace CycloneDX.Models
+{
+    public class DotnetCommandResult
+    {
+        public int ExitCode { get; set; }
+        public string StdErr { get; set; }
+        public string StdOut { get; set; }
+        
+        public bool Success => ExitCode == 0;
+    }
+}

--- a/CycloneDX/Models/DotnetUtilsResults.cs
+++ b/CycloneDX/Models/DotnetUtilsResults.cs
@@ -1,0 +1,31 @@
+// This file is part of the CycloneDX Tool for .NET
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright (c) Steve Springett. All Rights Reserved.
+
+namespace CycloneDX.Models
+{
+    public class DotnetUtilsResult
+    {
+        public bool Success => ErrorMessage == null;
+        public string ErrorMessage { get; set; }
+    }
+
+    public class DotnetUtilsResult<T>
+    {
+        public bool Success => ErrorMessage == null;
+        public string ErrorMessage { get; set; }
+        public T Result { get; set; }
+    }
+}

--- a/CycloneDX/Services/BomService.cs
+++ b/CycloneDX/Services/BomService.cs
@@ -50,23 +50,23 @@ namespace CycloneDX {
             {
                 Console.WriteLine(component.Name);
                 var c = new XElement(ns + "component", new XAttribute("type", "library"));
-                if (component.Group != null)
+                if (!string.IsNullOrEmpty(component.Group))
                 {
                     c.Add(new XElement(ns + "group", component.Group));
                 }
-                if (component.Name != null)
+                if (!string.IsNullOrEmpty(component.Name))
                 {
                     c.Add(new XElement(ns + "name", component.Name));
                 }
-                if (component.Version != null)
+                if (!string.IsNullOrEmpty(component.Version))
                 {
                     c.Add(new XElement(ns + "version", component.Version));
                 }
-                if (component.Description != null)
+                if (!string.IsNullOrEmpty(component.Description))
                 {
                     c.Add(new XElement(ns + "description", new XCData(component.Description)));
                 }
-                if (component.Scope != null)
+                if (!string.IsNullOrEmpty(component.Scope))
                 {
                     c.Add(new XElement(ns + "scope", component.Scope));
                 }
@@ -98,15 +98,15 @@ namespace CycloneDX {
                     }
                     c.Add(l);
                 }
-                if (component.Copyright != null)
+                if (!string.IsNullOrEmpty(component.Copyright))
                 {
                     c.Add(new XElement(ns + "copyright", component.Copyright));
                 }
-                if (component.Cpe != null)
+                if (!string.IsNullOrEmpty(component.Cpe))
                 {
                     c.Add(new XElement(ns + "cpe", component.Cpe));
                 }
-                if (component.Purl != null)
+                if (!string.IsNullOrEmpty(component.Purl))
                 {
                     c.Add(new XElement(ns + "purl", component.Purl));
                 }

--- a/CycloneDX/Services/DotnetCommandService.cs
+++ b/CycloneDX/Services/DotnetCommandService.cs
@@ -1,0 +1,91 @@
+// This file is part of the CycloneDX Tool for .NET
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright (c) Steve Springett. All Rights Reserved.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using McMaster.Extensions.CommandLineUtils;
+using DotnetCommandResult = CycloneDX.Models.DotnetCommandResult;
+
+namespace CycloneDX.Services
+{
+    public class DotnetCommandService : IDotnetCommandService
+    {
+        public DotnetCommandService() {}
+        
+        public DotnetCommandResult Run(string arguments)
+        {
+            return Run(Directory.GetCurrentDirectory(), arguments);
+        }
+
+        public DotnetCommandResult Run(string workingDirectory, string arguments)
+        {
+            var psi = new ProcessStartInfo(DotNetExe.FullPathOrDefault(), arguments)
+            {
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = workingDirectory
+            };
+            
+            using (var p = Process.Start(psi))
+            {
+                var exitCode = 0;
+                var output = new StringBuilder();
+                var errors = new StringBuilder();
+                var outputTask = ConsumeStreamReaderAsync(p.StandardOutput, output);
+                var errorTask = ConsumeStreamReaderAsync(p.StandardError, errors);
+
+                var processExited = p.WaitForExit(60000);
+
+                if (processExited)
+                {
+                    exitCode = p.ExitCode;
+                }
+                else
+                {
+                    p.Kill();
+                    exitCode = -1;
+                }
+
+                Task.WaitAll(outputTask, errorTask);
+
+                var result = new DotnetCommandResult
+                {
+                    ExitCode = exitCode,
+                    StdOut = output.ToString(),
+                    StdErr = errors.ToString()
+                };
+
+                return result;
+            }
+        }
+        
+        private async Task ConsumeStreamReaderAsync(StreamReader reader, StringBuilder lines)
+        {
+            await Task.Yield();
+
+            string line;
+            while ((line = await reader.ReadLineAsync()) != null)
+            {
+                lines.AppendLine(line);
+            }
+        }
+    }
+}

--- a/CycloneDX/Services/DotnetUtilsService.cs
+++ b/CycloneDX/Services/DotnetUtilsService.cs
@@ -1,0 +1,152 @@
+// This file is part of the CycloneDX Tool for .NET
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright (c) Steve Springett. All Rights Reserved.
+using System;
+using System.Collections.Generic;
+using System.IO.Abstractions;
+using System.Text.RegularExpressions;
+using CycloneDX.Models;
+
+namespace CycloneDX.Services
+{
+    public class DotnetUtilsService : IDotnetUtilsService
+    {
+        private Regex _sdkPathRegex = new Regex(@"(\S)+ \[(?<path>.*)\]");
+        private Regex _globalPackageCacheLocationPath = new Regex(@"global-packages: (?<path>.*)$");
+        private Regex _projectRegex = new Regex(@"Restore completed in \S+ \S+ for (?<path>.+)\.");
+
+        private IFileSystem _fileSystem;
+        private IDotnetCommandService _dotnetCommandService;
+
+        public DotnetUtilsService(IFileSystem fileSystem, IDotnetCommandService dotNetCommandService)
+        {
+            _fileSystem = fileSystem;
+            _dotnetCommandService = dotNetCommandService;
+        }
+
+        internal DotnetUtilsResult<string> GetNuGetFallbackFolderPath()
+        {
+            var commandResult = _dotnetCommandService.Run("--list-sdks");
+
+            if (commandResult.Success)
+            {
+                var match = _sdkPathRegex.Match(commandResult.StdOut);
+                if (match.Success)
+                {
+                    var fallbackPath = _fileSystem.Path.Combine(match.Groups["path"].ToString(), "NuGetFallbackFolder");
+                    if (_fileSystem.Directory.Exists(fallbackPath))
+                    {
+                        return new DotnetUtilsResult<string>
+                        {
+                            Result = fallbackPath
+                        };
+                    }
+                    else
+                    {
+                        return new DotnetUtilsResult<string>();
+                    }
+                }
+            }
+
+            return new DotnetUtilsResult<string>
+            {
+                ErrorMessage = commandResult.StdErr
+            };
+        }
+
+        internal DotnetUtilsResult<string> GetGlobalPackagesCacheLocation()
+        {
+            var commandResult = _dotnetCommandService.Run("nuget locals global-packages --list");
+
+            if (commandResult.Success)
+            {
+                var match = _globalPackageCacheLocationPath.Match(commandResult.StdOut);
+                if (match.Success)
+                {
+                    return new DotnetUtilsResult<string>
+                    {
+                        // on Windows (at least) the path will have a carriage return
+                        Result = match.Groups["path"].ToString().Trim()
+                    };
+                }
+            }
+
+            return new DotnetUtilsResult<string>
+            {
+                ErrorMessage = commandResult.StdErr
+            };
+        }
+
+        private string CombineErrorMessages(string currentErrorMessage, string additionalErrorMessage)
+        {
+            if (additionalErrorMessage == null) return currentErrorMessage;
+            if (currentErrorMessage == "")
+            {
+                return additionalErrorMessage;
+            }
+            else
+            {
+                return $"{currentErrorMessage}\n{additionalErrorMessage}";
+            }
+        }
+
+        public DotnetUtilsResult<List<string>> GetPackageCachePaths()
+        {
+            var result = new List<string>();
+            var cacheLocation = GetGlobalPackagesCacheLocation();
+            var fallbackLocation = GetNuGetFallbackFolderPath();
+
+            if (cacheLocation.Success && fallbackLocation.Success)
+            {
+                result.Add(cacheLocation.Result);
+                if (fallbackLocation.Result != null) result.Add(fallbackLocation.Result);
+                return new DotnetUtilsResult<List<string>>
+                {
+                    Result = result
+                };
+            }
+            else
+            {
+                var errorMessage = "";
+                errorMessage = CombineErrorMessages(errorMessage, cacheLocation.ErrorMessage);
+                errorMessage = CombineErrorMessages(errorMessage, fallbackLocation.ErrorMessage);
+                return new DotnetUtilsResult<List<string>>
+                {
+                    ErrorMessage = errorMessage
+                };
+            }
+        }
+
+        public DotnetUtilsResult Restore(string path)
+        {
+            var arguments = "restore";
+            if (!string.IsNullOrEmpty(path)) arguments = $"{arguments} \"{path}\"";
+
+            var commandResult = _dotnetCommandService.Run(arguments);
+
+            if (commandResult.Success)
+            {
+                return new DotnetUtilsResult();
+            }
+            else
+            {
+                return new DotnetUtilsResult
+                {
+                    ErrorMessage = commandResult.StdErr
+                };
+            }
+        }
+    }
+}

--- a/CycloneDX/Services/IDotnetCommandService.cs
+++ b/CycloneDX/Services/IDotnetCommandService.cs
@@ -1,0 +1,27 @@
+// This file is part of the CycloneDX Tool for .NET
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright (c) Steve Springett. All Rights Reserved.
+
+using System;
+using DotnetCommandResult = CycloneDX.Models.DotnetCommandResult;
+
+namespace CycloneDX.Services
+{
+    public interface IDotnetCommandService
+    {
+        DotnetCommandResult Run(string arguments);
+        DotnetCommandResult Run(string workingDirectory, string arguments);
+    }
+}

--- a/CycloneDX/Services/IDotnetUtilsService.cs
+++ b/CycloneDX/Services/IDotnetUtilsService.cs
@@ -1,0 +1,28 @@
+// This file is part of the CycloneDX Tool for .NET
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright (c) Steve Springett. All Rights Reserved.
+
+using System;
+using System.Collections.Generic;
+using CycloneDX.Models;
+
+namespace CycloneDX.Services
+{
+    public interface IDotnetUtilsService
+    {
+        DotnetUtilsResult<List<string>> GetPackageCachePaths();
+        DotnetUtilsResult Restore(string path);
+    }
+}

--- a/CycloneDX/Services/IPackagesFileService.cs
+++ b/CycloneDX/Services/IPackagesFileService.cs
@@ -1,0 +1,29 @@
+// This file is part of the CycloneDX Tool for .NET
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright (c) Steve Springett. All Rights Reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using CycloneDX.Models;
+
+namespace CycloneDX.Services
+{
+    public interface IPackagesFileService 
+    {
+        Task<HashSet<NugetPackage>> GetNugetPackagesAsync(string packagesFilePath);
+        Task<HashSet<NugetPackage>> RecursivelyGetNugetPackagesAsync(string directoryPath);
+    }
+}

--- a/CycloneDX/Services/IProjectAssetsFileService.cs
+++ b/CycloneDX/Services/IProjectAssetsFileService.cs
@@ -1,0 +1,27 @@
+// This file is part of the CycloneDX Tool for .NET
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright (c) Steve Springett. All Rights Reserved.
+
+using System;
+using System.Collections.Generic;
+using CycloneDX.Models;
+
+namespace CycloneDX.Services
+{
+    public interface IProjectAssetsFileService 
+    {
+        HashSet<NugetPackage> GetNugetPackages(string projectAssetsFilePath);
+    }
+}

--- a/CycloneDX/Services/IProjectFileService.cs
+++ b/CycloneDX/Services/IProjectFileService.cs
@@ -1,0 +1,31 @@
+// This file is part of the CycloneDX Tool for .NET
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright (c) Steve Springett. All Rights Reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using CycloneDX.Models;
+
+namespace CycloneDX.Services
+{
+    public interface IProjectFileService
+    {
+        Task<HashSet<NugetPackage>> GetProjectNugetPackagesAsync(string projectFilePath);
+        Task<HashSet<NugetPackage>> RecursivelyGetProjectNugetPackagesAsync(string projectFilePath);
+        Task<HashSet<string>> GetProjectReferencesAsync(string projectFilePath);
+        Task<HashSet<string>> RecursivelyGetProjectReferencesAsync(string projectFilePath);
+    }
+}

--- a/CycloneDX/Services/ISolutionFileService.cs
+++ b/CycloneDX/Services/ISolutionFileService.cs
@@ -1,0 +1,28 @@
+// This file is part of the CycloneDX Tool for .NET
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright (c) Steve Springett. All Rights Reserved.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using CycloneDX.Models;
+
+namespace CycloneDX.Services
+{
+    public interface ISolutionFileService
+    {
+        Task<HashSet<string>> GetSolutionProjectReferencesAsync(string solutionFilePath);
+        Task<HashSet<NugetPackage>> GetSolutionNugetPackages(string solutionFilePath);
+    }
+}

--- a/CycloneDX/Services/PackagesFileService.cs
+++ b/CycloneDX/Services/PackagesFileService.cs
@@ -25,7 +25,7 @@ using CycloneDX.Services;
 
 namespace CycloneDX.Services
 {
-    public class PackagesFileService
+    public class PackagesFileService : IPackagesFileService
     {
         private XmlReaderSettings _xmlReaderSettings = new XmlReaderSettings 
         {

--- a/CycloneDX/Services/ProjectAssetsFileService.cs
+++ b/CycloneDX/Services/ProjectAssetsFileService.cs
@@ -1,0 +1,60 @@
+// This file is part of the CycloneDX Tool for .NET
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright (c) Steve Springett. All Rights Reserved.
+
+using System;
+using System.Collections.Generic;
+using System.IO.Abstractions;
+using AssetFileReader = NuGet.ProjectModel.LockFileFormat;
+using CycloneDX.Models;
+
+namespace CycloneDX.Services
+{
+    public class ProjectAssetsFileService : IProjectAssetsFileService 
+    {
+        private IFileSystem _fileSystem;
+
+        public ProjectAssetsFileService(IFileSystem fileSystem)
+        {
+            _fileSystem = fileSystem;
+        }
+
+        public HashSet<NugetPackage> GetNugetPackages(string projectAssetsFilePath)
+        {
+            var packages = new HashSet<NugetPackage>();
+
+            if (_fileSystem.File.Exists(projectAssetsFilePath))
+            {
+                var assetFileReader = new AssetFileReader();
+                var assetsFile = assetFileReader.Read(projectAssetsFilePath);
+
+                foreach (var targetRuntime in assetsFile.Targets)
+                {
+                    foreach (var library in targetRuntime.Libraries)
+                    {
+                        var package = new NugetPackage
+                        {
+                            Name = library.Name,
+                            Version = library.Version.ToNormalizedString()
+                        };
+                        packages.Add(package);
+                    }
+                }
+            }
+
+            return packages;
+        }
+    }
+}

--- a/CycloneDX/Services/SolutionFileService.cs
+++ b/CycloneDX/Services/SolutionFileService.cs
@@ -23,15 +23,15 @@ using CycloneDX.Models;
 
 namespace CycloneDX.Services
 {
-    public class SolutionFileService
+    public class SolutionFileService : ISolutionFileService
     {
         private IFileSystem _fileSystem;
-        private ProjectFileService _projectFileService;
+        private IProjectFileService _projectFileService;
 
-        public SolutionFileService(IFileSystem fileSystem)
+        public SolutionFileService(IFileSystem fileSystem, IProjectFileService projectFileService)
         {
             _fileSystem = fileSystem;
-            _projectFileService = new ProjectFileService(_fileSystem);
+            _projectFileService = projectFileService;
         }
 
         /// <summary>
@@ -59,7 +59,7 @@ namespace CycloneDX.Services
                     {
                         var relativeProjectPath = match.Groups[3].Value.Replace('\\', _fileSystem.Path.DirectorySeparatorChar);
                         var projectFile = _fileSystem.Path.GetFullPath(_fileSystem.Path.Combine(solutionFolder, relativeProjectPath));
-                        projects.Add(projectFile);
+                        if (Utils.IsSupportedProjectType(projectFile)) projects.Add(projectFile);
                     }
                 }
             }


### PR DESCRIPTION
This is going to be another large pull request, sorry @stevespringett :/

This will resolve issues #27 and #15. And is based on PRs #41 and #39 

A few positive points of note:

- individual package resolution should be a _lot_ quicker, we're now using the local nuget package and nuspec cache, although this resolves all dependencies now, so it can actually take longer overall
- correct BoM contents because this uses the same `project.assets.json` file produced by the `dotnet restore` command and consumed by the build process
- version ranges are now handled due to the above point
- custom/private project nuget sources now supported out of the box as above
- improved nuspec and license expression parsing by using nuget libraries

But, this could result in some issues being raised.

For example...
We have one project that with the old project file reference and nuget resolution method had 7 dependencies. Now that it factors in everything it is reporting 179.

Part of this is because the standard libraries, like the Microsoft.* and System.* packages, weren't being included but they are now.

This seems like a massive change because of the line counts. But most of that is just test data. I've also added a test step timeout of 10 minutes. I had inadvertently introduced an async deadlock that was only evident when running on Windows or in the GitHub Linux agent.