### PR TITLE
Avoid `NullReferenceException` for packages with no dependencies

### DIFF
--- a/CycloneDX/Program.cs
+++ b/CycloneDX/Program.cs
@@ -104,7 +104,9 @@ namespace CycloneDX {
         static internal IPackagesFileService packagesFileService = new PackagesFileService(fileSystem);
         static internal IProjectFileService projectFileService = new ProjectFileService(fileSystem, dotnetUtilsService, packagesFileService, projectAssetsFileService);
         static internal ISolutionFileService solutionFileService = new SolutionFileService(fileSystem, projectFileService);
-        
+
+        static private HashSet<string> NoDependencies = new HashSet<string>();
+
         public static async Task<int> Main(string[] args)
             => await CommandLineApplication.ExecuteAsync<Program>(args).ConfigureAwait(false);
 
@@ -270,7 +272,7 @@ namespace CycloneDX {
                         Ref = bomRefLookup[package.Name.ToLower()],
                         Dependencies = new List<Dependency>()
                     };
-                    foreach (var dep in package.Dependencies)
+                    foreach (var dep in package.Dependencies ?? NoDependencies)
                     {
                         transitiveDepencies.Add(bomRefLookup[dep.ToLower()]);
                         packageDepencies.Dependencies.Add(new Dependency


### PR DESCRIPTION
As reported in https://github.com/CycloneDX/cyclonedx-dotnet/issues/436, attempts to iterate over `package.Dependencies` can lead to `NullReferenceException` if a package has no dependencies:

https://github.com/CycloneDX/cyclonedx-dotnet/blob/929544857c86d25ee4248963e7308dd0d287636f/CycloneDX/Program.cs#L273

This PR protects against the issue by substituting an empty dependency set whenever `package.Dependencies` is `null`. Testing locally, this resolved the original issue and unit tests pass.

Fixes #436.