### PR TITLE
Optional licence resolution

### DIFF
--- a/CycloneDX.Core/Services/NugetService.cs
+++ b/CycloneDX.Core/Services/NugetService.cs
@@ -155,12 +155,22 @@ namespace CycloneDX.Services
                 var licenseUrl = nuspecReader.GetLicenseUrl();
                 if (!string.IsNullOrEmpty(licenseUrl))
                 {
-                    var license = await _githubService.GetLicenseAsync(licenseUrl).ConfigureAwait(false);
+                    Models.License license = null;
                     
-                    component.Licenses.Add(license ?? new Models.License
+                    if (_githubService != null)
                     {
-                        Url = licenseUrl
-                    });
+                        license = await _githubService.GetLicenseAsync(licenseUrl).ConfigureAwait(false);
+                    }
+
+                    if (license == null)
+                    {
+                        license = new Models.License
+                        {
+                            Url = licenseUrl
+                        };
+                    }
+                    
+                    component.Licenses.Add(license);
                 }
             }
 

--- a/CycloneDX.Core/Services/NugetService.cs
+++ b/CycloneDX.Core/Services/NugetService.cs
@@ -51,7 +51,6 @@ namespace CycloneDX.Services
             string baseUrl = null)
         {
             _fileSystem = fileSystem;
-            _githubService = githubService;
             _packageCachePaths = packageCachePaths;
             _githubService = githubService;
             _httpClient = httpClient;

--- a/CycloneDX/Program.cs
+++ b/CycloneDX/Program.cs
@@ -47,6 +47,8 @@ namespace CycloneDX {
         string githubUsername { get; set; }
         [Option(Description = "Optionally provide a GitHub personal access token for license resolution. If set you also need to provide a GitHub username.", ShortName = "gt", LongName = "githubToken")]
         string githubToken { get; set; }
+        [Option(Description = "Optionally disable GitHub license resolution.", ShortName = "dgl", LongName = "disableGithubLicenses")]
+        bool disableGithubLicenses { get; set; }
 
 
         static internal IFileSystem fileSystem = new FileSystem();
@@ -100,15 +102,18 @@ namespace CycloneDX {
             // instantiate services
 
             var fileDiscoveryService = new FileDiscoveryService(Program.fileSystem);
-            // GitHubService requires its own HttpClient as it adds a default authorization header
-            GithubService githubService;
-            if (string.IsNullOrEmpty(githubUsername) || string.IsNullOrEmpty(githubToken))
+            GithubService githubService = null;
+            if (!disableGithubLicenses)
             {
-                githubService = new GithubService(new HttpClient());
-            }
-            else
-            {
-                githubService = new GithubService(new HttpClient(), githubUsername, githubToken);
+                // GitHubService requires its own HttpClient as it adds a default authorization header
+                if (string.IsNullOrEmpty(githubUsername) || string.IsNullOrEmpty(githubToken))
+                {
+                    githubService = new GithubService(new HttpClient());
+                }
+                else
+                {
+                    githubService = new GithubService(new HttpClient(), githubUsername, githubToken);
+                }
             }
             var nugetService = new NugetService(
                 Program.fileSystem,

--- a/README.md
+++ b/README.md
@@ -51,13 +51,14 @@ Arguments:
   Path            The path to a .sln, .csproj, .vbproj, or packages.config file or the path to a directory which will be recursively analyzed for packages.config files.
 
 Options:
-  -o|--out <DIR>        The directorty to write the BOM
-  -u|--url <URL>        Alternative NuGet repository URL to v3-flatcontainer API (a trailing slash is required).
-  -r|--recursive        To be used with a single project file, it will recursively scan project references of the supplied .csproj.	
- -ns|--noSerialNumber   Do not generate bom serial number
- -gu|--githubUsername   Optionally provide a GitHub username for license resolution (see notes below)
- -gt|--githubToken      Optionally provide a GitHub personal access token for license resolution
-  -?|-h|--help          Show help information
+  -o|--out <DIR>                The directorty to write the BOM
+  -u|--url <URL>                Alternative NuGet repository URL to v3-flatcontainer API (a trailing slash is required).
+  -r|--recursive                To be used with a single project file, it will recursively scan project references of the supplied .csproj.	
+ -ns|--noSerialNumber           Do not generate bom serial number
+ -gu|--githubUsername           Optionally provide a GitHub username for license resolution (see notes below)
+ -gt|--githubToken              Optionally provide a GitHub personal access token for license resolution
+ -dgl|--disableGithubLicenses   Optionally disable GitHub license resolution
+  -?|-h|--help                  Show help information
 ```
 
 #### Examples


### PR DESCRIPTION
To address issue #96 Make github license lookup optional

In particular to support operating in restricted environments without internet access.