### PR TITLE
Increase tolerance for GitHub license urls

### DIFF
--- a/CycloneDX.Tests/GithubServiceTests.cs
+++ b/CycloneDX.Tests/GithubServiceTests.cs
@@ -257,6 +257,48 @@ namespace CycloneDX.Tests
         }
 
         [Fact]
+        public async Task GitLicence_FromLicenseFileWithPascalCaseFileName()
+        {
+            var mockResponseContent = @"{
+                ""license"": {
+                    ""spdx_id"": ""LicenseSpdxId"",
+                    ""name"": ""Test License""
+                }
+            }";
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp.When("https://api.github.com/repos/CycloneDX/cyclonedx-dotnet/license?ref=master")
+                .Respond("application/json", mockResponseContent);
+            var client = mockHttp.ToHttpClient();
+            var githubService = new GithubService(client);
+
+            var license = await githubService.GetLicenseAsync("https://github.com/CycloneDX/cyclonedx-dotnet/blob/master/License.txt").ConfigureAwait(false);
+
+            Assert.Equal("LicenseSpdxId", license.Id);
+            Assert.Equal("Test License", license.Name);
+        }
+
+        [Fact]
+        public async Task GitLicence_FromLicenseFileWithLowerCaseFileName()
+        {
+            var mockResponseContent = @"{
+                ""license"": {
+                    ""spdx_id"": ""LicenseSpdxId"",
+                    ""name"": ""Test License""
+                }
+            }";
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp.When("https://api.github.com/repos/CycloneDX/cyclonedx-dotnet/license?ref=master")
+                .Respond("application/json", mockResponseContent);
+            var client = mockHttp.ToHttpClient();
+            var githubService = new GithubService(client);
+
+            var license = await githubService.GetLicenseAsync("https://github.com/CycloneDX/cyclonedx-dotnet/blob/master/license.txt").ConfigureAwait(false);
+
+            Assert.Equal("LicenseSpdxId", license.Id);
+            Assert.Equal("Test License", license.Name);
+        }
+
+        [Fact]
         public async Task GitLicence_FromGithubUserContent()
         {
             var mockResponseContent = @"{

--- a/CycloneDX.Tests/GithubServiceTests.cs
+++ b/CycloneDX.Tests/GithubServiceTests.cs
@@ -320,6 +320,27 @@ namespace CycloneDX.Tests
         }
 
         [Fact]
+        public async Task GitLicence_FromRawGithub()
+        {
+            var mockResponseContent = @"{
+                ""license"": {
+                    ""spdx_id"": ""LicenseSpdxId"",
+                    ""name"": ""Test License""
+                }
+            }";
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp.When("https://api.github.com/repos/CycloneDX/cyclonedx-dotnet/license?ref=master")
+                .Respond("application/json", mockResponseContent);
+            var client = mockHttp.ToHttpClient();
+            var githubService = new GithubService(client);
+
+            var license = await githubService.GetLicenseAsync("https://raw.github.com/CycloneDX/cyclonedx-dotnet/master/LICENSE").ConfigureAwait(false);
+
+            Assert.Equal("LicenseSpdxId", license.Id);
+            Assert.Equal("Test License", license.Name);
+        }
+
+        [Fact]
         public async Task GetLicense_AddsAuthorizationHeader()
         {
             var mockResponseContent = @"{

--- a/CycloneDX.Tests/GithubServiceTests.cs
+++ b/CycloneDX.Tests/GithubServiceTests.cs
@@ -236,6 +236,27 @@ namespace CycloneDX.Tests
         }
 
         [Fact]
+        public async Task GitLicence_FromLicenseNameWithHyphenLicenseId()
+        {
+            var mockResponseContent = @"{
+                ""license"": {
+                    ""spdx_id"": ""LicenseSpdxId"",
+                    ""name"": ""Test License""
+                }
+            }";
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp.When("https://api.github.com/repos/CycloneDX/cyclonedx-dotnet/license?ref=master")
+                .Respond("application/json", mockResponseContent);
+            var client = mockHttp.ToHttpClient();
+            var githubService = new GithubService(client);
+
+            var license = await githubService.GetLicenseAsync("https://github.com/CycloneDX/cyclonedx-dotnet/blob/master/LICENSE-MIT").ConfigureAwait(false);
+
+            Assert.Equal("LicenseSpdxId", license.Id);
+            Assert.Equal("Test License", license.Name);
+        }
+
+        [Fact]
         public async Task GitLicence_FromGithubUserContent()
         {
             var mockResponseContent = @"{

--- a/CycloneDX.Tests/GithubServiceTests.cs
+++ b/CycloneDX.Tests/GithubServiceTests.cs
@@ -152,6 +152,90 @@ namespace CycloneDX.Tests
         }
 
         [Fact]
+        public async Task GitLicence_FromBsdExtensionLicense()
+        {
+            var mockResponseContent = @"{
+                ""license"": {
+                    ""spdx_id"": ""LicenseSpdxId"",
+                    ""name"": ""Test License""
+                }
+            }";
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp.When("https://api.github.com/repos/CycloneDX/cyclonedx-dotnet/license?ref=master")
+                .Respond("application/json", mockResponseContent);
+            var client = mockHttp.ToHttpClient();
+            var githubService = new GithubService(client);
+
+            var license = await githubService.GetLicenseAsync("https://github.com/CycloneDX/cyclonedx-dotnet/blob/master/LICENSE.bsd").ConfigureAwait(false);
+
+            Assert.Equal("LicenseSpdxId", license.Id);
+            Assert.Equal("Test License", license.Name);
+        }
+
+        [Fact]
+        public async Task GitLicence_FromUpperCaseBsdExtensionLicense()
+        {
+            var mockResponseContent = @"{
+                ""license"": {
+                    ""spdx_id"": ""LicenseSpdxId"",
+                    ""name"": ""Test License""
+                }
+            }";
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp.When("https://api.github.com/repos/CycloneDX/cyclonedx-dotnet/license?ref=master")
+                .Respond("application/json", mockResponseContent);
+            var client = mockHttp.ToHttpClient();
+            var githubService = new GithubService(client);
+
+            var license = await githubService.GetLicenseAsync("https://github.com/CycloneDX/cyclonedx-dotnet/blob/master/LICENSE.BSD").ConfigureAwait(false);
+
+            Assert.Equal("LicenseSpdxId", license.Id);
+            Assert.Equal("Test License", license.Name);
+        }
+
+        [Fact]
+        public async Task GitLicence_FromMitExtensionLicense()
+        {
+            var mockResponseContent = @"{
+                ""license"": {
+                    ""spdx_id"": ""LicenseSpdxId"",
+                    ""name"": ""Test License""
+                }
+            }";
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp.When("https://api.github.com/repos/CycloneDX/cyclonedx-dotnet/license?ref=master")
+                .Respond("application/json", mockResponseContent);
+            var client = mockHttp.ToHttpClient();
+            var githubService = new GithubService(client);
+
+            var license = await githubService.GetLicenseAsync("https://github.com/CycloneDX/cyclonedx-dotnet/blob/master/LICENSE.mit").ConfigureAwait(false);
+
+            Assert.Equal("LicenseSpdxId", license.Id);
+            Assert.Equal("Test License", license.Name);
+        }
+
+        [Fact]
+        public async Task GitLicence_FromUpperCaseMitExtensionLicense()
+        {
+            var mockResponseContent = @"{
+                ""license"": {
+                    ""spdx_id"": ""LicenseSpdxId"",
+                    ""name"": ""Test License""
+                }
+            }";
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp.When("https://api.github.com/repos/CycloneDX/cyclonedx-dotnet/license?ref=master")
+                .Respond("application/json", mockResponseContent);
+            var client = mockHttp.ToHttpClient();
+            var githubService = new GithubService(client);
+
+            var license = await githubService.GetLicenseAsync("https://github.com/CycloneDX/cyclonedx-dotnet/blob/master/LICENSE.MIT").ConfigureAwait(false);
+
+            Assert.Equal("LicenseSpdxId", license.Id);
+            Assert.Equal("Test License", license.Name);
+        }
+
+        [Fact]
         public async Task GitLicence_FromGithubUserContent()
         {
             var mockResponseContent = @"{

--- a/CycloneDX.Tests/GithubServiceTests.cs
+++ b/CycloneDX.Tests/GithubServiceTests.cs
@@ -131,6 +131,27 @@ namespace CycloneDX.Tests
         }
 
         [Fact]
+        public async Task GitLicence_FromUpperCaseTextExtensionLicense()
+        {
+            var mockResponseContent = @"{
+                ""license"": {
+                    ""spdx_id"": ""LicenseSpdxId"",
+                    ""name"": ""Test License""
+                }
+            }";
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp.When("https://api.github.com/repos/CycloneDX/cyclonedx-dotnet/license?ref=master")
+                .Respond("application/json", mockResponseContent);
+            var client = mockHttp.ToHttpClient();
+            var githubService = new GithubService(client);
+
+            var license = await githubService.GetLicenseAsync("https://github.com/CycloneDX/cyclonedx-dotnet/blob/master/LICENSE.TXT").ConfigureAwait(false);
+
+            Assert.Equal("LicenseSpdxId", license.Id);
+            Assert.Equal("Test License", license.Name);
+        }
+
+        [Fact]
         public async Task GitLicence_FromGithubUserContent()
         {
             var mockResponseContent = @"{

--- a/CycloneDX.Tests/GithubServiceTests.cs
+++ b/CycloneDX.Tests/GithubServiceTests.cs
@@ -46,6 +46,27 @@ namespace CycloneDX.Tests
             Assert.Equal("Test License", license.Name);
         }
 
+        [Fact]
+        public async Task GitLicence_FromRawMasterBranch()
+        {
+            var mockResponseContent = @"{
+                ""license"": {
+                    ""spdx_id"": ""LicenseSpdxId"",
+                    ""name"": ""Test License""
+                }
+            }";
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp.When("https://api.github.com/repos/CycloneDX/cyclonedx-dotnet/license?ref=master")
+                .Respond("application/json", mockResponseContent);
+            var client = mockHttp.ToHttpClient();
+            var githubService = new GithubService(client);
+
+            var license = await githubService.GetLicenseAsync("https://github.com/CycloneDX/cyclonedx-dotnet/raw/master/LICENSE").ConfigureAwait(false);
+
+            Assert.Equal("LicenseSpdxId", license.Id);
+            Assert.Equal("Test License", license.Name);
+        }
+
         [Fact(Skip="Currently failing as GitHub license API only returns the current license")]
         public async Task GitLicence_FromVersionTag()
         {

--- a/CycloneDX/Services/GithubService.cs
+++ b/CycloneDX/Services/GithubService.cs
@@ -69,7 +69,7 @@ namespace CycloneDX.Services
         private List<Regex> _githubRepositoryRegexes = new List<Regex>
         {
             new Regex(@"^https?\:\/\/github\.com\/(?<repositoryId>[^\/]+\/[^\/]+)\/((blob)|(raw))\/(?<refSpec>[^\/]+)\/[Ll][Ii][Cc][Ee][Nn][Ss][Ee]((\.|-)((md)|([Tt][Xx][Tt])|([Mm][Ii][Tt])|([Bb][Ss][Dd])))?$"),
-            new Regex(@"^https?\:\/\/raw\.githubusercontent\.com\/(?<repositoryId>[^\/]+\/[^\/]+)\/(?<refSpec>[^\/]+)\/[Ll][Ii][Cc][Ee][Nn][Ss][Ee]((\.|-)((md)|([Tt][Xx][Tt])|([Mm][Ii][Tt])|([Bb][Ss][Dd])))?$"),
+            new Regex(@"^https?\:\/\/raw\.github(usercontent)?\.com\/(?<repositoryId>[^\/]+\/[^\/]+)\/(?<refSpec>[^\/]+)\/[Ll][Ii][Cc][Ee][Nn][Ss][Ee]((\.|-)((md)|([Tt][Xx][Tt])|([Mm][Ii][Tt])|([Bb][Ss][Dd])))?$"),
         };
 
         public GithubService(HttpClient httpClient)

--- a/CycloneDX/Services/GithubService.cs
+++ b/CycloneDX/Services/GithubService.cs
@@ -68,8 +68,8 @@ namespace CycloneDX.Services
         private HttpClient _httpClient;
         private List<Regex> _githubRepositoryRegexes = new List<Regex>
         {
-            new Regex(@"^https?\:\/\/github\.com\/(?<repositoryId>[^\/]+\/[^\/]+)\/((blob)|(raw))\/(?<refSpec>[^\/]+)\/LICENSE((\.|-)((md)|([Tt][Xx][Tt])|([Mm][Ii][Tt])|([Bb][Ss][Dd])))?$"),
-            new Regex(@"^https?\:\/\/raw\.githubusercontent\.com\/(?<repositoryId>[^\/]+\/[^\/]+)\/(?<refSpec>[^\/]+)\/LICENSE((\.|-)((md)|([Tt][Xx][Tt])|([Mm][Ii][Tt])|([Bb][Ss][Dd])))?$"),
+            new Regex(@"^https?\:\/\/github\.com\/(?<repositoryId>[^\/]+\/[^\/]+)\/((blob)|(raw))\/(?<refSpec>[^\/]+)\/[Ll][Ii][Cc][Ee][Nn][Ss][Ee]((\.|-)((md)|([Tt][Xx][Tt])|([Mm][Ii][Tt])|([Bb][Ss][Dd])))?$"),
+            new Regex(@"^https?\:\/\/raw\.githubusercontent\.com\/(?<repositoryId>[^\/]+\/[^\/]+)\/(?<refSpec>[^\/]+)\/[Ll][Ii][Cc][Ee][Nn][Ss][Ee]((\.|-)((md)|([Tt][Xx][Tt])|([Mm][Ii][Tt])|([Bb][Ss][Dd])))?$"),
         };
 
         public GithubService(HttpClient httpClient)

--- a/CycloneDX/Services/GithubService.cs
+++ b/CycloneDX/Services/GithubService.cs
@@ -68,8 +68,8 @@ namespace CycloneDX.Services
         private HttpClient _httpClient;
         private List<Regex> _githubRepositoryRegexes = new List<Regex>
         {
-            new Regex(@"^https?\:\/\/github\.com\/(?<repositoryId>[^\/]+\/[^\/]+)\/((blob)|(raw))\/(?<refSpec>[^\/]+)\/LICENSE(\.((md)|([Tt][Xx][Tt])|([Mm][Ii][Tt])|([Bb][Ss][Dd])))?$"),
-            new Regex(@"^https?\:\/\/raw\.githubusercontent\.com\/(?<repositoryId>[^\/]+\/[^\/]+)\/(?<refSpec>[^\/]+)\/LICENSE(\.((md)|([Tt][Xx][Tt])|([Mm][Ii][Tt])|([Bb][Ss][Dd])))?$"),
+            new Regex(@"^https?\:\/\/github\.com\/(?<repositoryId>[^\/]+\/[^\/]+)\/((blob)|(raw))\/(?<refSpec>[^\/]+)\/LICENSE((\.|-)((md)|([Tt][Xx][Tt])|([Mm][Ii][Tt])|([Bb][Ss][Dd])))?$"),
+            new Regex(@"^https?\:\/\/raw\.githubusercontent\.com\/(?<repositoryId>[^\/]+\/[^\/]+)\/(?<refSpec>[^\/]+)\/LICENSE((\.|-)((md)|([Tt][Xx][Tt])|([Mm][Ii][Tt])|([Bb][Ss][Dd])))?$"),
         };
 
         public GithubService(HttpClient httpClient)

--- a/CycloneDX/Services/GithubService.cs
+++ b/CycloneDX/Services/GithubService.cs
@@ -68,8 +68,8 @@ namespace CycloneDX.Services
         private HttpClient _httpClient;
         private List<Regex> _githubRepositoryRegexes = new List<Regex>
         {
-            new Regex(@"^https?\:\/\/github\.com\/(?<repositoryId>[^\/]+\/[^\/]+)\/((blob)|(raw))\/(?<refSpec>[^\/]+)\/LICENSE(\.((md)|([Tt][Xx][Tt])))?$"),
-            new Regex(@"^https?\:\/\/raw\.githubusercontent\.com\/(?<repositoryId>[^\/]+\/[^\/]+)\/(?<refSpec>[^\/]+)\/LICENSE(\.((md)|([Tt][Xx][Tt])))?$"),
+            new Regex(@"^https?\:\/\/github\.com\/(?<repositoryId>[^\/]+\/[^\/]+)\/((blob)|(raw))\/(?<refSpec>[^\/]+)\/LICENSE(\.((md)|([Tt][Xx][Tt])|([Mm][Ii][Tt])|([Bb][Ss][Dd])))?$"),
+            new Regex(@"^https?\:\/\/raw\.githubusercontent\.com\/(?<repositoryId>[^\/]+\/[^\/]+)\/(?<refSpec>[^\/]+)\/LICENSE(\.((md)|([Tt][Xx][Tt])|([Mm][Ii][Tt])|([Bb][Ss][Dd])))?$"),
         };
 
         public GithubService(HttpClient httpClient)

--- a/CycloneDX/Services/GithubService.cs
+++ b/CycloneDX/Services/GithubService.cs
@@ -68,7 +68,7 @@ namespace CycloneDX.Services
         private HttpClient _httpClient;
         private List<Regex> _githubRepositoryRegexes = new List<Regex>
         {
-            new Regex(@"^https?\:\/\/github\.com\/(?<repositoryId>[^\/]+\/[^\/]+)\/blob\/(?<refSpec>[^\/]+)\/LICENSE(\.((md)|(txt)))?$"),
+            new Regex(@"^https?\:\/\/github\.com\/(?<repositoryId>[^\/]+\/[^\/]+)\/((blob)|(raw))\/(?<refSpec>[^\/]+)\/LICENSE(\.((md)|(txt)))?$"),
             new Regex(@"^https?\:\/\/raw\.githubusercontent\.com\/(?<repositoryId>[^\/]+\/[^\/]+)\/(?<refSpec>[^\/]+)\/LICENSE(\.((md)|(txt)))?$"),
         };
 

--- a/CycloneDX/Services/GithubService.cs
+++ b/CycloneDX/Services/GithubService.cs
@@ -68,8 +68,8 @@ namespace CycloneDX.Services
         private HttpClient _httpClient;
         private List<Regex> _githubRepositoryRegexes = new List<Regex>
         {
-            new Regex(@"^https?\:\/\/github\.com\/(?<repositoryId>[^\/]+\/[^\/]+)\/((blob)|(raw))\/(?<refSpec>[^\/]+)\/LICENSE(\.((md)|(txt)))?$"),
-            new Regex(@"^https?\:\/\/raw\.githubusercontent\.com\/(?<repositoryId>[^\/]+\/[^\/]+)\/(?<refSpec>[^\/]+)\/LICENSE(\.((md)|(txt)))?$"),
+            new Regex(@"^https?\:\/\/github\.com\/(?<repositoryId>[^\/]+\/[^\/]+)\/((blob)|(raw))\/(?<refSpec>[^\/]+)\/LICENSE(\.((md)|([Tt][Xx][Tt])))?$"),
+            new Regex(@"^https?\:\/\/raw\.githubusercontent\.com\/(?<repositoryId>[^\/]+\/[^\/]+)\/(?<refSpec>[^\/]+)\/LICENSE(\.((md)|([Tt][Xx][Tt])))?$"),
         };
 
         public GithubService(HttpClient httpClient)


### PR DESCRIPTION
I stumbled upon a number of GitHub license urls, which seems reasonable to add support for when checking for the checking the GitHub api for license details.

These are the GitHub license urls I found that I would like to be able to extract license details about:
- https://raw.githubusercontent.com/moq/moq4/master/License.txt
- https://raw.githubusercontent.com/xunit/xunit/master/license.txt
- http://raw.github.com/NLog/NLog/master/LICENSE.txt
- https://raw.github.com/HangfireIO/Hangfire/master/LICENSE.md
- https://raw.github.com/JamesNK/Newtonsoft.Json/master/LICENSE.md
- https://raw.github.com/timrwood/moment/master/LICENSE
- https://raw.github.com/StackExchange/StackExchange.Redis/master/LICENSE
- https://raw.github.com/jkowalski/NLog/master/LICENSE.txt
- https://github.com/mmanela/chutzpah/blob/master/License.txt
- https://github.com/NancyFx/Nancy.Bootstrappers.Autofac/blob/master/license.txt
- https://github.com/NancyFx/Nancy.Bootstrappers.Ninject/blob/master/license.txt
- https://github.com/NancyFx/Nancy.Serialization.JsonNet/blob/master/license.txt
- https://github.com/NancyFx/Nancy/blob/master/license.txt
- https://github.com/ninject/ninject.extensions.childkernel/raw/master/LICENSE.txt
- https://github.com/ninject/ninject.extensions.conventions/raw/master/LICENSE.txt
- https://github.com/ninject/ninject/raw/master/LICENSE.txt
- https://github.com/DefinitelyTyped/NugetAutomation/blob/master/LICENSE.MIT
- https://github.com/dotnet/corefx/blob/master/LICENSE.TXT
- https://github.com/ariya/phantomjs/blob/master/LICENSE.BSD
- https://github.com/scottjehl/Respond/blob/master/LICENSE-MIT

I've added test cases for each of the new scenario I've encountered.