### PR TITLE
Fix null reference in project reference resolving

### DIFF
--- a/CycloneDX/Services/ProjectFileService.cs
+++ b/CycloneDX/Services/ProjectFileService.cs
@@ -200,11 +200,17 @@ namespace CycloneDX.Services
                     {
                         if (reader.IsStartElement() && reader.Name == "ProjectReference")
                         {
-                            var relativeProjectReference =
-                                reader["Include"].Replace('\\', _fileSystem.Path.DirectorySeparatorChar);
-                            var fullProjectReference = _fileSystem.Path.Combine(projectDirectory, relativeProjectReference);
-                            var absoluteProjectReference = _fileSystem.Path.GetFullPath(fullProjectReference);
-                            projectReferences.Add(absoluteProjectReference);
+                            string includeAttribute = reader["Include"];
+
+                            if (includeAttribute != null)
+                            {
+                                var relativeProjectReference =
+                                    includeAttribute.Replace('\\', _fileSystem.Path.DirectorySeparatorChar);
+                                var fullProjectReference =
+                                    _fileSystem.Path.Combine(projectDirectory, relativeProjectReference);
+                                var absoluteProjectReference = _fileSystem.Path.GetFullPath(fullProjectReference);
+                                projectReferences.Add(absoluteProjectReference);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
**Problem:**

`ProjectFileService` relies on `ProjectReference` msbuild item to allways have `Include` attribute. 

That however doesn't need to be present in some special cases (`Update` or `Remove` attributes are possible as well - see e.g.: https://github.com/dotnet/runtime/blob/main/eng/references.targets#L19).

**Solution:**

Skipping the items without include attribute.
In ideal case the Remove should be special case handled as well - but that's outside of scope of this change