### PR TITLE
GitHub rate limit error fix

### DIFF
--- a/CycloneDX/Program.cs
+++ b/CycloneDX/Program.cs
@@ -188,21 +188,25 @@ namespace CycloneDX
             if (!(disableGithubLicenses || disableGithubLicensesDeprecated))
             {
                 // GitHubService requires its own HttpClient as it adds a default authorization header
+                HttpClient httpClient = new HttpClient(new HttpClientHandler {
+                    AllowAutoRedirect = false
+                });
+                
                 if (!string.IsNullOrEmpty(githubBearerToken))
                 {
-                    githubService = new GithubService(new HttpClient(), githubBearerToken);
+                    githubService = new GithubService(httpClient, githubBearerToken);
                 }
                 else if (!string.IsNullOrEmpty(githubBearerTokenDeprecated))
                 {
-                    githubService = new GithubService(new HttpClient(), githubBearerTokenDeprecated);
+                    githubService = new GithubService(httpClient, githubBearerTokenDeprecated);
                 }
                 else if (!string.IsNullOrEmpty(githubUsername))
                 {
-                    githubService = new GithubService(new HttpClient(), githubUsername, githubToken);
+                    githubService = new GithubService(httpClient, githubUsername, githubToken);
                 }
                 else if (!string.IsNullOrEmpty(githubUsernameDeprecated))
                 {
-                    githubService = new GithubService(new HttpClient(), githubUsernameDeprecated, githubTokenDeprecated);
+                    githubService = new GithubService(httpClient, githubUsernameDeprecated, githubTokenDeprecated);
                 }
                 else
                 {

--- a/CycloneDX/Services/GithubService.cs
+++ b/CycloneDX/Services/GithubService.cs
@@ -179,14 +179,18 @@ namespace CycloneDX.Services
         /// <returns></returns>
         private async Task<GithubLicenseRoot> GetGithubLicenseAsync(string githubLicenseUrl)
         {
-            var githubLicenseRequestMessage = new HttpRequestMessage(HttpMethod.Get, githubLicenseUrl);
-
-            // Add needed headers
-            githubLicenseRequestMessage.Headers.UserAgent.ParseAdd("CycloneDX/1.0");
-            githubLicenseRequestMessage.Headers.Accept.ParseAdd("application/json");
+            var githubLicenseRequestMessage = ConfigureGithubRequestMessage(githubLicenseUrl);
 
             // Send HTTP request and handle its response
             var githubResponse = await _httpClient.SendAsync(githubLicenseRequestMessage).ConfigureAwait(false);
+            
+            
+            if (githubResponse.StatusCode == System.Net.HttpStatusCode.MovedPermanently && githubResponse.Headers.Location != null) 
+            {
+                // Authorization header won't be sent in redirect requests
+                githubLicenseRequestMessage = ConfigureGithubRequestMessage(githubResponse.Headers.Location.ToString());
+                githubResponse = await httpClient.SendAsync(githubLicenseRequestMessage).ConfigureAwait(false);
+            }
             if (githubResponse.IsSuccessStatusCode)
             {
                 // License found, extract data
@@ -209,5 +213,14 @@ namespace CycloneDX.Services
                 return null;
             }
         }
+        private HttpRequestMessage ConfigureGithubRequestMessage(String githubUrl) {
+            var githubRequestMessage = new HttpRequestMessage(HttpMethod.Get, githubUrl);
+
+            // Add needed headers
+            githubRequestMessage.Headers.UserAgent.ParseAdd("CycloneDX/1.0");
+            githubRequestMessage.Headers.Accept.ParseAdd("application/json");
+
+            return githubRequestMessage;
+	    }
     }
 }

--- a/CycloneDX/Services/GithubService.cs
+++ b/CycloneDX/Services/GithubService.cs
@@ -184,7 +184,6 @@ namespace CycloneDX.Services
             // Send HTTP request and handle its response
             var githubResponse = await _httpClient.SendAsync(githubLicenseRequestMessage).ConfigureAwait(false);
             
-            
             if (githubResponse.StatusCode == System.Net.HttpStatusCode.MovedPermanently && githubResponse.Headers.Location != null) 
             {
                 // Authorization header won't be sent in redirect requests


### PR DESCRIPTION
HttpClient won't send Authorization header in redirect requests. Rate limit error will be occured even if credentials were provided.