### PR TITLE
Address https://github.com/CycloneDX/cyclonedx-dotnet/issues/597

### DIFF
--- a/CycloneDX/Models/NugetInputModel.cs
+++ b/CycloneDX/Models/NugetInputModel.cs
@@ -31,7 +31,8 @@ namespace CycloneDX.Models
             {
                 return new NugetInputModel(baseUrl, baseUrlUserName, baseUrlUserPassword, isPasswordClearText);
             }
-            return null;
+
+            return new NugetInputModel(baseUrl);
         }
 
     }
@@ -42,6 +43,11 @@ namespace CycloneDX.Models
         public string nugetUsername { get; set; }
         public string nugetPassword { get; set; }
         public bool IsPasswordClearText { get; set; }
+
+        public NugetInputModel(string baseUrl)
+        {
+            nugetFeedUrl = baseUrl;
+        }
 
         public NugetInputModel(string baseUrl, string baseUrlUserName, string baseUrlUserPassword,
             bool isPasswordClearText)

--- a/CycloneDX/Services/NugetV3Service.cs
+++ b/CycloneDX/Services/NugetV3Service.cs
@@ -101,7 +101,7 @@ namespace CycloneDX.Services
             if (nugetInput == null || string.IsNullOrEmpty(nugetInput.nugetFeedUrl) ||
                 string.IsNullOrEmpty(nugetInput.nugetUsername) || string.IsNullOrEmpty(nugetInput.nugetPassword))
             {
-                return Repository.Factory.GetCoreV3("https://api.nuget.org/v3/index.json");
+                return Repository.Factory.GetCoreV3(nugetInput?.nugetFeedUrl ?? "https://api.nuget.org/v3/index.json");
             }
 
             var packageSource =


### PR DESCRIPTION
What happens currently: `NugetInputModel.Create` ignores the `baseUrl` argument it receives, representing the user-specified `--url` command-line argument, unless access credentials (user name / password for the alternate NuGet URL) are also specified.

What changes in this commit: `NugetInputModel.Create` stores the value of `baseUrl` regardless of whether credentials are specified or not. In turn, `NugetV3Service.SetupNugetRepository` is updated to use `baseUrl` when specified, otherwise fall back to the default value `https://api.nuget.org/v3/index.json`.

Fixes https://github.com/CycloneDX/cyclonedx-dotnet/issues/597