### PR TITLE
Catch DotnetRestoreExceptions

### DIFF
--- a/CycloneDX/ExitCode.cs
+++ b/CycloneDX/ExitCode.cs
@@ -9,6 +9,7 @@ namespace CycloneDX
         GitHubParameterMissing,
         InvalidGitHubApiCredentials,
         GitHubApiRateLimitExceeded,
-        LocalPackageCacheError
+        LocalPackageCacheError,
+        DotnetRestoreFailed
     }
 }


### PR DESCRIPTION
Makes the tool fail more gracefully for invalid package references that
cause `dotnet restore` to fail.