### PR TITLE
Add devcontainer configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:20.04
+
+RUN apt-get update \
+    && apt-get install -y \
+        wget \
+        apt-transport-https \
+    && wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb \
+    && dpkg -i packages-microsoft-prod.deb \
+    && apt-get update \
+    && apt-get install -y dotnet-sdk-2.1 \
+    && apt-get install -y dotnet-sdk-3.1 \
+    && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,11 @@
+{
+    "name": "devcontainer",
+    "build": {
+        "dockerfile": "Dockerfile",
+        "context": ".."
+    },
+    "extensions": [
+        "ms-dotnettools.csharp",
+        "redhat.vscode-yaml"
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ Pull requests are welcome. But please read the
 To build and test the solution locally you should have .NET core 2.1 and 3.1
 installed. Standard commands like `dotnet build` and `dotnet test` work.
 
+Alternatively, you can use VS Code and the included devcontainer configuration
+to work in a pre-configured docker image. (You will also need the "Remote - Containers"
+extension and Docker)
+
 It is generally expected that pull requests will include relevant tests.
 Tests are automatically run on Windows, MacOS and Linux for every pull request.
 And build warnings will break the build.


### PR DESCRIPTION
This is mainly to make switching between implementations for maintainers easier. But can also be handy for new contributors.