### PR TITLE
fix: populate authors as Author, not Publisher

### DIFF
--- a/CycloneDX/Services/NugetV3Service.cs
+++ b/CycloneDX/Services/NugetV3Service.cs
@@ -279,7 +279,7 @@ namespace CycloneDX.Services
 
         private static Component SetupComponentProperties(Component component, NuspecModel nuspecModel)
         {
-            component.Publisher = nuspecModel.nuspecReader.GetAuthors();
+            component.Author = nuspecModel.nuspecReader.GetAuthors();
             component.Copyright = nuspecModel.nuspecReader.GetCopyright();
             // this prevents empty copyright values in the JSON BOM
             if (string.IsNullOrEmpty(component.Copyright))


### PR DESCRIPTION
The Author and Publisher are distinct fields, and feels like this should be used for Author.

https://cyclonedx.org/docs/1.4/json/#components_items_author 
https://cyclonedx.org/docs/1.4/json/#components_items_publisher

/cc @fgreinacher