### PR TITLE
Remove explicit setup of .NET SDKs

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -10,11 +10,6 @@ jobs:
     steps:
       - uses: actions/checkout@v1
   
-      - name: Setup .NET Core
-        uses: coderpatros/setup-dotnet@sxs
-        with:
-          dotnet-version: 2.1.807,3.1.301
-
       - name: Build
         run: dotnet build /WarnAsError
 
@@ -29,11 +24,6 @@ jobs:
     
     steps:
     - uses: actions/checkout@v1
-
-    - name: Setup .NET Core
-      uses: coderpatros/setup-dotnet@sxs
-      with:
-        dotnet-version: 2.1.807,3.1.301
 
     - name: Tests
       run: dotnet test --framework netcoreapp${{ matrix.framework }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,20 +11,6 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v1
-  
-      - name: Setup .NET Core 2.1
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: 2.1.807
-  
-      - name: Setup .NET Core 3.1
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: 3.1.301
-
-      - name: Setup side by side .NET SDKs on *nix
-        run: |
-          rsync -a ${DOTNET_ROOT/3.1.301/2.1.807}/* $DOTNET_ROOT/
       
       # The tests should have already been run during the PR workflow, so this is really just a sanity check
       - name: Tests


### PR DESCRIPTION
Turns out all the github hosted runners have .NET SDKs already installed.