### PR TITLE
Add flexibility to Regex and add main lookup

### DIFF
--- a/CycloneDX.Tests/GithubServiceTests.cs
+++ b/CycloneDX.Tests/GithubServiceTests.cs
@@ -66,6 +66,48 @@ namespace CycloneDX.Tests
             Assert.Equal("Test License", license.Name);
         }
 
+        [Fact]
+        public async Task GitLicence_FromMainBranch()
+        {
+            var mockResponseContent = @"{
+                ""license"": {
+                    ""spdx_id"": ""LicenseSpdxId"",
+                    ""name"": ""Test License""
+                }
+            }";
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp.When("https://api.github.com/repos/CycloneDX/cyclonedx-dotnet/license?ref=main")
+                .Respond("application/json", mockResponseContent);
+            var client = mockHttp.ToHttpClient();
+            var githubService = new GithubService(client);
+
+            var license = await githubService.GetLicenseAsync("https://github.com/CycloneDX/cyclonedx-dotnet/blob/main/LICENSE").ConfigureAwait(false);
+
+            Assert.Equal("LicenseSpdxId", license.Id);
+            Assert.Equal("Test License", license.Name);
+        }
+
+        [Fact]
+        public async Task GitLicence_NonAmericanSpelling()
+        {
+            var mockResponseContent = @"{
+                ""license"": {
+                    ""spdx_id"": ""LicenseSpdxId"",
+                    ""name"": ""Test License""
+                }
+            }";
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp.When("https://api.github.com/repos/CycloneDX/cyclonedx-dotnet/license?ref=master")
+                .Respond("application/json", mockResponseContent);
+            var client = mockHttp.ToHttpClient();
+            var githubService = new GithubService(client);
+
+            var license = await githubService.GetLicenseAsync("https://github.com/CycloneDX/cyclonedx-dotnet/blob/master/LICENCE").ConfigureAwait(false);
+
+            Assert.Equal("LicenseSpdxId", license.Id);
+            Assert.Equal("Test License", license.Name);
+        }
+
         [Fact(Skip="Currently failing as GitHub license API only returns the current license")]
         public async Task GitLicence_FromVersionTag()
         {

--- a/CycloneDX/Services/GithubService.cs
+++ b/CycloneDX/Services/GithubService.cs
@@ -67,8 +67,8 @@ namespace CycloneDX.Services
         private readonly HttpClient _httpClient;
         private readonly List<Regex> _githubRepositoryRegexes = new List<Regex>
         {
-            new Regex(@"^https?\:\/\/github\.com\/(?<repositoryId>[^\/]+\/[^\/]+)\/((blob)|(raw))\/(?<refSpec>[^\/]+)\/[Ll][Ii][Cc][Ee][Nn][Ss][Ee]((\.|-)((md)|([Tt][Xx][Tt])|([Mm][Ii][Tt])|([Bb][Ss][Dd])))?$"),
-            new Regex(@"^https?\:\/\/raw\.github(usercontent)?\.com\/(?<repositoryId>[^\/]+\/[^\/]+)\/(?<refSpec>[^\/]+)\/[Ll][Ii][Cc][Ee][Nn][Ss][Ee]((\.|-)((md)|([Tt][Xx][Tt])|([Mm][Ii][Tt])|([Bb][Ss][Dd])))?$"),
+            new Regex(@"^https?\:\/\/github\.com\/(?<repositoryId>[^\/]+\/[^\/]+)\/((blob)|(raw))\/(?<refSpec>[^\/]+)\/[Ll][Ii][Cc][Ee][Nn][CcSs][Ee]((\.|-)((md)|([Tt][Xx][Tt])|([Mm][Ii][Tt])|([Bb][Ss][Dd])))?$"),
+            new Regex(@"^https?\:\/\/raw\.github(usercontent)?\.com\/(?<repositoryId>[^\/]+\/[^\/]+)\/(?<refSpec>[^\/]+)\/[Ll][Ii][Cc][Ee][Nn][CcSs][Ee]((\.|-)((md)|([Tt][Xx][Tt])|([Mm][Ii][Tt])|([Bb][Ss][Dd])))?$"),
         };
 
         public GithubService(HttpClient httpClient)
@@ -130,7 +130,7 @@ namespace CycloneDX.Services
 
             // GitHub API doesn't necessarily return the correct license for any ref other than master
             // support ticket has been raised, in the meantime will ignore non-master refs
-            if (refSpec.ToString() != "master") {return null;}
+            if (refSpec.ToString() != "master" && refSpec.ToString() != "main") {return null;}
 
             Console.WriteLine($"Retrieving GitHub license for repository {repositoryId} and ref {refSpec}");
 

--- a/CycloneDX/Services/GithubService.cs
+++ b/CycloneDX/Services/GithubService.cs
@@ -67,8 +67,8 @@ namespace CycloneDX.Services
         private readonly HttpClient _httpClient;
         private readonly List<Regex> _githubRepositoryRegexes = new List<Regex>
         {
-            new Regex(@"^https?\:\/\/github\.com\/(?<repositoryId>[^\/]+\/[^\/]+)\/((blob)|(raw))\/(?<refSpec>[^\/]+)\/[Ll][Ii][Cc][Ee][Nn][CcSs][Ee]((\.|-)((md)|([Tt][Xx][Tt])|([Mm][Ii][Tt])|([Bb][Ss][Dd])))?$"),
-            new Regex(@"^https?\:\/\/raw\.github(usercontent)?\.com\/(?<repositoryId>[^\/]+\/[^\/]+)\/(?<refSpec>[^\/]+)\/[Ll][Ii][Cc][Ee][Nn][CcSs][Ee]((\.|-)((md)|([Tt][Xx][Tt])|([Mm][Ii][Tt])|([Bb][Ss][Dd])))?$"),
+            new Regex(@"^https?\:\/\/github\.com\/(?<repositoryId>[^\/]+\/[^\/]+)\/((blob)|(raw))\/(?<refSpec>[^\/]+)\/[l][i][c][e][n][cs][e]((\.|-)((md)|([t][x][t])|([m][i][t])|([b][s][d])))?$", RegexOptions.IgnoreCase),
+            new Regex(@"^https?\:\/\/raw\.github(usercontent)?\.com\/(?<repositoryId>[^\/]+\/[^\/]+)\/(?<refSpec>[^\/]+)\/[l][i][c][e][n][cs][e]((\.|-)((md)|([t][x][t])|([m][i][t])|([b][s][d])))?$", RegexOptions.IgnoreCase),
         };
 
         public GithubService(HttpClient httpClient)
@@ -87,9 +87,9 @@ namespace CycloneDX.Services
             var userTokenBase64 = Convert.ToBase64String(userTokenBytes);
 
             var authorizationHeader = new AuthenticationHeaderValue(
-                "Basic", 
+                "Basic",
                 userTokenBase64);
-            
+
             _httpClient.DefaultRequestHeaders.Authorization = authorizationHeader;
         }
 
@@ -99,9 +99,9 @@ namespace CycloneDX.Services
             _httpClient = httpClient;
 
             var authorizationHeader = new AuthenticationHeaderValue(
-                "Bearer", 
+                "Bearer",
                 bearerToken);
-            
+
             _httpClient.DefaultRequestHeaders.Authorization = authorizationHeader;
         }
 


### PR DESCRIPTION
Adds license support for the non-American spelling. And adds support for the main branch instead of only the master.