### PR TITLE
GitHub Performance & Edge case improvements

### DIFF
--- a/CycloneDX.Tests/GithubServiceTests.cs
+++ b/CycloneDX.Tests/GithubServiceTests.cs
@@ -15,17 +15,18 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) OWASP Foundation. All Rights Reserved.
 
+using System.Net;
 using System.Threading.Tasks;
-using Xunit;
-using RichardSzalay.MockHttp;
 using CycloneDX.Services;
+using RichardSzalay.MockHttp;
+using Xunit;
 
 namespace CycloneDX.Tests
 {
     public class GithubServiceTests
     {
         [Fact]
-        public async Task GitLicence_FromMasterBranch()
+        public async Task GitLicense_FromMasterBranch()
         {
             var mockResponseContent = @"{
                 ""license"": {
@@ -40,13 +41,13 @@ namespace CycloneDX.Tests
             var githubService = new GithubService(client);
 
             var license = await githubService.GetLicenseAsync("https://github.com/CycloneDX/cyclonedx-dotnet/blob/master/LICENSE").ConfigureAwait(false);
-            
+
             Assert.Equal("LicenseSpdxId", license.Id);
             Assert.Equal("Test License", license.Name);
         }
 
         [Fact]
-        public async Task GitLicence_FromRawMasterBranch()
+        public async Task GitLicense_FromRawMasterBranch()
         {
             var mockResponseContent = @"{
                 ""license"": {
@@ -67,7 +68,7 @@ namespace CycloneDX.Tests
         }
 
         [Fact]
-        public async Task GitLicence_FromMainBranch()
+        public async Task GitLicense_FromMainBranch()
         {
             var mockResponseContent = @"{
                 ""license"": {
@@ -88,7 +89,7 @@ namespace CycloneDX.Tests
         }
 
         [Fact]
-        public async Task GitLicence_NonAmericanSpelling()
+        public async Task GitLicense_NonAmericanSpelling()
         {
             var mockResponseContent = @"{
                 ""license"": {
@@ -108,8 +109,8 @@ namespace CycloneDX.Tests
             Assert.Equal("Test License", license.Name);
         }
 
-        [Fact(Skip="Currently failing as GitHub license API only returns the current license")]
-        public async Task GitLicence_FromVersionTag()
+        [Fact(Skip = "Currently failing as GitHub license API only returns the current license")]
+        public async Task GitLicense_FromVersionTag()
         {
             var mockResponseContent = @"{
                 ""license"": {
@@ -124,13 +125,13 @@ namespace CycloneDX.Tests
             var githubService = new GithubService(client);
 
             var license = await githubService.GetLicenseAsync("https://github.com/CycloneDX/cyclonedx-dotnet/blob/v1.2.3/LICENSE").ConfigureAwait(false);
-            
+
             Assert.Equal("LicenseSpdxId", license.Id);
             Assert.Equal("Test License", license.Name);
         }
 
         [Fact]
-        public async Task GitLicence_FromMarkdownExtensionLicense()
+        public async Task GitLicense_FromMarkdownExtensionLicense()
         {
             var mockResponseContent = @"{
                 ""license"": {
@@ -145,13 +146,13 @@ namespace CycloneDX.Tests
             var githubService = new GithubService(client);
 
             var license = await githubService.GetLicenseAsync("https://github.com/CycloneDX/cyclonedx-dotnet/blob/master/LICENSE.md").ConfigureAwait(false);
-            
+
             Assert.Equal("LicenseSpdxId", license.Id);
             Assert.Equal("Test License", license.Name);
         }
 
         [Fact]
-        public async Task GitLicence_FromTextExtensionLicense()
+        public async Task GitLicense_FromTextExtensionLicense()
         {
             var mockResponseContent = @"{
                 ""license"": {
@@ -166,13 +167,13 @@ namespace CycloneDX.Tests
             var githubService = new GithubService(client);
 
             var license = await githubService.GetLicenseAsync("https://github.com/CycloneDX/cyclonedx-dotnet/blob/master/LICENSE.txt").ConfigureAwait(false);
-            
+
             Assert.Equal("LicenseSpdxId", license.Id);
             Assert.Equal("Test License", license.Name);
         }
 
         [Fact]
-        public async Task GitLicence_FromUpperCaseTextExtensionLicense()
+        public async Task GitLicense_FromUpperCaseTextExtensionLicense()
         {
             var mockResponseContent = @"{
                 ""license"": {
@@ -193,7 +194,7 @@ namespace CycloneDX.Tests
         }
 
         [Fact]
-        public async Task GitLicence_FromBsdExtensionLicense()
+        public async Task GitLicense_FromBsdExtensionLicense()
         {
             var mockResponseContent = @"{
                 ""license"": {
@@ -214,7 +215,7 @@ namespace CycloneDX.Tests
         }
 
         [Fact]
-        public async Task GitLicence_FromUpperCaseBsdExtensionLicense()
+        public async Task GitLicense_FromUpperCaseBsdExtensionLicense()
         {
             var mockResponseContent = @"{
                 ""license"": {
@@ -235,7 +236,7 @@ namespace CycloneDX.Tests
         }
 
         [Fact]
-        public async Task GitLicence_FromMitExtensionLicense()
+        public async Task GitLicense_FromMitExtensionLicense()
         {
             var mockResponseContent = @"{
                 ""license"": {
@@ -256,7 +257,7 @@ namespace CycloneDX.Tests
         }
 
         [Fact]
-        public async Task GitLicence_FromUpperCaseMitExtensionLicense()
+        public async Task GitLicense_FromUpperCaseMitExtensionLicense()
         {
             var mockResponseContent = @"{
                 ""license"": {
@@ -277,7 +278,7 @@ namespace CycloneDX.Tests
         }
 
         [Fact]
-        public async Task GitLicence_FromLicenseNameWithHyphenLicenseId()
+        public async Task GitLicense_FromLicenseNameWithHyphenLicenseId()
         {
             var mockResponseContent = @"{
                 ""license"": {
@@ -298,7 +299,7 @@ namespace CycloneDX.Tests
         }
 
         [Fact]
-        public async Task GitLicence_FromLicenseFileWithPascalCaseFileName()
+        public async Task GitLicense_FromLicenseFileWithPascalCaseFileName()
         {
             var mockResponseContent = @"{
                 ""license"": {
@@ -319,7 +320,7 @@ namespace CycloneDX.Tests
         }
 
         [Fact]
-        public async Task GitLicence_FromLicenseFileWithLowerCaseFileName()
+        public async Task GitLicense_FromLicenseFileWithLowerCaseFileName()
         {
             var mockResponseContent = @"{
                 ""license"": {
@@ -340,7 +341,7 @@ namespace CycloneDX.Tests
         }
 
         [Fact]
-        public async Task GitLicence_FromGithubUserContent()
+        public async Task GitLicense_FromGithubUserContent()
         {
             var mockResponseContent = @"{
                 ""license"": {
@@ -355,13 +356,13 @@ namespace CycloneDX.Tests
             var githubService = new GithubService(client);
 
             var license = await githubService.GetLicenseAsync("https://raw.githubusercontent.com/CycloneDX/cyclonedx-dotnet/master/LICENSE").ConfigureAwait(false);
-            
+
             Assert.Equal("LicenseSpdxId", license.Id);
             Assert.Equal("Test License", license.Name);
         }
 
         [Fact]
-        public async Task GitLicence_FromRawGithub()
+        public async Task GitLicense_FromRawGithub()
         {
             var mockResponseContent = @"{
                 ""license"": {
@@ -448,7 +449,7 @@ namespace CycloneDX.Tests
         }
 
         [Fact]
-        public async Task GitLicence_DifferentHtmlUrl()
+        public async Task GitLicense_DifferentHtmlUrl()
         {
             var mockResponseContent = @"{
                 ""license"": {
@@ -471,7 +472,7 @@ namespace CycloneDX.Tests
         }
 
         [Fact]
-        public async Task GitLicence_NoRef()
+        public async Task GitLicense_NoRef()
         {
             var mockResponseContent = @"{
                 ""license"": {

--- a/CycloneDX.Tests/GithubServiceTests.cs
+++ b/CycloneDX.Tests/GithubServiceTests.cs
@@ -382,6 +382,50 @@ namespace CycloneDX.Tests
         }
 
         [Fact]
+        public async Task GitLicense_FromSshGithub()
+        {
+            var mockResponseContent = @"{
+                ""license"": {
+                    ""spdx_id"": ""LicenseSpdxId"",
+                    ""name"": ""Test License""
+                }
+            }";
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp.When("https://api.github.com/repos/CycloneDX/cyclonedx-dotnet/license")
+                .Respond("application/json", mockResponseContent);
+            var client = mockHttp.ToHttpClient();
+            var githubService = new GithubService(client);
+
+            var license = await githubService.GetLicenseAsync("git@github.com/CycloneDX/cyclonedx-dotnet.git").ConfigureAwait(false);
+
+            Assert.Equal("LicenseSpdxId", license.Id);
+            Assert.Equal("Test License", license.Name);
+        }
+
+        [Fact]
+        public async Task GitLicense_FromGithubWithDotGit()
+        {
+            var mockResponseContent = @"{
+                ""license"": {
+                    ""spdx_id"": ""LicenseSpdxId"",
+                    ""name"": ""Test License""
+                }
+            }";
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp.When("https://api.github.com/repos/CycloneDX/cyclonedx-dotnet.git/license")
+                .Respond(HttpStatusCode.NotFound);
+            mockHttp.When("https://api.github.com/repos/CycloneDX/cyclonedx-dotnet/license")
+                .Respond("application/json", mockResponseContent);
+            var client = mockHttp.ToHttpClient();
+            var githubService = new GithubService(client);
+
+            var license = await githubService.GetLicenseAsync("https://github.com/CycloneDX/cyclonedx-dotnet.git").ConfigureAwait(false);
+
+            Assert.Equal("LicenseSpdxId", license.Id);
+            Assert.Equal("Test License", license.Name);
+        }
+
+        [Fact]
         public async Task GetLicense_AddsAuthorizationHeader()
         {
             var mockResponseContent = @"{

--- a/CycloneDX.Tests/GithubServiceTests.cs
+++ b/CycloneDX.Tests/GithubServiceTests.cs
@@ -397,7 +397,7 @@ namespace CycloneDX.Tests
             var client = mockHttp.ToHttpClient();
             var githubService = new GithubService(client);
 
-            var license = await githubService.GetLicenseAsync("git@github.com/CycloneDX/cyclonedx-dotnet.git").ConfigureAwait(false);
+            var license = await githubService.GetLicenseAsync("git@github.com:CycloneDX/cyclonedx-dotnet.git").ConfigureAwait(false);
 
             Assert.Equal("LicenseSpdxId", license.Id);
             Assert.Equal("Test License", license.Name);

--- a/CycloneDX.Tests/NugetV3ServiceTests.cs
+++ b/CycloneDX.Tests/NugetV3ServiceTests.cs
@@ -101,8 +101,7 @@ namespace CycloneDX.Tests
                 mockFileSystem,
                 new List<string> { XFS.Path(@"c:\nugetcache") },
                 new Mock<IGithubService>().Object,
-                new NullLogger(),false);
-
+                new NullLogger(), false);
 
             var component = await nugetService.GetComponentAsync("testpackage", "1.0.0", Component.ComponentScope.Required).ConfigureAwait(false);
 
@@ -177,13 +176,11 @@ namespace CycloneDX.Tests
         [Fact]
         public async Task GetComponentFromNugetOrgReturnsComponent()
         {
-
             var nugetService = new NugetV3Service(null,
                 new MockFileSystem(),
                 new List<string> { XFS.Path(@"c:\nugetcache") },
                 new Mock<IGithubService>().Object,
                 new NullLogger(), false);
-
 
             var packageName = "Newtonsoft.Json";
             var packageVersion = "13.0.1";
@@ -202,7 +199,7 @@ namespace CycloneDX.Tests
                 new MockFileSystem(),
                 new List<string> { XFS.Path(@"c:\nugetcache") },
                 new Mock<IGithubService>().Object,
-                new NullLogger(),true);
+                new NullLogger(), true);
 
             var packageName = "Newtonsoft.Json";
             var packageVersion = "13.0.1";
@@ -339,7 +336,7 @@ namespace CycloneDX.Tests
         }
 
         [Fact]
-        public async Task GetComponent_GitHubLicenseLookup_FromRepository_WhenLicenceInvalid_ReturnsComponent()
+        public async Task GetComponent_GitHubLicenseLookup_FromRepository_WhenLicenseInvalid_ReturnsComponent()
         {
             var nuspecFileContents = @"<?xml version=""1.0"" encoding=""utf-8""?>
                 <package xmlns=""http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd"">

--- a/CycloneDX/CycloneDX.csproj
+++ b/CycloneDX/CycloneDX.csproj
@@ -9,6 +9,7 @@
     <PackAsTool>true</PackAsTool>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <ToolCommandName>dotnet-CycloneDX</ToolCommandName>
+    <_SkipUpgradeNetAnalyzersNuGetWarning>true</_SkipUpgradeNetAnalyzersNuGetWarning>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OsEnvironment )'=='windows'">
@@ -20,7 +21,7 @@
   <PropertyGroup Condition="'$(OsEnvironment )'=='linux'">
     <DefineConstants>Linux</DefineConstants>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">

--- a/CycloneDX/Services/GithubService.cs
+++ b/CycloneDX/Services/GithubService.cs
@@ -139,16 +139,11 @@ namespace CycloneDX.Services
             // support ticket has been raised, in the meantime will ignore non-master refs
             if (refSpec != null && refSpec != "master" && refSpec != "main") { return null; }
 
-            Console.WriteLine($"Retrieving GitHub license for repository {repositoryId} and ref {refSpec}");
-
             // Try getting license for the specified version
             GithubLicenseRoot githubLicense = null;
             try
             {
-                var url = string.IsNullOrWhiteSpace(refSpec) ? $"{_baseUrl}repos/{repositoryId}/license" :
-                                                               $"{_baseUrl}repos/{repositoryId}/license?ref={refSpec}";
-
-                githubLicense = await GetGithubLicenseAsync(url).ConfigureAwait(false);
+                githubLicense = await GetGithubLicenseAsync(repositoryId, refSpec).ConfigureAwait(false);
             }
             catch (HttpRequestException exc)
             {
@@ -157,7 +152,8 @@ namespace CycloneDX.Services
                 throw new GitHubLicenseResolutionException("GitHub license resolution failed.", exc);
             }
 
-            if (githubLicense == null) {
+            if (githubLicense == null)
+            {
                 Console.WriteLine($"No license found on GitHub for repository {repositoryId} using ref {refSpec}");
 
                 return null;
@@ -177,8 +173,20 @@ namespace CycloneDX.Services
         /// </summary>
         /// <param name="githubLicenseUrl"></param>
         /// <returns></returns>
-        private async Task<GithubLicenseRoot> GetGithubLicenseAsync(string githubLicenseUrl)
+        private async Task<GithubLicenseRoot> GetGithubLicenseAsync(string repositoryId, string refSpec)
         {
+            string githubLicenseUrl;
+            if (string.IsNullOrWhiteSpace(refSpec))
+            {
+                githubLicenseUrl = $"{_baseUrl}repos/{repositoryId}/license";
+                Console.WriteLine($"Retrieving GitHub license for repository {repositoryId} - URL: {githubLicenseUrl}");
+            }
+            else
+            {
+                githubLicenseUrl = $"{_baseUrl}repos/{repositoryId}/license?ref={refSpec}";
+                Console.WriteLine($"Retrieving GitHub license for repository {repositoryId} and ref {refSpec} - URL: {githubLicenseUrl}");
+            }
+
             var githubLicenseRequestMessage = new HttpRequestMessage(HttpMethod.Get, githubLicenseUrl);
 
             // Add needed headers
@@ -201,6 +209,11 @@ namespace CycloneDX.Services
             {
                 Console.Error.WriteLine("GitHub API rate limit exceeded.");
                 throw new GitHubApiRateLimitExceededException("GitHub API rate limit exceeded http status code 403");
+            }
+            else if (githubResponse.StatusCode == System.Net.HttpStatusCode.NotFound && repositoryId.EndsWith(".git", StringComparison.InvariantCultureIgnoreCase))
+            {
+                Console.WriteLine($"GitHub API failed with status code NotFound - will try again without '.git' on the repository name");
+                return await GetGithubLicenseAsync(repositoryId.Substring(0, repositoryId.Length - 4), refSpec);
             }
             else
             {

--- a/CycloneDX/Services/GithubService.cs
+++ b/CycloneDX/Services/GithubService.cs
@@ -70,7 +70,8 @@ namespace CycloneDX.Services
             new Regex(@"^https?\:\/\/github\.com\/(?<repositoryId>[^\/]+\/[^\/]+)\/((blob)|(raw))\/(?<refSpec>[^\/]+)\/[l][i][c][e][n][cs][e]((\.|-)((md)|([t][x][t])|([m][i][t])|([b][s][d])))?$", RegexOptions.IgnoreCase),
             new Regex(@"^https?\:\/\/raw\.github(usercontent)?\.com\/(?<repositoryId>[^\/]+\/[^\/]+)\/(?<refSpec>[^\/]+)\/[l][i][c][e][n][cs][e]((\.|-)((md)|([t][x][t])|([m][i][t])|([b][s][d])))?$", RegexOptions.IgnoreCase),
             new Regex(@"^https?\:\/\/github\.com\/(?<repositoryId>[^\/]+\/[^\/]+)\/?$", RegexOptions.IgnoreCase),
-            new Regex(@"^https?\:\/\/raw\.github(usercontent)?\.com\/(?<repositoryId>[^\/]+\/[^\/]+)\/?$", RegexOptions.IgnoreCase)
+            new Regex(@"^https?\:\/\/raw\.github(usercontent)?\.com\/(?<repositoryId>[^\/]+\/[^\/]+)\/?$", RegexOptions.IgnoreCase),
+            new Regex(@"^git\@github\.com:(?<repositoryId>[^\/]+\/[^\/]+)\/?$", RegexOptions.IgnoreCase)
         };
 
         public GithubService(HttpClient httpClient)


### PR DESCRIPTION
* If getting licence and repository URL ends ".git" and you get a NOTFOUND (404) try again without ".git"
* Add support for the URL being a SSH URL (git@github.com/owner/repo.git)
* Add Cache of URL to licence so if same URL requested, return from the previous result rather than getting again from GitHub