### PR TITLE
add flag to disable hash computation for packages

### DIFF
--- a/CycloneDX.Tests/NugetServiceTests.cs
+++ b/CycloneDX.Tests/NugetServiceTests.cs
@@ -171,7 +171,7 @@ namespace CycloneDX.Tests
 
             var component = await nugetService.GetComponentAsync("testpackage", "1.0.0", Component.ComponentScope.Required).ConfigureAwait(false);
 
-            Assert.Equal(null, component.Hashes);
+            Assert.Null(component.Hashes);
         }
 
         [Fact]
@@ -258,7 +258,7 @@ namespace CycloneDX.Tests
 
 
             Assert.Equal("testpackage", component.Name);
-            Assert.Equal(null, component.Hashes);
+            Assert.Null(component.Hashes);
         }
 
         [Fact]

--- a/CycloneDX.Tests/NugetServiceTests.cs
+++ b/CycloneDX.Tests/NugetServiceTests.cs
@@ -79,7 +79,7 @@ namespace CycloneDX.Tests
                 new HttpClient());
 
             var component = await nugetService.GetComponentAsync("testpackage", "1.0.0", Component.ComponentScope.Required).ConfigureAwait(false);
-            
+
             Assert.Equal("testpackage", component.Name);
         }
 
@@ -147,6 +147,34 @@ namespace CycloneDX.Tests
         }
 
         [Fact]
+        public async Task GetComponent_FromCachedNugetFile_DoNotReturnsHash_WhenDisabled()
+        {
+            var nuspecFileContents = @"<?xml version=""1.0"" encoding=""utf-8""?>
+                <package xmlns=""http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd"">
+                <metadata>
+                    <id>testpackage</id>
+                </metadata>
+                </package>";
+
+            var nugetFileContent = "FooBarBaz";
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\nugetcache\testpackage\1.0.0\testpackage.nuspec"), new MockFileData(nuspecFileContents) },
+                { XFS.Path(@"c:\nugetcache\testpackage\1.0.0\testpackage.1.0.0.nupkg"), new MockFileData(nugetFileContent) },
+            });
+            var nugetService = new NugetService(
+                mockFileSystem,
+                new List<string> { XFS.Path(@"c:\nugetcache") },
+                new Mock<IGithubService>().Object,
+                new HttpClient(),
+                disableHashComputation: true);
+
+            var component = await nugetService.GetComponentAsync("testpackage", "1.0.0", Component.ComponentScope.Required).ConfigureAwait(false);
+
+            Assert.Equal(null, component.Hashes);
+        }
+
+        [Fact]
         public async Task GetComponent_FromNugetOrg_ReturnsComponent()
         {
             var mockResponseContent = @"<?xml version=""1.0"" encoding=""utf-8""?>
@@ -166,7 +194,7 @@ namespace CycloneDX.Tests
                 client);
 
             var component = await nugetService.GetComponentAsync("testpackage", "1.0.0", Component.ComponentScope.Required).ConfigureAwait(false);
-            
+
             Assert.Equal("testpackage", component.Name);
         }
 
@@ -207,6 +235,33 @@ namespace CycloneDX.Tests
         }
 
         [Fact]
+        public async Task GetComponent_FromNugetOrg_DoNotReturnsHash_WhenDisabled()
+        {
+            var mockNuspecResponseContent = @"<?xml version=""1.0"" encoding=""utf-8""?>
+                <package xmlns=""http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd"">
+                <metadata>
+                    <name>testpackage</name>
+                </metadata>
+                </package>";
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp.When("https://api.nuget.org/v3-flatcontainer/testpackage/1.0.0/testpackage.nuspec")
+                .Respond("application/xml", mockNuspecResponseContent);
+            var client = mockHttp.ToHttpClient();
+            var nugetService = new NugetService(
+                new MockFileSystem(),
+                new List<string>(),
+                new Mock<IGithubService>().Object,
+                client,
+                disableHashComputation: true);
+
+            var component = await nugetService.GetComponentAsync("testpackage", "1.0.0", Component.ComponentScope.Required).ConfigureAwait(false);
+
+
+            Assert.Equal("testpackage", component.Name);
+            Assert.Equal(null, component.Hashes);
+        }
+
+        [Fact]
         public async Task GetComponent_FromNugetOrgWhichDoesntExist_ReturnsComponent()
         {
             var mockHttp = new MockHttpMessageHandler();
@@ -220,7 +275,7 @@ namespace CycloneDX.Tests
                 client);
 
             var component = await nugetService.GetComponentAsync("testpackage", "1.0.0", Component.ComponentScope.Required).ConfigureAwait(false);
-            
+
             Assert.Equal("testpackage", component.Name);
         }
 
@@ -254,7 +309,7 @@ namespace CycloneDX.Tests
 
             var component = await nugetService.GetComponentAsync("PackageName", "1.2.3", Component.ComponentScope.Required).ConfigureAwait(false);
 
-            Assert.Collection(component.Licenses, 
+            Assert.Collection(component.Licenses,
                 item => {
                     Assert.Equal("TestLicenseId", item.License.Id);
                     Assert.Equal("Test License", item.License.Name);
@@ -283,7 +338,7 @@ namespace CycloneDX.Tests
 
             var component = await nugetService.GetComponentAsync("PackageName", "1.2.3", Component.ComponentScope.Required).ConfigureAwait(false);
 
-            Assert.Collection(component.Licenses, 
+            Assert.Collection(component.Licenses,
                 item => {
                     Assert.Null(item.License.Id);
                     Assert.Null(item.License.Name);

--- a/CycloneDX/Program.cs
+++ b/CycloneDX/Program.cs
@@ -82,6 +82,9 @@ namespace CycloneDX {
         [Option(Description = "Optionally disable package restore", ShortName = "dpr", LongName = "disable-package-restore")]
         bool disablePackageRestore { get; set; }
 
+        [Option(Description = "Optionally disable hash computation for packages", ShortName = "dhc", LongName = "disable-hash-computation")]
+        bool disableHashComputation { get; set; }
+
         [Option(Description = "dotnet command timeout in milliseconds (primarily used for long dotnet restore operations)", ShortName = "dct", LongName = "dotnet-command-timeout")]
         int dotnetCommandTimeout { get; set; } = 300000;
 
@@ -191,7 +194,8 @@ namespace CycloneDX {
                 packageCachePathsResult.Result,
                 githubService,
                 Program.httpClient,
-                baseUrl);
+                baseUrl,
+                disableHashComputation);
 
             var packages = new HashSet<NugetPackage>();
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Options:
   -gbt|--github-bearer-token <GITHUB_BEARER_TOKEN>                       Optionally provide a GitHub bearer token for license resolution. This is useful in GitHub actions
   -dgl|--disable-github-licenses                                         Optionally disable GitHub license resolution
   -dpr|--disable-package-restore                                         Optionally disable package restore
+  -dhc|--disable-hash-computation                                        Optionally disable hash computation for packages
   -biop|--base-intermediate-output-path <BASE_INTERMEDIATE_OUTPUT_PATH>  Optionally provide a folder for customized build environment. Required if folder 'obj' is relocated.
   -imp|--import-metadata-path <METADATA_TEMPLATE>                        Optionally provide a metadata template which has project specific details
   -?|-h|--help                                                           Show help information


### PR DESCRIPTION
Add a flag (`disable-hash-computation`) to disable the computation of hash for components.
Main reason for that is to speed up the BOM generation when we don't need hash for components.

I maintaned the hash only in case it was already available as `.nupkg.sha512`, because my assumption is that in this case the performance penality is small.