### PR TITLE
Run tests for Windows, Linux and MacOS

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -3,9 +3,12 @@ name: .NET Core CI
 on: [push, pull_request]
 
 jobs:
-  build:
-
-    runs-on: ubuntu-latest
+  test:
+    name: Test on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
     
     steps:
     - uses: actions/checkout@v1
@@ -15,5 +18,3 @@ jobs:
         dotnet-version: 2.2.108
     - name: Tests
       run: dotnet test
-    - name: Build with dotnet
-      run: dotnet build --configuration Release


### PR DESCRIPTION
While working on #42 I had some tests that were passing on Ubuntu but not Windows.

This change just does what's on the label.

I also removed the `dotnet build` step as `dotnet test` runs a build anyway and the output isn't being used.