### PR TITLE
Fix nuget 404 regression

### DIFF
--- a/CycloneDX/Services/NugetService.cs
+++ b/CycloneDX/Services/NugetService.cs
@@ -99,14 +99,14 @@ namespace CycloneDX.Services
 
             var nuspecFilename = GetCachedNuspecFilename(name, version);
 
-            NuspecReader nuspecReader;
+            NuspecReader nuspecReader = null;
 
             if (nuspecFilename == null)
             {
                 var url = _baseUrl + name + "/" + version + "/" + name + ".nuspec";
                 using (var xmlStream = await _httpClient.GetXmlStreamAsync(url))
                 {
-                    nuspecReader = new NuspecReader(xmlStream);
+                    if (xmlStream != null) nuspecReader = new NuspecReader(xmlStream);
                 }
             }
             else


### PR DESCRIPTION
Sorry @stevespringett, I introduced a regression that would cause bom generation to fail if there are any references to packages that don't exist in an available feed. Fixes #74 