### PR TITLE
Dependency bump

### DIFF
--- a/CycloneDX.IntegrationTests/CycloneDX.IntegrationTests.csproj
+++ b/CycloneDX.IntegrationTests/CycloneDX.IntegrationTests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
     <PackageReference Include="Snapshooter.Xunit" Version="0.5.2" />
-    <PackageReference Include="System.IO.Abstractions" Version="8.0.5" />
+    <PackageReference Include="System.IO.Abstractions" Version="9.0.4" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="8.0.5" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">

--- a/CycloneDX.IntegrationTests/CycloneDX.IntegrationTests.csproj
+++ b/CycloneDX.IntegrationTests/CycloneDX.IntegrationTests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
     <PackageReference Include="Snapshooter.Xunit" Version="0.5.2" />
     <PackageReference Include="System.IO.Abstractions" Version="9.0.4" />
-    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="8.0.5" />
+    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="9.0.4" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/CycloneDX.IntegrationTests/CycloneDX.IntegrationTests.csproj
+++ b/CycloneDX.IntegrationTests/CycloneDX.IntegrationTests.csproj
@@ -15,7 +15,6 @@
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
     <PackageReference Include="Snapshooter.Xunit" Version="0.5.2" />
-    <PackageReference Include="System.IO.Abstractions" Version="9.0.4" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="9.0.4" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">

--- a/CycloneDX.Tests/CycloneDX.Tests.csproj
+++ b/CycloneDX.Tests/CycloneDX.Tests.csproj
@@ -14,7 +14,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
-    <PackageReference Include="System.IO.Abstractions" Version="9.0.4" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="9.0.4" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">

--- a/CycloneDX.Tests/CycloneDX.Tests.csproj
+++ b/CycloneDX.Tests/CycloneDX.Tests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
-    <PackageReference Include="System.IO.Abstractions" Version="8.0.5" />
+    <PackageReference Include="System.IO.Abstractions" Version="9.0.4" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="8.0.5" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">

--- a/CycloneDX.Tests/CycloneDX.Tests.csproj
+++ b/CycloneDX.Tests/CycloneDX.Tests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
     <PackageReference Include="System.IO.Abstractions" Version="9.0.4" />
-    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="8.0.5" />
+    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="9.0.4" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/CycloneDX/CycloneDX.csproj
+++ b/CycloneDX/CycloneDX.csproj
@@ -37,7 +37,7 @@
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.5.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="nuget.projectmodel" Version="5.4.0" />
-    <PackageReference Include="System.IO.Abstractions" Version="8.0.5" />
+    <PackageReference Include="System.IO.Abstractions" Version="9.0.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Includes #80 and #81. Then removes unnecessary package reference that causes issue when only one package reference is bumped in Dependabot PRs.