### PR TITLE
Remove unnecessary error for projects without project references

### DIFF
--- a/CycloneDX/Services/ProjectFileService.cs
+++ b/CycloneDX/Services/ProjectFileService.cs
@@ -212,7 +212,7 @@ namespace CycloneDX.Services
 
             if (projectReferences.Count == 0)
             {
-                Console.Error.WriteLine("  No project references found");
+                Console.WriteLine("  No project references found");
             }
 
             return projectReferences;


### PR DESCRIPTION
Do not write an error if a project has no project references. Fixes #520.