### PR TITLE
Additional Lookups For Licence

### DIFF
--- a/CycloneDX.Tests/GithubServiceTests.cs
+++ b/CycloneDX.Tests/GithubServiceTests.cs
@@ -402,5 +402,28 @@ namespace CycloneDX.Tests
 
             mockHttp.VerifyNoOutstandingExpectation();
         }
+
+        [Fact]
+        public async Task GitLicence_DifferentHtmlUrl()
+        {
+            var mockResponseContent = @"{
+                ""license"": {
+                    ""spdx_id"": ""LicenseSpdxId"",
+                    ""name"": ""Test License""
+                },
+                ""html_url"": ""https://licenceUrl.com""
+            }";
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp.When("https://api.github.com/repos/CycloneDX/cyclonedx-dotnet/license?ref=master")
+                .Respond("application/json", mockResponseContent);
+            var client = mockHttp.ToHttpClient();
+            var githubService = new GithubService(client);
+
+            var license = await githubService.GetLicenseAsync("https://raw.github.com/CycloneDX/cyclonedx-dotnet/master/LICENSE").ConfigureAwait(false);
+
+            Assert.Equal("LicenseSpdxId", license.Id);
+            Assert.Equal("Test License", license.Name);
+            Assert.Equal("https://licenceurl.com/", license.Url);
+        }
     }
 }

--- a/CycloneDX.Tests/GithubServiceTests.cs
+++ b/CycloneDX.Tests/GithubServiceTests.cs
@@ -425,5 +425,28 @@ namespace CycloneDX.Tests
             Assert.Equal("Test License", license.Name);
             Assert.Equal("https://licenceurl.com/", license.Url);
         }
+
+        [Fact]
+        public async Task GitLicence_NoRef()
+        {
+            var mockResponseContent = @"{
+                ""license"": {
+                    ""spdx_id"": ""LicenseSpdxId"",
+                    ""name"": ""Test License""
+                },
+                ""html_url"": ""https://licenceUrl.com""
+            }";
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp.When("https://api.github.com/repos/CycloneDX/cyclonedx-dotnet/license")
+                .Respond("application/json", mockResponseContent);
+            var client = mockHttp.ToHttpClient();
+            var githubService = new GithubService(client);
+
+            var license = await githubService.GetLicenseAsync("https://raw.github.com/CycloneDX/cyclonedx-dotnet").ConfigureAwait(false);
+
+            Assert.Equal("LicenseSpdxId", license.Id);
+            Assert.Equal("Test License", license.Name);
+            Assert.Equal("https://licenceurl.com/", license.Url);
+        }
     }
 }

--- a/CycloneDX/Services/GithubService.cs
+++ b/CycloneDX/Services/GithubService.cs
@@ -69,8 +69,8 @@ namespace CycloneDX.Services
         {
             new Regex(@"^https?\:\/\/github\.com\/(?<repositoryId>[^\/]+\/[^\/]+)\/((blob)|(raw))\/(?<refSpec>[^\/]+)\/[l][i][c][e][n][cs][e]((\.|-)((md)|([t][x][t])|([m][i][t])|([b][s][d])))?$", RegexOptions.IgnoreCase),
             new Regex(@"^https?\:\/\/raw\.github(usercontent)?\.com\/(?<repositoryId>[^\/]+\/[^\/]+)\/(?<refSpec>[^\/]+)\/[l][i][c][e][n][cs][e]((\.|-)((md)|([t][x][t])|([m][i][t])|([b][s][d])))?$", RegexOptions.IgnoreCase),
-            new Regex(@"^https?\:\/\/github\.com\/(?<repositoryId>[^\/]+\/[^\/]+).*$", RegexOptions.IgnoreCase),
-            new Regex(@"^https?\:\/\/raw\.github(usercontent)?\.com\/(?<repositoryId>[^\/]+\/[^\/]+).*$", RegexOptions.IgnoreCase)
+            new Regex(@"^https?\:\/\/github\.com\/(?<repositoryId>[^\/]+\/[^\/]+)\/?$", RegexOptions.IgnoreCase),
+            new Regex(@"^https?\:\/\/raw\.github(usercontent)?\.com\/(?<repositoryId>[^\/]+\/[^\/]+)\/?$", RegexOptions.IgnoreCase)
         };
 
         public GithubService(HttpClient httpClient)

--- a/CycloneDX/Services/GithubService.cs
+++ b/CycloneDX/Services/GithubService.cs
@@ -69,6 +69,8 @@ namespace CycloneDX.Services
         {
             new Regex(@"^https?\:\/\/github\.com\/(?<repositoryId>[^\/]+\/[^\/]+)\/((blob)|(raw))\/(?<refSpec>[^\/]+)\/[l][i][c][e][n][cs][e]((\.|-)((md)|([t][x][t])|([m][i][t])|([b][s][d])))?$", RegexOptions.IgnoreCase),
             new Regex(@"^https?\:\/\/raw\.github(usercontent)?\.com\/(?<repositoryId>[^\/]+\/[^\/]+)\/(?<refSpec>[^\/]+)\/[l][i][c][e][n][cs][e]((\.|-)((md)|([t][x][t])|([m][i][t])|([b][s][d])))?$", RegexOptions.IgnoreCase),
+            new Regex(@"^https?\:\/\/github\.com\/(?<repositoryId>[^\/]+\/[^\/]+).*$", RegexOptions.IgnoreCase),
+            new Regex(@"^https?\:\/\/raw\.github(usercontent)?\.com\/(?<repositoryId>[^\/]+\/[^\/]+).*$", RegexOptions.IgnoreCase)
         };
 
         public GithubService(HttpClient httpClient)
@@ -125,12 +127,17 @@ namespace CycloneDX.Services
 
             // License is not on GitHub, we need to abort
             if (!match.Success) return null;
-            var repositoryId = match.Groups["repositoryId"];
-            var refSpec = match.Groups["refSpec"];
+            var repositoryId = match.Groups["repositoryId"].Value;
+            string refSpec = null;
+
+            if (match.Groups["refSpec"].Success)
+            {
+                refSpec = match.Groups["refSpec"].Value;
+            }
 
             // GitHub API doesn't necessarily return the correct license for any ref other than master
             // support ticket has been raised, in the meantime will ignore non-master refs
-            if (refSpec.ToString() != "master" && refSpec.ToString() != "main") {return null;}
+            if (refSpec != null && refSpec != "master" && refSpec != "main") { return null; }
 
             Console.WriteLine($"Retrieving GitHub license for repository {repositoryId} and ref {refSpec}");
 
@@ -138,7 +145,10 @@ namespace CycloneDX.Services
             GithubLicenseRoot githubLicense = null;
             try
             {
-                githubLicense = await GetGithubLicenseAsync($"{_baseUrl}repos/{repositoryId}/license?ref={refSpec}").ConfigureAwait(false);
+                var url = string.IsNullOrWhiteSpace(refSpec) ? $"{_baseUrl}repos/{repositoryId}/license" :
+                                                               $"{_baseUrl}repos/{repositoryId}/license?ref={refSpec}";
+
+                githubLicense = await GetGithubLicenseAsync(url).ConfigureAwait(false);
             }
             catch (HttpRequestException exc)
             {

--- a/CycloneDX/Services/GithubService.cs
+++ b/CycloneDX/Services/GithubService.cs
@@ -158,7 +158,7 @@ namespace CycloneDX.Services
             {
                 Id = githubLicense.License.SpdxId,
                 Name = githubLicense.License.Name,
-                Url = licenseUrl
+                Url = githubLicense.HtmlUrl?.ToString() ?? licenseUrl
             };
         }
 

--- a/CycloneDX/Services/NugetV3Service.cs
+++ b/CycloneDX/Services/NugetV3Service.cs
@@ -192,12 +192,6 @@ namespace CycloneDX.Services
                     license = await _githubService.GetLicenseAsync(licenseUrl).ConfigureAwait(false);
                 }
 
-                var branchesToCheck = new List<string>
-                {
-                    "master",
-                    "main",
-                };
-
                 if (license == null)
                 {
                     // try repository URLs for potential that they are github
@@ -211,14 +205,7 @@ namespace CycloneDX.Services
 
                         if (license == null)
                         {
-                            foreach (var branchToCheck in branchesToCheck)
-                            {
-                                license = await _githubService.GetLicenseAsync($"{repository.Url}/blob/{branchToCheck}/licence").ConfigureAwait(false);
-                                if (license != null)
-                                {
-                                    break;
-                                }
-                            }
+                            license = await _githubService.GetLicenseAsync(repository.Url).ConfigureAwait(false);
                         }
                     }
                 }
@@ -229,14 +216,7 @@ namespace CycloneDX.Services
                     var project = nuspecModel.nuspecReader.GetProjectUrl();
                     if (!string.IsNullOrWhiteSpace(project))
                     {
-                        foreach (var branchToCheck in branchesToCheck)
-                        {
-                            license = await _githubService.GetLicenseAsync($"{project}/blob/{branchToCheck}/licence").ConfigureAwait(false);
-                            if (license != null)
-                            {
-                                break;
-                            }
-                        }
+                        license = await _githubService.GetLicenseAsync(project).ConfigureAwait(false);
                     }
                 }
 

--- a/CycloneDX/Services/NugetV3Service.cs
+++ b/CycloneDX/Services/NugetV3Service.cs
@@ -192,6 +192,12 @@ namespace CycloneDX.Services
                     license = await _githubService.GetLicenseAsync(licenseUrl).ConfigureAwait(false);
                 }
 
+                var branchesToCheck = new List<string>
+                {
+                    "master",
+                    "main",
+                };
+
                 if (license == null)
                 {
                     // try repository URLs for potential that they are github
@@ -205,11 +211,6 @@ namespace CycloneDX.Services
 
                         if (license == null)
                         {
-                            var branchesToCheck = new List<string>
-                            {
-                                "master",
-                                "main",
-                            };
                             foreach (var branchToCheck in branchesToCheck)
                             {
                                 license = await _githubService.GetLicenseAsync($"{repository.Url}/blob/{branchToCheck}/licence").ConfigureAwait(false);
@@ -217,6 +218,23 @@ namespace CycloneDX.Services
                                 {
                                     break;
                                 }
+                            }
+                        }
+                    }
+                }
+
+                if (license == null)
+                {
+                    // try project URL for potential that they are github
+                    var project = nuspecModel.nuspecReader.GetProjectUrl();
+                    if (!string.IsNullOrWhiteSpace(project))
+                    {
+                        foreach (var branchToCheck in branchesToCheck)
+                        {
+                            license = await _githubService.GetLicenseAsync($"{project}/blob/{branchToCheck}/licence").ConfigureAwait(false);
+                            if (license != null)
+                            {
+                                break;
                             }
                         }
                     }


### PR DESCRIPTION
Have seen situations whereby the licence URL isn't github (often when it's a file) and using the repository (or project) url then locates the licence

Logic now locates licence based on this order

* Expression in the package (this is where Nuget has found the licence itself)
* Licence URL node
* Repository node with commit SHA
* Repository node without ref
* Project URL

These checks all assume that the URLs are github, the github service will only check valid URLs


Secondary updates to the GitHub service:

* Use the actual licence URL for the located licence (sometimes this differs from the input URL)
* Allow a licence lookup with a base repository URL - use the current default branch licence