### PR TITLE
add baseIntermediateOutputPath option

### DIFF
--- a/CycloneDX.Core.Tests/ProjectFileServiceTests.cs
+++ b/CycloneDX.Core.Tests/ProjectFileServiceTests.cs
@@ -30,6 +30,13 @@ namespace CycloneDX.Tests
     public class ProjectFileServiceTests
     {
         [Fact]
+        public void GetPropertyUseProjectFileName()
+        {
+          string outputPath = ProjectFileService.GetProjectProperty(@"C:\github\cyclonedx-dotnet\Core\CycloneDX.Core.csproj", @"C:\github\cyclonedx-dotnet\artifacts");
+          Assert.Equal(@"C:\github\cyclonedx-dotnet\artifacts\obj\CycloneDX.Core", outputPath);
+        }
+
+        [Fact]
         public async Task GetProjectNugetPackages_WithProjectAssetsFile_ReturnsNugetPackage()
         {
             var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -55,7 +62,7 @@ namespace CycloneDX.Tests
                 mockPackageFileService.Object,
                 mockProjectAssetsFileService.Object);
 
-            var packages = await projectFileService.GetProjectNugetPackagesAsync(XFS.Path(@"c:\Project\Project.csproj")).ConfigureAwait(false);
+            var packages = await projectFileService.GetProjectNugetPackagesAsync(XFS.Path(@"c:\Project\Project.csproj"),"").ConfigureAwait(false);
             
             Assert.Collection(packages,
                 item => {
@@ -92,7 +99,7 @@ namespace CycloneDX.Tests
                 mockPackageFileService.Object,
                 mockProjectAssetsFileService.Object);
 
-            var packages = await projectFileService.GetProjectNugetPackagesAsync(XFS.Path(@"c:\Project\Project.csproj")).ConfigureAwait(false);
+            var packages = await projectFileService.GetProjectNugetPackagesAsync(XFS.Path(@"c:\Project\Project.csproj"), "").ConfigureAwait(false);
             var sortedPackages = new List<NugetPackage>(packages);
             sortedPackages.Sort();
             
@@ -133,7 +140,7 @@ namespace CycloneDX.Tests
                 mockPackageFileService.Object,
                 mockProjectAssetsFileService.Object);
 
-            var packages = await projectFileService.GetProjectNugetPackagesAsync(XFS.Path(@"c:\Project\Project.csproj")).ConfigureAwait(false);
+            var packages = await projectFileService.GetProjectNugetPackagesAsync(XFS.Path(@"c:\Project\Project.csproj"), "").ConfigureAwait(false);
             
             Assert.Collection(packages,
                 item => {
@@ -175,7 +182,7 @@ namespace CycloneDX.Tests
                 mockPackageFileService.Object,
                 mockProjectAssetsFileService.Object);
 
-            var packages = await projectFileService.GetProjectNugetPackagesAsync(XFS.Path(@"c:\Project\Project.csproj")).ConfigureAwait(false);
+            var packages = await projectFileService.GetProjectNugetPackagesAsync(XFS.Path(@"c:\Project\Project.csproj"), "").ConfigureAwait(false);
             var sortedPackages = new List<NugetPackage>(packages);
             sortedPackages.Sort();
             

--- a/CycloneDX.Core/Services/IProjectFileService.cs
+++ b/CycloneDX.Core/Services/IProjectFileService.cs
@@ -22,8 +22,8 @@ namespace CycloneDX.Services
 {
     public interface IProjectFileService
     {
-        Task<HashSet<NugetPackage>> GetProjectNugetPackagesAsync(string projectFilePath);
-        Task<HashSet<NugetPackage>> RecursivelyGetProjectNugetPackagesAsync(string projectFilePath);
+        Task<HashSet<NugetPackage>> GetProjectNugetPackagesAsync(string projectFilePath, string baseIntermediateOutputPath);
+        Task<HashSet<NugetPackage>> RecursivelyGetProjectNugetPackagesAsync(string projectFilePath, string baseIntermediateOutputPath);
         Task<HashSet<string>> GetProjectReferencesAsync(string projectFilePath);
         Task<HashSet<string>> RecursivelyGetProjectReferencesAsync(string projectFilePath);
     }

--- a/CycloneDX.Core/Services/ISolutionFileService.cs
+++ b/CycloneDX.Core/Services/ISolutionFileService.cs
@@ -23,6 +23,6 @@ namespace CycloneDX.Services
     public interface ISolutionFileService
     {
         Task<HashSet<string>> GetSolutionProjectReferencesAsync(string solutionFilePath);
-        Task<HashSet<NugetPackage>> GetSolutionNugetPackages(string solutionFilePath);
+        Task<HashSet<NugetPackage>> GetSolutionNugetPackages(string solutionFilePath, string baseIntermediateOutputPath);
     }
 }

--- a/CycloneDX.Core/Services/ProjectFileService.cs
+++ b/CycloneDX.Core/Services/ProjectFileService.cs
@@ -58,12 +58,25 @@ namespace CycloneDX.Services
             _projectAssetsFileService = projectAssetsFileService;
         }
 
-        /// <summary>
-        /// Analyzes a single Project file for NuGet package references.
-        /// </summary>
-        /// <param name="projectFilePath"></param>
-        /// <returns></returns>
-        public async Task<HashSet<NugetPackage>> GetProjectNugetPackagesAsync(string projectFilePath)
+
+    static internal String GetProjectProperty(string projectFilePath, string baseIntermediateOutputPath)
+    {
+      if (string.IsNullOrEmpty(baseIntermediateOutputPath))
+      {
+        return Path.Combine(Path.GetDirectoryName(projectFilePath), "obj");
+      }
+      else
+      {
+        string folderName = Path.GetFileNameWithoutExtension(projectFilePath);
+        return Path.Combine(baseIntermediateOutputPath, "obj", folderName);
+      }
+    }
+    /// <summary>
+    /// Analyzes a single Project file for NuGet package references.
+    /// </summary>
+    /// <param name="projectFilePath"></param>
+    /// <returns></returns>
+    public async Task<HashSet<NugetPackage>> GetProjectNugetPackagesAsync(string projectFilePath, string baseIntermediateOutputPath)
         {
             if (!_fileSystem.File.Exists(projectFilePath))
             {
@@ -81,10 +94,11 @@ namespace CycloneDX.Services
 
             if (restoreResult.Success)
             {
-                var assetsFilename = _fileSystem.Path.Combine(
-                    _fileSystem.Path.GetDirectoryName(projectFilePath),
-                    "obj", "project.assets.json");
-                
+                var assetsFilename = _fileSystem.Path.Combine(GetProjectProperty(projectFilePath, baseIntermediateOutputPath), "project.assets.json");
+                if (!File.Exists(assetsFilename))
+                {
+                  Console.WriteLine($"File not found: \"{assetsFilename}\", \"{projectFilePath}\" ");
+                }
                 packages.UnionWith(_projectAssetsFileService.GetNugetPackages(assetsFilename));
             }
             else
@@ -114,13 +128,13 @@ namespace CycloneDX.Services
         /// </summary>
         /// <param name="projectFilePath"></param>
         /// <returns></returns>
-        public async Task<HashSet<NugetPackage>> RecursivelyGetProjectNugetPackagesAsync(string projectFilePath)
+        public async Task<HashSet<NugetPackage>> RecursivelyGetProjectNugetPackagesAsync(string projectFilePath, string baseIntermediateOutputPath)
         {
-            var nugetPackages = await GetProjectNugetPackagesAsync(projectFilePath).ConfigureAwait(false);
+            var nugetPackages = await GetProjectNugetPackagesAsync(projectFilePath, baseIntermediateOutputPath).ConfigureAwait(false);
             var projectReferences = await RecursivelyGetProjectReferencesAsync(projectFilePath).ConfigureAwait(false);
             foreach (var project in projectReferences)
             {
-                var projectNugetPackages = await GetProjectNugetPackagesAsync(project).ConfigureAwait(false);
+                var projectNugetPackages = await GetProjectNugetPackagesAsync(project, baseIntermediateOutputPath).ConfigureAwait(false);
                 nugetPackages.UnionWith(projectNugetPackages);
             }
             return nugetPackages;

--- a/CycloneDX.Core/Services/SolutionFileService.cs
+++ b/CycloneDX.Core/Services/SolutionFileService.cs
@@ -79,7 +79,7 @@ namespace CycloneDX.Services
         /// </summary>
         /// <param name="solutionFilePath"></param>
         /// <returns></returns>
-        public async Task<HashSet<NugetPackage>> GetSolutionNugetPackages(string solutionFilePath)
+        public async Task<HashSet<NugetPackage>> GetSolutionNugetPackages(string solutionFilePath, string baseIntermediateOutputPath)
         {
             if (!_fileSystem.File.Exists(solutionFilePath))
             {
@@ -107,7 +107,7 @@ namespace CycloneDX.Services
             foreach (var projectFilePath in projectPaths)
             {
                 Console.WriteLine();
-                var projectPackages = await _projectFileService.GetProjectNugetPackagesAsync(projectFilePath).ConfigureAwait(false);
+                var projectPackages = await _projectFileService.GetProjectNugetPackagesAsync(projectFilePath, baseIntermediateOutputPath).ConfigureAwait(false);
                 packages.UnionWith(projectPackages);
             }
 

--- a/CycloneDX.Tests/ProgramTests.cs
+++ b/CycloneDX.Tests/ProgramTests.cs
@@ -53,7 +53,7 @@ namespace CycloneDX.Tests
                 });
             var mockSolutionFileService = new Mock<ISolutionFileService>();
             mockSolutionFileService
-                .Setup(s => s.GetSolutionNugetPackages(It.IsAny<string>()))
+                .Setup(s => s.GetSolutionNugetPackages(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync(new HashSet<NugetPackage>());
             Program.fileSystem = mockFileSystem;
             Program.solutionFileService = mockSolutionFileService.Object;

--- a/CycloneDX/Program.cs
+++ b/CycloneDX/Program.cs
@@ -71,7 +71,10 @@ namespace CycloneDX {
         [Option(Description = "dotnet command timeout in milliseconds (primarily used for long dotnet restore operations)", ShortName = "dct", LongName = "dotnet-command-timeout")]
         int dotnetCommandTimeout { get; set; } = 300000;
 
-        static internal IFileSystem fileSystem = new FileSystem();
+        [Option(Description = "Optionally provide a folder for customized build environment. Required if folder 'obj' is relocated.", ShortName = "biop", LongName = "base-intermediate-output-path")]
+        public string baseIntermediateOutputPath { get; }
+
+    static internal IFileSystem fileSystem = new FileSystem();
         static internal HttpClient httpClient = new HttpClient();
         static internal IProjectAssetsFileService projectAssetsFileService = new ProjectAssetsFileService(fileSystem);
         static internal IDotnetCommandService dotnetCommandService = new DotnetCommandService();
@@ -167,15 +170,15 @@ namespace CycloneDX {
             {
                 if (SolutionOrProjectFile.ToLowerInvariant().EndsWith(".sln", StringComparison.OrdinalIgnoreCase))
                 {
-                    packages = await solutionFileService.GetSolutionNugetPackages(fullSolutionOrProjectFilePath).ConfigureAwait(false);
+                    packages = await solutionFileService.GetSolutionNugetPackages(fullSolutionOrProjectFilePath, baseIntermediateOutputPath).ConfigureAwait(false);
                 }
                 else if (Core.Utils.IsSupportedProjectType(SolutionOrProjectFile) && scanProjectReferences)
                 {
-                    packages = await projectFileService.RecursivelyGetProjectNugetPackagesAsync(fullSolutionOrProjectFilePath).ConfigureAwait(false);
+                    packages = await projectFileService.RecursivelyGetProjectNugetPackagesAsync(fullSolutionOrProjectFilePath, baseIntermediateOutputPath).ConfigureAwait(false);
                 }
                 else if (Core.Utils.IsSupportedProjectType(SolutionOrProjectFile))
                 {
-                    packages = await projectFileService.GetProjectNugetPackagesAsync(fullSolutionOrProjectFilePath).ConfigureAwait(false);
+                    packages = await projectFileService.GetProjectNugetPackagesAsync(fullSolutionOrProjectFilePath, baseIntermediateOutputPath).ConfigureAwait(false);
                 }
                 else if (Program.fileSystem.Path.GetFileName(SolutionOrProjectFile).ToLowerInvariant().Equals("packages.config", StringComparison.OrdinalIgnoreCase))
                 {

--- a/README.md
+++ b/README.md
@@ -52,17 +52,18 @@ Arguments:
   path                                              The path to a .sln, .csproj, .vbproj, or packages.config file or the path to a directory which will be recursively analyzed for packages.config files
 
 Options:
-  -o|--out <OUTPUT_DIRECTORY>                       The directory to write the BOM
-  -j|--json                                         Produce a JSON BOM instead of XML
-  -d|--exclude-dev                                  Exclude development dependencies from the BOM
-  -u|--url <BASE_URL>                               Alternative NuGet repository URL to v3-flatcontainer API (a trailing slash is required)
-  -r|--recursive                                    To be used with a single project file, it will recursively scan project references of the supplied .csproj
-  -ns|--no-serial-number                            Optionally omit the serial number from the resulting BOM
-  -gu|--github-username <GITHUB_USERNAME>           Optionally provide a GitHub username for license resolution. If set you also need to provide a GitHub personal access token
-  -gt|--github-token <GITHUB_TOKEN>                 Optionally provide a GitHub personal access token for license resolution. If set you also need to provide a GitHub username
-  -gbt|--github-bearer-token <GITHUB_BEARER_TOKEN>  Optionally provide a GitHub bearer token for license resolution. This is useful in GitHub actions
-  -dgl|--disable-github-licenses                    Optionally disable GitHub license resolution
-  -?|-h|--help                                      Show help information
+  -o|--out <OUTPUT_DIRECTORY>                                            The directory to write the BOM
+  -j|--json                                                              Produce a JSON BOM instead of XML
+  -d|--exclude-dev                                                       Exclude development dependencies from the BOM
+  -u|--url <BASE_URL>                                                    Alternative NuGet repository URL to v3-flatcontainer API (a trailing slash is required)
+  -r|--recursive                                                         To be used with a single project file, it will recursively scan project references of the supplied .csproj
+  -ns|--no-serial-number                                                 Optionally omit the serial number from the resulting BOM
+  -gu|--github-username <GITHUB_USERNAME>                                Optionally provide a GitHub username for license resolution. If set you also need to provide a GitHub personal access token
+  -gt|--github-token <GITHUB_TOKEN>                                      Optionally provide a GitHub personal access token for license resolution. If set you also need to provide a GitHub username
+  -gbt|--github-bearer-token <GITHUB_BEARER_TOKEN>                       Optionally provide a GitHub bearer token for license resolution. This is useful in GitHub actions
+  -dgl|--disable-github-licenses                                         Optionally disable GitHub license resolution
+  -biop|--base-intermediate-output-path <BASE_INTERMEDIATE_OUTPUT_PATH>  Optionally provide a folder for customized build environment. Required if folder 'obj' is relocated.
+  -?|-h|--help                                                           Show help information
 ```
 
 #### Examples


### PR DESCRIPTION
Revolves #210 with new optional argument 

_-biop|--base-intermediate-output-path <BASE_INTERMEDIATE_OUTPUT_PATH>  Optionally provide a folder for customized build environment. Required if folder 'obj' is relocated._