### PR TITLE
Run FxCop analyzers for PRs and builds

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -3,6 +3,30 @@ name: .NET Core CI
 on: [pull_request]
 
 jobs:
+  build-warnings:
+    name: Build warnings check
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v1
+  
+      - name: Setup .NET Core 2.1
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 2.1.803
+  
+      - name: Setup .NET Core 3.1
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 3.1.101
+
+      - name: Setup side by side .NET SDKs on *nix
+        run: |
+          rsync -a ${DOTNET_ROOT/3.1.101/2.1.803}/* $DOTNET_ROOT/
+
+      - name: Build
+        run: dotnet build /WarnAsError
+
   test:
     name: Tests for .net core ${{ matrix.framework }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/CycloneDX.Core.Tests/ComponentServiceTests.cs
+++ b/CycloneDX.Core.Tests/ComponentServiceTests.cs
@@ -45,7 +45,7 @@ namespace CycloneDX.Tests
                 new NugetPackage { Name = "Package3", Version = "1.0.0" },
             };
 
-            var components = await componentService.RecursivelyGetComponentsAsync(nugetPackages);
+            var components = await componentService.RecursivelyGetComponentsAsync(nugetPackages).ConfigureAwait(false);
             var sortedComponents = components.OrderBy(c => c.Name).ToList();
 
             Assert.Collection(sortedComponents,
@@ -81,7 +81,7 @@ namespace CycloneDX.Tests
                 new NugetPackage { Name = "Package1", Version = "1.0.0" }
             };
 
-            var components = await componentService.RecursivelyGetComponentsAsync(nugetPackages);
+            var components = await componentService.RecursivelyGetComponentsAsync(nugetPackages).ConfigureAwait(false);
             var sortedComponents = components.OrderBy(c => c.Name).ToList();
 
             Assert.Collection(sortedComponents,

--- a/CycloneDX.Core.Tests/GithubServiceTests.cs
+++ b/CycloneDX.Core.Tests/GithubServiceTests.cs
@@ -41,7 +41,7 @@ namespace CycloneDX.Tests
             var client = mockHttp.ToHttpClient();
             var githubService = new GithubService(client);
 
-            var license = await githubService.GetLicenseAsync("https://github.com/CycloneDX/cyclonedx-dotnet/blob/master/LICENSE");
+            var license = await githubService.GetLicenseAsync("https://github.com/CycloneDX/cyclonedx-dotnet/blob/master/LICENSE").ConfigureAwait(false);
             
             Assert.Equal("LicenseSpdxId", license.Id);
             Assert.Equal("Test License", license.Name);
@@ -62,7 +62,7 @@ namespace CycloneDX.Tests
             var client = mockHttp.ToHttpClient();
             var githubService = new GithubService(client);
 
-            var license = await githubService.GetLicenseAsync("https://github.com/CycloneDX/cyclonedx-dotnet/blob/v1.2.3/LICENSE");
+            var license = await githubService.GetLicenseAsync("https://github.com/CycloneDX/cyclonedx-dotnet/blob/v1.2.3/LICENSE").ConfigureAwait(false);
             
             Assert.Equal("LicenseSpdxId", license.Id);
             Assert.Equal("Test License", license.Name);
@@ -83,7 +83,7 @@ namespace CycloneDX.Tests
             var client = mockHttp.ToHttpClient();
             var githubService = new GithubService(client);
 
-            var license = await githubService.GetLicenseAsync("https://github.com/CycloneDX/cyclonedx-dotnet/blob/master/LICENSE.md");
+            var license = await githubService.GetLicenseAsync("https://github.com/CycloneDX/cyclonedx-dotnet/blob/master/LICENSE.md").ConfigureAwait(false);
             
             Assert.Equal("LicenseSpdxId", license.Id);
             Assert.Equal("Test License", license.Name);
@@ -104,7 +104,7 @@ namespace CycloneDX.Tests
             var client = mockHttp.ToHttpClient();
             var githubService = new GithubService(client);
 
-            var license = await githubService.GetLicenseAsync("https://github.com/CycloneDX/cyclonedx-dotnet/blob/master/LICENSE.txt");
+            var license = await githubService.GetLicenseAsync("https://github.com/CycloneDX/cyclonedx-dotnet/blob/master/LICENSE.txt").ConfigureAwait(false);
             
             Assert.Equal("LicenseSpdxId", license.Id);
             Assert.Equal("Test License", license.Name);
@@ -125,7 +125,7 @@ namespace CycloneDX.Tests
             var client = mockHttp.ToHttpClient();
             var githubService = new GithubService(client);
 
-            var license = await githubService.GetLicenseAsync("https://raw.githubusercontent.com/CycloneDX/cyclonedx-dotnet/master/LICENSE");
+            var license = await githubService.GetLicenseAsync("https://raw.githubusercontent.com/CycloneDX/cyclonedx-dotnet/master/LICENSE").ConfigureAwait(false);
             
             Assert.Equal("LicenseSpdxId", license.Id);
             Assert.Equal("Test License", license.Name);
@@ -148,7 +148,7 @@ namespace CycloneDX.Tests
             var client = mockHttp.ToHttpClient();
             var githubService = new GithubService(client, "Aladdin", "open sesame");
 
-            await githubService.GetLicenseAsync("https://raw.githubusercontent.com/CycloneDX/cyclonedx-dotnet/master/LICENSE");
+            await githubService.GetLicenseAsync("https://raw.githubusercontent.com/CycloneDX/cyclonedx-dotnet/master/LICENSE").ConfigureAwait(false);
 
             mockHttp.VerifyNoOutstandingExpectation();
         }

--- a/CycloneDX.Core.Tests/NugetServiceTests.cs
+++ b/CycloneDX.Core.Tests/NugetServiceTests.cs
@@ -75,7 +75,7 @@ namespace CycloneDX.Tests
                 new Mock<IGithubService>().Object,
                 new HttpClient());
 
-            var component = await nugetService.GetComponentAsync("testpackage", "1.0.0");
+            var component = await nugetService.GetComponentAsync("testpackage", "1.0.0").ConfigureAwait(false);
             
             Assert.Equal("testpackage", component.Name);
         }
@@ -99,7 +99,7 @@ namespace CycloneDX.Tests
                 new Mock<IGithubService>().Object,
                 client);
 
-            var component = await nugetService.GetComponentAsync("testpackage", "1.0.0");
+            var component = await nugetService.GetComponentAsync("testpackage", "1.0.0").ConfigureAwait(false);
             
             Assert.Equal("testpackage", component.Name);
         }
@@ -117,7 +117,7 @@ namespace CycloneDX.Tests
                 new Mock<IGithubService>().Object,
                 client);
 
-            var component = await nugetService.GetComponentAsync("testpackage", "1.0.0");
+            var component = await nugetService.GetComponentAsync("testpackage", "1.0.0").ConfigureAwait(false);
             
             Assert.Equal("testpackage", component.Name);
         }
@@ -150,7 +150,7 @@ namespace CycloneDX.Tests
                 mockGithubService.Object,
                 client);
 
-            var component = await nugetService.GetComponentAsync("PackageName", "1.2.3");
+            var component = await nugetService.GetComponentAsync("PackageName", "1.2.3").ConfigureAwait(false);
 
             Assert.Collection(component.Licenses, 
                 item => {

--- a/CycloneDX.Core.Tests/PackagesFileServiceTests.cs
+++ b/CycloneDX.Core.Tests/PackagesFileServiceTests.cs
@@ -36,7 +36,7 @@ namespace CycloneDX.Tests
                 });
             var packagesFileService = new PackagesFileService(mockFileSystem);
 
-            var packages = await packagesFileService.GetNugetPackagesAsync(XFS.Path(@"c:\Project\packages.config"));
+            var packages = await packagesFileService.GetNugetPackagesAsync(XFS.Path(@"c:\Project\packages.config")).ConfigureAwait(false);
             
             Assert.Collection(packages,
                 item => {
@@ -60,7 +60,7 @@ namespace CycloneDX.Tests
                 });
             var packagesFileService = new PackagesFileService(mockFileSystem);
 
-            var packages = await packagesFileService.GetNugetPackagesAsync(XFS.Path(@"c:\Project\packages.config"));
+            var packages = await packagesFileService.GetNugetPackagesAsync(XFS.Path(@"c:\Project\packages.config")).ConfigureAwait(false);
             var sortedPackages = new List<NugetPackage>(packages);
             sortedPackages.Sort();
 

--- a/CycloneDX.Core.Tests/ProjectFileServiceTests.cs
+++ b/CycloneDX.Core.Tests/ProjectFileServiceTests.cs
@@ -54,7 +54,7 @@ namespace CycloneDX.Tests
                 mockPackageFileService.Object,
                 mockProjectAssetsFileService.Object);
 
-            var packages = await projectFileService.GetProjectNugetPackagesAsync(XFS.Path(@"c:\Project\Project.csproj"));
+            var packages = await projectFileService.GetProjectNugetPackagesAsync(XFS.Path(@"c:\Project\Project.csproj")).ConfigureAwait(false);
             
             Assert.Collection(packages,
                 item => {
@@ -91,7 +91,7 @@ namespace CycloneDX.Tests
                 mockPackageFileService.Object,
                 mockProjectAssetsFileService.Object);
 
-            var packages = await projectFileService.GetProjectNugetPackagesAsync(XFS.Path(@"c:\Project\Project.csproj"));
+            var packages = await projectFileService.GetProjectNugetPackagesAsync(XFS.Path(@"c:\Project\Project.csproj")).ConfigureAwait(false);
             var sortedPackages = new List<NugetPackage>(packages);
             sortedPackages.Sort();
             
@@ -132,7 +132,7 @@ namespace CycloneDX.Tests
                 mockPackageFileService.Object,
                 mockProjectAssetsFileService.Object);
 
-            var packages = await projectFileService.GetProjectNugetPackagesAsync(XFS.Path(@"c:\Project\Project.csproj"));
+            var packages = await projectFileService.GetProjectNugetPackagesAsync(XFS.Path(@"c:\Project\Project.csproj")).ConfigureAwait(false);
             
             Assert.Collection(packages,
                 item => {
@@ -174,7 +174,7 @@ namespace CycloneDX.Tests
                 mockPackageFileService.Object,
                 mockProjectAssetsFileService.Object);
 
-            var packages = await projectFileService.GetProjectNugetPackagesAsync(XFS.Path(@"c:\Project\Project.csproj"));
+            var packages = await projectFileService.GetProjectNugetPackagesAsync(XFS.Path(@"c:\Project\Project.csproj")).ConfigureAwait(false);
             var sortedPackages = new List<NugetPackage>(packages);
             sortedPackages.Sort();
             
@@ -206,7 +206,7 @@ namespace CycloneDX.Tests
                 mockPackageFileService.Object,
                 mockProjectAssetsFileService.Object);
 
-            var projects = await projectFileService.GetProjectReferencesAsync(XFS.Path(@"c:\SolutionPath\Project\Project.csproj"));
+            var projects = await projectFileService.GetProjectReferencesAsync(XFS.Path(@"c:\SolutionPath\Project\Project.csproj")).ConfigureAwait(false);
             var sortedProjects = new List<string>(projects);
             sortedProjects.Sort();
             
@@ -242,7 +242,7 @@ namespace CycloneDX.Tests
                 mockPackageFileService.Object,
                 mockProjectAssetsFileService.Object);
 
-            var projects = await projectFileService.RecursivelyGetProjectReferencesAsync(XFS.Path(@"c:\SolutionPath\Project1\Project1.csproj"));
+            var projects = await projectFileService.RecursivelyGetProjectReferencesAsync(XFS.Path(@"c:\SolutionPath\Project1\Project1.csproj")).ConfigureAwait(false);
             var sortedProjects = new List<string>(projects);
             sortedProjects.Sort();
             

--- a/CycloneDX.Core.Tests/SolutionFileServiceTests.cs
+++ b/CycloneDX.Core.Tests/SolutionFileServiceTests.cs
@@ -43,7 +43,7 @@ Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""CycloneDX"", ""Project\P
                 .ReturnsAsync(new HashSet<string>());
             var solutionFileService = new SolutionFileService(mockFileSystem, mockProjectFileService.Object);
 
-            var projects = await solutionFileService.GetSolutionProjectReferencesAsync(XFS.Path(@"c:\SolutionPath\SolutionFile.sln"));
+            var projects = await solutionFileService.GetSolutionProjectReferencesAsync(XFS.Path(@"c:\SolutionPath\SolutionFile.sln")).ConfigureAwait(false);
             
             Assert.Collection(projects, 
                 item => Assert.Equal(XFS.Path(@"c:\SolutionPath\Project\Project.csproj"), item));
@@ -71,7 +71,7 @@ Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""CycloneDX"", ""Project3\
                 .ReturnsAsync(new HashSet<string>());
             var solutionFileService = new SolutionFileService(mockFileSystem, mockProjectFileService.Object);
 
-            var projects = await solutionFileService.GetSolutionProjectReferencesAsync(XFS.Path(@"c:\SolutionPath\SolutionFile.sln"));
+            var projects = await solutionFileService.GetSolutionProjectReferencesAsync(XFS.Path(@"c:\SolutionPath\SolutionFile.sln")).ConfigureAwait(false);
             var sortedProjects = new List<string>(projects);
             sortedProjects.Sort();
             
@@ -102,7 +102,7 @@ Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""CycloneDX"", ""Project1\
                 .ReturnsAsync(new HashSet<string>());
             var solutionFileService = new SolutionFileService(mockFileSystem, mockProjectFileService.Object);
 
-            var projects = await solutionFileService.GetSolutionProjectReferencesAsync(XFS.Path(@"c:\SolutionPath\SolutionFile.sln"));
+            var projects = await solutionFileService.GetSolutionProjectReferencesAsync(XFS.Path(@"c:\SolutionPath\SolutionFile.sln")).ConfigureAwait(false);
             var sortedProjects = new List<string>(projects);
             sortedProjects.Sort();
             

--- a/CycloneDX.Core/AssemblyInfo.cs
+++ b/CycloneDX.Core/AssemblyInfo.cs
@@ -1,2 +1,4 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("CycloneDX.Core.Tests")]
+// TODO: in the context of a CLI tool this wasn't as much of a problem, we wanted the http client to hang around and be re-used, but needs to be revisited for the core library
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:DisposeObjectsBeforeLosingScope")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Globalization", "CA1303:DoNotPassLiteralsAsLocalizedParameters")]

--- a/CycloneDX.Core/AssemblyInfo.cs
+++ b/CycloneDX.Core/AssemblyInfo.cs
@@ -1,4 +1,13 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("CycloneDX.Core.Tests")]
+
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1054:UriParametersShouldNotBeStrings")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1055:UriReturnValuesShouldNotBeStrings")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1056:UriPropertiesShouldNotBeStrings")]
+
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Name", "CA1720:IdentifiersShouldNotContainTypeNames")]
+
 // TODO: in the context of a CLI tool this wasn't as much of a problem, we wanted the http client to hang around and be re-used, but needs to be revisited for the core library
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:DisposeObjectsBeforeLosingScope")]
+
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Globalization", "CA1303:DoNotPassLiteralsAsLocalizedParameters")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Globalization", "CA1308:NormalizeStringsToUppercase")]

--- a/CycloneDX.Core/AssemblyInfo.cs
+++ b/CycloneDX.Core/AssemblyInfo.cs
@@ -1,1 +1,2 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("CycloneDX.Core.Tests")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Globalization", "CA1303:DoNotPassLiteralsAsLocalizedParameters")]

--- a/CycloneDX.Core/CycloneDX.Core.csproj
+++ b/CycloneDX.Core/CycloneDX.Core.csproj
@@ -6,6 +6,10 @@
 
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.5.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="nuget.projectmodel" Version="5.4.0" />
     <PackageReference Include="System.IO.Abstractions" Version="9.0.4" />

--- a/CycloneDX.Core/Extensions/HttpClientExtensions.cs
+++ b/CycloneDX.Core/Extensions/HttpClientExtensions.cs
@@ -14,6 +14,8 @@
 //
 // Copyright (c) Steve Springett. All Rights Reserved.
 
+using System;
+using System.Diagnostics.Contracts;
 using System.IO;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -28,6 +30,7 @@ namespace CycloneDX.Extensions
          */
         public static async Task<Stream> GetXmlStreamAsync(this HttpClient httpClient, string url)
         {
+            Contract.Requires(httpClient != null);
             httpClient.DefaultRequestHeaders.Accept.Clear();
             httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/xml"));
             HttpResponseMessage response;

--- a/CycloneDX.Core/Extensions/HttpClientExtensions.cs
+++ b/CycloneDX.Core/Extensions/HttpClientExtensions.cs
@@ -31,12 +31,12 @@ namespace CycloneDX.Extensions
             httpClient.DefaultRequestHeaders.Accept.Clear();
             httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/xml"));
             HttpResponseMessage response;
-            response = await httpClient.GetAsync(url);
+            response = await httpClient.GetAsync(url).ConfigureAwait(false);
             
             if (response.StatusCode == System.Net.HttpStatusCode.NotFound) return null;
             
             response.EnsureSuccessStatusCode();
-            var contentStream = await response.Content.ReadAsStreamAsync();
+            var contentStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
             return contentStream;
         }
     }

--- a/CycloneDX.Core/Models/Component.cs
+++ b/CycloneDX.Core/Models/Component.cs
@@ -21,6 +21,8 @@ using System.Diagnostics.CodeAnalysis;
 namespace CycloneDX.Models
 {
     [SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly")]
+    // This suppression should maybe be revisited when/if a CycloneDX library is published
+    [SuppressMessage("Microsoft.Design", "CA1036:OverrideMethodsOnComparableTypes")]
     public class Component : IComparable<Component>
     {
         public string Publisher { get; set; }

--- a/CycloneDX.Core/Models/Component.cs
+++ b/CycloneDX.Core/Models/Component.cs
@@ -16,9 +16,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace CycloneDX.Models
 {
+    [SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly")]
     public class Component : IComparable<Component>
     {
         public string Publisher { get; set; }

--- a/CycloneDX.Core/Models/Component.cs
+++ b/CycloneDX.Core/Models/Component.cs
@@ -73,9 +73,9 @@ namespace CycloneDX.Models
             }
             else
             {
-                var nameComparison = this.Name.ToLowerInvariant().CompareTo(other.Name.ToLowerInvariant());
+                var nameComparison = string.Compare(this.Name.ToUpperInvariant(), other.Name.ToUpperInvariant(), StringComparison.Ordinal);
                 return nameComparison == 0
-                    ? this.Version.CompareTo(other.Version)
+                    ? string.Compare(this.Version, other.Version, StringComparison.Ordinal)
                     : nameComparison;
             }
         }

--- a/CycloneDX.Core/Models/ExternalReference.cs
+++ b/CycloneDX.Core/Models/ExternalReference.cs
@@ -18,6 +18,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace CycloneDX.Models
 {
+    [SuppressMessage("Microsoft.Naming", "CA1707:IdentifiersShouldNotContainUnderscores")]
     public class ExternalReference
     {
         public string Url { get; set; }

--- a/CycloneDX.Core/Models/Hash.cs
+++ b/CycloneDX.Core/Models/Hash.cs
@@ -14,8 +14,12 @@
 //
 // Copyright (c) Steve Springett. All Rights Reserved.
 
+using System;
+using System.Diagnostics.CodeAnalysis;
+
 namespace CycloneDX.Models
 {
+    [SuppressMessage("Microsoft.Naming", "CA1707:IdentifiersShouldNotContainUnderscores")]
     public enum Algorithm
     {
         MD5,

--- a/CycloneDX.Core/Models/NugetPackage.cs
+++ b/CycloneDX.Core/Models/NugetPackage.cs
@@ -57,9 +57,9 @@ namespace CycloneDX.Models
             }
             else
             {
-                var nameComparison = this.Name.CompareTo(other.Name);
+                var nameComparison = string.Compare(this.Name, other.Name, StringComparison.Ordinal);
                 return nameComparison == 0
-                    ? this.Version.CompareTo(other.Version)
+                    ? string.Compare(this.Version, other.Version, StringComparison.Ordinal)
                     : nameComparison;
             }
         }

--- a/CycloneDX.Core/Models/NugetPackage.cs
+++ b/CycloneDX.Core/Models/NugetPackage.cs
@@ -15,9 +15,12 @@
 // Copyright (c) Steve Springett. All Rights Reserved.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace CycloneDX.Models
 {
+    // This suppression should maybe be revisited when/if a CycloneDX library is published
+    [SuppressMessage("Microsoft.Design", "CA1036:OverrideMethodsOnComparableTypes")]
     public class NugetPackage : IComparable
     {
         public string Name { get; set; }

--- a/CycloneDX.Core/Services/ComponentService.cs
+++ b/CycloneDX.Core/Services/ComponentService.cs
@@ -46,7 +46,7 @@ namespace CycloneDX.Services
             while (packages.Count > 0)
             {
                 var currentPackage = packages.Dequeue();
-                var component = await _nugetService.GetComponentAsync(currentPackage);
+                var component = await _nugetService.GetComponentAsync(currentPackage).ConfigureAwait(false);
 
                 if (component == null) continue;
 

--- a/CycloneDX.Core/Services/DotnetCommandService.cs
+++ b/CycloneDX.Core/Services/DotnetCommandService.cs
@@ -82,7 +82,7 @@ namespace CycloneDX.Services
             await Task.Yield();
 
             string line;
-            while ((line = await reader.ReadLineAsync()) != null)
+            while ((line = await reader.ReadLineAsync().ConfigureAwait(false)) != null)
             {
                 lines.AppendLine(line);
             }

--- a/CycloneDX.Core/Services/DotnetUtilsService.cs
+++ b/CycloneDX.Core/Services/DotnetUtilsService.cs
@@ -91,7 +91,7 @@ namespace CycloneDX.Services
         private string CombineErrorMessages(string currentErrorMessage, string additionalErrorMessage)
         {
             if (additionalErrorMessage == null) return currentErrorMessage;
-            if (currentErrorMessage == "")
+            if (currentErrorMessage.Length == 0)
             {
                 return additionalErrorMessage;
             }

--- a/CycloneDX.Core/Services/DotnetUtilsService.cs
+++ b/CycloneDX.Core/Services/DotnetUtilsService.cs
@@ -25,7 +25,6 @@ namespace CycloneDX.Services
     {
         private Regex _sdkPathRegex = new Regex(@"(\S)+ \[(?<path>.*)\]");
         private Regex _globalPackageCacheLocationPath = new Regex(@"global-packages: (?<path>.*)$");
-        private Regex _projectRegex = new Regex(@"Restore completed in \S+ \S+ for (?<path>.+)\.");
 
         private IFileSystem _fileSystem;
         private IDotnetCommandService _dotnetCommandService;

--- a/CycloneDX.Core/Services/GithubService.cs
+++ b/CycloneDX.Core/Services/GithubService.cs
@@ -28,8 +28,23 @@ using License = CycloneDX.Models.License;
 
 namespace CycloneDX.Services
 {
-    public class InvalidGitHubApiCredentialsException : Exception {}
-    public class GitHubApiRateLimitExceededException : Exception {}
+    public class InvalidGitHubApiCredentialsException : Exception
+    {
+        public InvalidGitHubApiCredentialsException() : base() {}
+
+        public InvalidGitHubApiCredentialsException(string message) : base(message) {}
+
+        public InvalidGitHubApiCredentialsException(string message, Exception innerException) : base(message, innerException) {}
+    }
+
+    public class GitHubApiRateLimitExceededException : Exception
+    {
+        public GitHubApiRateLimitExceededException() : base() {}
+
+        public GitHubApiRateLimitExceededException(string message) : base(message) {}
+
+        public GitHubApiRateLimitExceededException(string message, Exception innerException) : base(message, innerException) {}
+    }
 
     public interface IGithubService
     {
@@ -139,12 +154,12 @@ namespace CycloneDX.Services
             else if (githubResponse.StatusCode == System.Net.HttpStatusCode.Unauthorized)
             {
                 Console.Error.WriteLine("Invalid GitHub API credentials.");
-                throw new InvalidGitHubApiCredentialsException();
+                throw new InvalidGitHubApiCredentialsException("Invalid GitHub API credentials http status code 401");
             }
             else if (githubResponse.StatusCode == System.Net.HttpStatusCode.Forbidden)
             {
                 Console.Error.WriteLine("GitHub API rate limit exceeded.");
-                throw new GitHubApiRateLimitExceededException();
+                throw new GitHubApiRateLimitExceededException("GitHub API rate limit exceeded http status code 403");
             }
             else
             {

--- a/CycloneDX.Core/Services/GithubService.cs
+++ b/CycloneDX.Core/Services/GithubService.cs
@@ -18,6 +18,7 @@ using CycloneDX.Models;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.Contracts;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text.RegularExpressions;
@@ -52,6 +53,7 @@ namespace CycloneDX.Services
 
         public GithubService(HttpClient httpClient, string username, string token)
         {
+            Contract.Requires(httpClient != null);
             _httpClient = httpClient;
 
             // implemented as per RFC 7617 https://tools.ietf.org/html/rfc7617.html

--- a/CycloneDX.Core/Services/GithubService.cs
+++ b/CycloneDX.Core/Services/GithubService.cs
@@ -96,7 +96,7 @@ namespace CycloneDX.Services
             Console.WriteLine($"Retrieving GitHub license for repository {repositoryId} and ref {refSpec}");
 
             // Try getting license for the specified version
-            var githubLicense = await GetGithubLicenseAsync($"{_baseUrl}repos/{repositoryId}/license?ref={refSpec}");
+            var githubLicense = await GetGithubLicenseAsync($"{_baseUrl}repos/{repositoryId}/license?ref={refSpec}").ConfigureAwait(false);
 
             if (githubLicense == null) {
                 Console.WriteLine($"No license found on GitHub for repository {repositoryId} using ref {refSpec}");
@@ -127,11 +127,11 @@ namespace CycloneDX.Services
             githubLicenseRequestMessage.Headers.Accept.ParseAdd("application/json");
 
             // Send HTTP request and handle its response
-            var githubResponse = await _httpClient.SendAsync(githubLicenseRequestMessage);
+            var githubResponse = await _httpClient.SendAsync(githubLicenseRequestMessage).ConfigureAwait(false);
             if (githubResponse.IsSuccessStatusCode)
             {
                 // License found, extract data
-                return JsonConvert.DeserializeObject<GithubLicenseRoot>(await githubResponse.Content.ReadAsStringAsync());
+                return JsonConvert.DeserializeObject<GithubLicenseRoot>(await githubResponse.Content.ReadAsStringAsync().ConfigureAwait(false));
             }
             else if (githubResponse.StatusCode == System.Net.HttpStatusCode.Unauthorized)
             {

--- a/CycloneDX.Core/Services/GithubService.cs
+++ b/CycloneDX.Core/Services/GithubService.cs
@@ -19,6 +19,7 @@ using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
+using System.Globalization;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text.RegularExpressions;
@@ -57,7 +58,7 @@ namespace CycloneDX.Services
             _httpClient = httpClient;
 
             // implemented as per RFC 7617 https://tools.ietf.org/html/rfc7617.html
-            var userToken = string.Format("{0}:{1}", username, token);
+            var userToken = string.Format(CultureInfo.InvariantCulture, "{0}:{1}", username, token);
             var userTokenBytes = System.Text.Encoding.UTF8.GetBytes(userToken);
             var userTokenBase64 = System.Convert.ToBase64String(userTokenBytes);
 

--- a/CycloneDX.Core/Services/NugetService.cs
+++ b/CycloneDX.Core/Services/NugetService.cs
@@ -104,7 +104,7 @@ namespace CycloneDX.Services
             if (nuspecFilename == null)
             {
                 var url = _baseUrl + name + "/" + version + "/" + name + ".nuspec";
-                using (var xmlStream = await _httpClient.GetXmlStreamAsync(url))
+                using (var xmlStream = await _httpClient.GetXmlStreamAsync(url).ConfigureAwait(false))
                 {
                     if (xmlStream != null) nuspecReader = new NuspecReader(xmlStream);
                 }
@@ -155,7 +155,7 @@ namespace CycloneDX.Services
                 var licenseUrl = nuspecReader.GetLicenseUrl();
                 if (!string.IsNullOrEmpty(licenseUrl))
                 {
-                    var license = await _githubService.GetLicenseAsync(licenseUrl);
+                    var license = await _githubService.GetLicenseAsync(licenseUrl).ConfigureAwait(false);
                     
                     component.Licenses.Add(license ?? new Models.License
                     {
@@ -183,7 +183,7 @@ namespace CycloneDX.Services
         /// <returns></returns>
         public async Task<Component> GetComponentAsync(NugetPackage package)
         {
-            return await GetComponentAsync(package.Name, package.Version);
+            return await GetComponentAsync(package.Name, package.Version).ConfigureAwait(false);
         }
     }
 }

--- a/CycloneDX.Core/Services/NugetService.cs
+++ b/CycloneDX.Core/Services/NugetService.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.Contracts;
 using System.IO.Abstractions;
 using System.Linq;
 using System.Net.Http;
@@ -183,6 +184,7 @@ namespace CycloneDX.Services
         /// <returns></returns>
         public async Task<Component> GetComponentAsync(NugetPackage package)
         {
+            Contract.Requires(package != null);
             return await GetComponentAsync(package.Name, package.Version).ConfigureAwait(false);
         }
     }

--- a/CycloneDX.Core/Services/PackagesFileService.cs
+++ b/CycloneDX.Core/Services/PackagesFileService.cs
@@ -53,7 +53,7 @@ namespace CycloneDX.Services
             {
                 using (XmlReader reader = XmlReader.Create(fileReader, _xmlReaderSettings))
                 {
-                    while (await reader.ReadAsync())
+                    while (await reader.ReadAsync().ConfigureAwait(false))
                     {
                         if (reader.IsStartElement() && reader.Name == "package")
                         {
@@ -81,7 +81,7 @@ namespace CycloneDX.Services
 
             foreach (var packageFile in packageFiles)
             {
-                var newPackages = await GetNugetPackagesAsync(packageFile);
+                var newPackages = await GetNugetPackagesAsync(packageFile).ConfigureAwait(false);
                 packages.UnionWith(newPackages);
             }
 

--- a/CycloneDX.Core/Services/ProjectFileService.cs
+++ b/CycloneDX.Core/Services/ProjectFileService.cs
@@ -97,7 +97,7 @@ namespace CycloneDX.Services
                 if (_fileSystem.File.Exists(packagesPath))
                 {
                     Console.WriteLine("  Found packages.config. Will attempt to process");
-                    packages = await _packagesFileService.GetNugetPackagesAsync(packagesPath);
+                    packages = await _packagesFileService.GetNugetPackagesAsync(packagesPath).ConfigureAwait(false);
                 }
             }
             return packages;
@@ -110,11 +110,11 @@ namespace CycloneDX.Services
         /// <returns></returns>
         public async Task<HashSet<NugetPackage>> RecursivelyGetProjectNugetPackagesAsync(string projectFilePath)
         {
-            var nugetPackages = await GetProjectNugetPackagesAsync(projectFilePath);
-            var projectReferences = await RecursivelyGetProjectReferencesAsync(projectFilePath);
+            var nugetPackages = await GetProjectNugetPackagesAsync(projectFilePath).ConfigureAwait(false);
+            var projectReferences = await RecursivelyGetProjectReferencesAsync(projectFilePath).ConfigureAwait(false);
             foreach (var project in projectReferences)
             {
-                var projectNugetPackages = await GetProjectNugetPackagesAsync(project);
+                var projectNugetPackages = await GetProjectNugetPackagesAsync(project).ConfigureAwait(false);
                 nugetPackages.UnionWith(projectNugetPackages);
             }
             return nugetPackages;
@@ -144,7 +144,7 @@ namespace CycloneDX.Services
             {
                 using (XmlReader reader = XmlReader.Create(fileReader, _xmlReaderSettings))
                 {
-                    while (await reader.ReadAsync())
+                    while (await reader.ReadAsync().ConfigureAwait(false))
                     {
                         if (reader.IsStartElement() && reader.Name == "ProjectReference")
                         {
@@ -185,7 +185,7 @@ namespace CycloneDX.Services
             {
                 var currentFile = files.Dequeue();
                 // Find all project references inside of currentFile
-                var foundProjectReferences = await GetProjectReferencesAsync(currentFile);
+                var foundProjectReferences = await GetProjectReferencesAsync(currentFile).ConfigureAwait(false);
 
                 // Add unvisited project files to the queue
                 // Loop through found project references

--- a/CycloneDX.Core/Services/ProjectFileService.cs
+++ b/CycloneDX.Core/Services/ProjectFileService.cs
@@ -26,7 +26,14 @@ using CycloneDX.Models;
 
 namespace CycloneDX.Services
 {
-    public class DotnetRestoreException : Exception {}
+    public class DotnetRestoreException : Exception
+    {
+        public DotnetRestoreException() : base() {}
+        
+        public DotnetRestoreException(string message) : base(message) {}
+        
+        public DotnetRestoreException(string message, Exception innerException) : base(message, innerException) {}
+    }
 
     public class ProjectFileService : IProjectFileService
     {
@@ -85,7 +92,7 @@ namespace CycloneDX.Services
             {
                 Console.WriteLine("Dotnet restore failed:");
                 Console.WriteLine(restoreResult.ErrorMessage);
-                throw new DotnetRestoreException();
+                throw new DotnetRestoreException($"Dotnet restore failed with message: {restoreResult.ErrorMessage}");
             }
 
             // if there are no project file package references look for a packages.config

--- a/CycloneDX.Core/Services/SolutionFileService.cs
+++ b/CycloneDX.Core/Services/SolutionFileService.cs
@@ -47,7 +47,7 @@ namespace CycloneDX.Services
             {
                 string line;
 
-                while ((line = await reader.ReadLineAsync()) != null)
+                while ((line = await reader.ReadLineAsync().ConfigureAwait(false)) != null)
                 {
                     if (!line.StartsWith("Project", StringComparison.OrdinalIgnoreCase))
                     {
@@ -67,7 +67,7 @@ namespace CycloneDX.Services
             var projectList = new List<string>(projects);
             foreach (var project in projectList)
             {
-                var projectReferences = await _projectFileService.RecursivelyGetProjectReferencesAsync(project);
+                var projectReferences = await _projectFileService.RecursivelyGetProjectReferencesAsync(project).ConfigureAwait(false);
                 projects.UnionWith(projectReferences);
             }
 
@@ -93,7 +93,7 @@ namespace CycloneDX.Services
 
             var packages = new HashSet<NugetPackage>();
 
-            var projectPaths = await GetSolutionProjectReferencesAsync(solutionFilePath);
+            var projectPaths = await GetSolutionProjectReferencesAsync(solutionFilePath).ConfigureAwait(false);
 
             if (projectPaths.Count == 0)
             {
@@ -107,7 +107,7 @@ namespace CycloneDX.Services
             foreach (var projectFilePath in projectPaths)
             {
                 Console.WriteLine();
-                var projectPackages = await _projectFileService.GetProjectNugetPackagesAsync(projectFilePath);
+                var projectPackages = await _projectFileService.GetProjectNugetPackagesAsync(projectFilePath).ConfigureAwait(false);
                 packages.UnionWith(projectPackages);
             }
 

--- a/CycloneDX.Core/Utils.cs
+++ b/CycloneDX.Core/Utils.cs
@@ -15,6 +15,7 @@
 // Copyright (c) Steve Springett. All Rights Reserved.
 
 using System;
+using System.Diagnostics.Contracts;
 
 namespace CycloneDX
 {
@@ -31,6 +32,7 @@ namespace CycloneDX
         }
 
         public static bool IsSupportedProjectType(string filename) {
+            Contract.Requires(filename != null);
             return filename.ToLowerInvariant().EndsWith(".csproj", StringComparison.OrdinalIgnoreCase) ||
                 filename.ToLowerInvariant().EndsWith(".vbproj", StringComparison.OrdinalIgnoreCase);
         }

--- a/CycloneDX.IntegrationTests/IntegrationTests.cs
+++ b/CycloneDX.IntegrationTests/IntegrationTests.cs
@@ -49,7 +49,7 @@ namespace CycloneDX.IntegrationTests
                     Path.Join("Resources", directoryName),
                     "--noSerialNumber",
                     "--out", tempDir.DirectoryPath
-                });
+                }).ConfigureAwait(false);
                 // defensive assert, if this fails there is no point attempting to inspect the bom contents
                 Assert.Equal(0, exitCode);
 
@@ -72,7 +72,7 @@ namespace CycloneDX.IntegrationTests
                     Path.Join("Resources", solutionName, $"{solutionName}.sln"),
                     "--noSerialNumber",
                     "--out", tempDir.DirectoryPath
-                });
+                }).ConfigureAwait(false);
                 // defensive assert, if this fails there is no point attempting to inspect the bom contents
                 Assert.Equal(0, exitCode);
 
@@ -100,7 +100,7 @@ namespace CycloneDX.IntegrationTests
                     projectFilePath,
                     "--noSerialNumber",
                     "--out", tempDir.DirectoryPath
-                });
+                }).ConfigureAwait(false);
                 // defensive assert, if this fails there is no point attempting to inspect the bom contents
                 Assert.Equal(0, exitCode);
 

--- a/CycloneDX.Tests/ProgramTests.cs
+++ b/CycloneDX.Tests/ProgramTests.cs
@@ -31,7 +31,7 @@ namespace CycloneDX.Tests
         [Fact]
         public async Task CallingCycloneDX_WithoutSolutionFile_ReturnsSolutionOrProjectFileParameterMissingExitCode()
         {
-            var exitCode = await Program.Main(new string[] {});
+            var exitCode = await Program.Main(new string[] {}).ConfigureAwait(false);
 
             Assert.Equal((int)ExitCode.SolutionOrProjectFileParameterMissing, exitCode);
         }
@@ -39,7 +39,7 @@ namespace CycloneDX.Tests
         [Fact]
         public async Task CallingCycloneDX_WithoutOutputDirectory_ReturnsOutputDirectoryParameterMissingExitCode()
         {
-            var exitCode = await Program.Main(new string[] { XFS.Path(@"c:\SolutionPath\Solution.sln") });
+            var exitCode = await Program.Main(new string[] { XFS.Path(@"c:\SolutionPath\Solution.sln") }).ConfigureAwait(false);
 
             Assert.Equal((int)ExitCode.OutputDirectoryParameterMissing, exitCode);
         }
@@ -63,7 +63,7 @@ namespace CycloneDX.Tests
                 "-o", XFS.Path(@"c:\NewDirectory")
             };
 
-            var exitCode = await Program.Main(args);
+            var exitCode = await Program.Main(args).ConfigureAwait(false);
 
             Assert.Equal((int)ExitCode.OK, exitCode);
             Assert.True(mockFileSystem.FileExists(XFS.Path(@"c:\NewDirectory\bom.xml")));

--- a/CycloneDX/AssemblyInfo.cs
+++ b/CycloneDX/AssemblyInfo.cs
@@ -1,2 +1,3 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("CycloneDX.Tests")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("CycloneDX.IntegrationTests")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Globalization", "CA1303:DoNotPassLiteralsAsLocalizedParameters")]

--- a/CycloneDX/AssemblyInfo.cs
+++ b/CycloneDX/AssemblyInfo.cs
@@ -1,3 +1,5 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("CycloneDX.Tests")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("CycloneDX.IntegrationTests")]
+// TODO: in the context of a CLI tool this wasn't as much of a problem, we wanted the http client to hang around and be re-used, but needs to be revisited for the core library
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:DisposeObjectsBeforeLosingScope")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Globalization", "CA1303:DoNotPassLiteralsAsLocalizedParameters")]

--- a/CycloneDX/AssemblyInfo.cs
+++ b/CycloneDX/AssemblyInfo.cs
@@ -1,5 +1,14 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("CycloneDX.Tests")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("CycloneDX.IntegrationTests")]
+
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1054:UriParametersShouldNotBeStrings")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1055:UriReturnValuesShouldNotBeStrings")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1056:UriPropertiesShouldNotBeStrings")]
+
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Name", "CA1720:IdentifiersShouldNotContainTypeNames")]
+
 // TODO: in the context of a CLI tool this wasn't as much of a problem, we wanted the http client to hang around and be re-used, but needs to be revisited for the core library
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:DisposeObjectsBeforeLosingScope")]
+
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Globalization", "CA1303:DoNotPassLiteralsAsLocalizedParameters")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Globalization", "CA1308:NormalizeStringsToUppercase")]

--- a/CycloneDX/CycloneDX.csproj
+++ b/CycloneDX/CycloneDX.csproj
@@ -35,6 +35,10 @@
 
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.5.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="nuget.projectmodel" Version="5.4.0" />
     <PackageReference Include="System.IO.Abstractions" Version="9.0.4" />

--- a/CycloneDX/Program.cs
+++ b/CycloneDX/Program.cs
@@ -59,7 +59,7 @@ namespace CycloneDX {
         static internal ISolutionFileService solutionFileService = new SolutionFileService(fileSystem, projectFileService);
         
         public static async Task<int> Main(string[] args)
-            => await CommandLineApplication.ExecuteAsync<Program>(args);
+            => await CommandLineApplication.ExecuteAsync<Program>(args).ConfigureAwait(false);
 
         async Task<int> OnExecuteAsync() {
             Console.WriteLine();
@@ -127,23 +127,23 @@ namespace CycloneDX {
             {
                 if (SolutionOrProjectFile.ToLowerInvariant().EndsWith(".sln", StringComparison.OrdinalIgnoreCase))
                 {
-                    packages = await solutionFileService.GetSolutionNugetPackages(fullSolutionOrProjectFilePath);
+                    packages = await solutionFileService.GetSolutionNugetPackages(fullSolutionOrProjectFilePath).ConfigureAwait(false);
                 }
                 else if (Utils.IsSupportedProjectType(SolutionOrProjectFile) && scanProjectReferences)
                 {
-                    packages = await projectFileService.RecursivelyGetProjectNugetPackagesAsync(fullSolutionOrProjectFilePath);
+                    packages = await projectFileService.RecursivelyGetProjectNugetPackagesAsync(fullSolutionOrProjectFilePath).ConfigureAwait(false);
                 }
                 else if (Utils.IsSupportedProjectType(SolutionOrProjectFile))
                 {
-                    packages = await projectFileService.GetProjectNugetPackagesAsync(fullSolutionOrProjectFilePath);
+                    packages = await projectFileService.GetProjectNugetPackagesAsync(fullSolutionOrProjectFilePath).ConfigureAwait(false);
                 }
                 else if (Program.fileSystem.Path.GetFileName(SolutionOrProjectFile).ToLowerInvariant().Equals("packages.config", StringComparison.OrdinalIgnoreCase))
                 {
-                    packages = await packagesFileService.GetNugetPackagesAsync(fullSolutionOrProjectFilePath);
+                    packages = await packagesFileService.GetNugetPackagesAsync(fullSolutionOrProjectFilePath).ConfigureAwait(false);
                 } 
                 else if (attr.HasFlag(FileAttributes.Directory))
                 {
-                    packages = await packagesFileService.RecursivelyGetNugetPackagesAsync(fullSolutionOrProjectFilePath);
+                    packages = await packagesFileService.RecursivelyGetNugetPackagesAsync(fullSolutionOrProjectFilePath).ConfigureAwait(false);
                 }
                 else
                 {
@@ -162,7 +162,7 @@ namespace CycloneDX {
             {
                 foreach (var package in packages)
                 {
-                    var component = await nugetService.GetComponentAsync(package);
+                    var component = await nugetService.GetComponentAsync(package).ConfigureAwait(false);
                     if (component != null) components.Add(component);
                 }
             }


### PR DESCRIPTION
Incorporate FxCop analyzer checks for code quality.

Suppresses some checks that are just "noise" in the current context and fix some identified code quality issues.

In particular, some of them relate to globalization so should be revisited if we start doing localized versions of the tool.