### PR TITLE
Use Queue<T>.Dequeue instead of Queue<T>.TryDequeue

### DIFF
--- a/CycloneDX/Services/ComponentService.cs
+++ b/CycloneDX/Services/ComponentService.cs
@@ -40,12 +40,12 @@ namespace CycloneDX.Services
 
             // Initialize the queue with the current packages
             var packages = new Queue<NugetPackage>(nugetPackges);
-            NugetPackage currentPackage;
 
             var visitedNugetPackages = new HashSet<NugetPackage>();
 
-            while (packages.TryDequeue(out currentPackage))
+            while (packages.Count > 0)
             {
+                var currentPackage = packages.Dequeue();
                 var component = await _nugetService.GetComponentAsync(currentPackage);
 
                 if (component == null) continue;

--- a/CycloneDX/Services/ProjectFileService.cs
+++ b/CycloneDX/Services/ProjectFileService.cs
@@ -178,12 +178,12 @@ namespace CycloneDX.Services
             // Initialize the queue with the current project file
             var files = new Queue<string>();
             files.Enqueue(_fileSystem.FileInfo.FromFileName(projectFilePath).FullName);
-            string currentFile;
 
             var visitedProjectFiles = new HashSet<string>();
 
-            while (files.TryDequeue(out currentFile))
+            while (files.Count > 0)
             {
+                var currentFile = files.Dequeue();
                 // Find all project references inside of currentFile
                 var foundProjectReferences = await GetProjectReferencesAsync(currentFile);
 


### PR DESCRIPTION
TryDequeue is not available in .net standard 2. This is to support
moving the services into the core library. Which currently targets .net
core 2.1 and 3.1. .net core 2.1 only supports .net standard 2, not 2.1.