### PR TITLE
use System.CommandLine instead of McMaster.Extensions.CommandLineUtils

### DIFF
--- a/CycloneDX.Tests/ProgramTests.cs
+++ b/CycloneDX.Tests/ProgramTests.cs
@@ -31,19 +31,19 @@ namespace CycloneDX.Tests
     public class ProgramTests
     {
         [Fact]
-        public async Task CallingCycloneDX_WithoutSolutionFile_ReturnsSolutionOrProjectFileParameterMissingExitCode()
+        public async Task CallingCycloneDX_WithoutSolutionFile_ReturnsInvalidOptionsExitCode()
         {
             var exitCode = await Program.Main(new string[] {}).ConfigureAwait(false);
 
-            Assert.Equal((int)ExitCode.SolutionOrProjectFileParameterMissing, exitCode);
+            Assert.Equal((int)ExitCode.InvalidOptions, exitCode);
         }
 
         [Fact]
-        public async Task CallingCycloneDX_WithoutOutputDirectory_ReturnsOutputDirectoryParameterMissingExitCode()
+        public async Task CallingCycloneDX_WithoutOutputDirectory_ReturnsInvalidOptionsExitCode()
         {
             var exitCode = await Program.Main(new string[] { XFS.Path(@"c:\SolutionPath\Solution.sln") }).ConfigureAwait(false);
 
-            Assert.Equal((int)ExitCode.OutputDirectoryParameterMissing, exitCode);
+            Assert.Equal((int)ExitCode.InvalidOptions, exitCode);
         }
 
         [Fact]

--- a/CycloneDX/CycloneDX.csproj
+++ b/CycloneDX/CycloneDX.csproj
@@ -29,7 +29,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!--<PackageReference Include="McMaster.Extensions.CommandLineUtils" />-->
     <PackageReference Include="NuGet.Protocol" />
     <PackageReference Include="System.IO.Abstractions" />
     <PackageReference Include="CycloneDX.Core" />

--- a/CycloneDX/CycloneDX.csproj
+++ b/CycloneDX/CycloneDX.csproj
@@ -23,14 +23,18 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="CycloneDX.Tests" />
+    <InternalsVisibleTo Include="CycloneDX.IntegrationTests" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" />
+    <!--<PackageReference Include="McMaster.Extensions.CommandLineUtils" />-->
     <PackageReference Include="NuGet.Protocol" />
     <PackageReference Include="System.IO.Abstractions" />
     <PackageReference Include="CycloneDX.Core" />
     <PackageReference Include="NuGet.ProjectModel" />
+    <PackageReference Include="System.CommandLine" />
+    <PackageReference Include="System.CommandLine.NamingConventionBinder" />
   </ItemGroup>
 </Project>

--- a/CycloneDX/ExitCode.cs
+++ b/CycloneDX/ExitCode.cs
@@ -20,9 +20,9 @@ namespace CycloneDX
     {
         OK,
         InvalidOptions,
-        SolutionOrProjectFileParameterMissing,
-        OutputDirectoryParameterMissing,
-        GitHubParameterMissing,
+//        SolutionOrProjectFileParameterMissing,
+//        OutputDirectoryParameterMissing,
+//        GitHubParameterMissing,
         InvalidGitHubApiCredentials,
         GitHubApiRateLimitExceeded,
         LocalPackageCacheError,

--- a/CycloneDX/Program.cs
+++ b/CycloneDX/Program.cs
@@ -22,110 +22,18 @@ using System.IO;
 using System.IO.Abstractions;
 using System.Net.Http;
 using System.Threading.Tasks;
-using McMaster.Extensions.CommandLineUtils;
 using CycloneDX.Models;
 using CycloneDX.Services;
 using System.Reflection;
 using System.Linq;
 using CycloneDX.Interfaces;
-using System.Text.Json;
-
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("CycloneDX.Tests")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("CycloneDX.IntegrationTests")]
+using System.CommandLine;
+using System.CommandLine.NamingConventionBinder;
 
 namespace CycloneDX
 {
-    [Command(Name = "dotnet cyclonedx", FullName = "A .NET Core global tool which creates CycloneDX Software Bill-of-Materials (SBOM) from .NET projects.")]
-    class Program {
-        #region Options
-        [Option(Description = "Output the tool version and exit", ShortName = "v", LongName = "version")]
-        bool version { get; }
-
-        [Argument(0, Name = "path", Description = "The path to a .sln, .csproj, .fsproj, .vbproj, or packages.config file or the path to a directory which will be recursively analyzed for packages.config files")]
-        string SolutionOrProjectFile { get; set; }
-
-        [Option(Description = "The target framework to use. If not defined, all will be aggregated.", ShortName = "tfm", LongName = "framework")]
-        string framework { get; }
-
-        [Option(Description = "The runtime to use. If not defined, all will be aggregated.", ShortName = "rt", LongName = "runtime")]
-        string runtime { get; }
-
-        [Option(Description = "The directory to write the BOM", ShortName = "o", LongName = "out")]
-        string outputDirectory { get; }
-
-        [Option(Description = "Optionally provide a filename for the BOM (default: bom.xml or bom.json)", ShortName = "f", LongName = "filename")]
-        string outputFilename { get; }
-
-        [Option(Description = "Produce a JSON BOM instead of XML", ShortName = "j", LongName = "json")]
-        bool json { get; }
-
-        [Option(Description = "Exclude development dependencies from the BOM", ShortName = "d", LongName = "exclude-dev")]
-        bool excludeDev { get; }
-
-        [Option(Description = "Exclude test projects from the BOM", ShortName = "t", LongName = "exclude-test-projects")]
-        bool excludetestprojects { get; }
-
-        [Option(Description = "Alternative NuGet repository URL to https://<yoururl>/nuget/<yourrepository>/v3/index.json", ShortName = "u", LongName = "url")]
-        string baseUrl { get; set; }
-
-        [Option(Description = "Alternative NuGet repository username", ShortName = "us", LongName = "baseUrlUsername")]
-        string baseUrlUserName { get; set; }
-
-        [Option(Description = "Alternative NuGet repository username password/apikey", ShortName = "usp", LongName = "baseUrlUserPassword")]
-        string baseUrlUserPassword { get; set; }
-
-        [Option(Description = "Alternative NuGet repository password is cleartext", ShortName = "uspct", LongName = "isBaseUrlPasswordClearText")]
-        bool isPasswordClearText { get; set; }
-
-        [Option(Description = "To be used with a single project file, it will recursively scan project references of the supplied project file", ShortName = "r", LongName = "recursive")]
-        bool scanProjectReferences { get; set; }
-
-        [Option(Description = "DEPRECATED: Optionally omit the serial number from the resulting BOM", ShowInHelpText = false, ShortName = "nsdeprecated", LongName = "noSerialNumber")]
-        bool noSerialNumberDeprecated { get; set; }
-        [Option(Description = "Optionally omit the serial number from the resulting BOM", ShortName = "ns", LongName = "no-serial-number")]
-        bool noSerialNumber { get; set; }
-
-        [Option(Description = "DEPRECATED: Optionally provide a GitHub username for license resolution. If set you also need to provide a GitHub personal access token", ShowInHelpText = false, ShortName = "gudeprecated", LongName = "githubUsername")]
-        string githubUsernameDeprecated { get; set; }
-        [Option(Description = "Optionally provide a GitHub username for license resolution. If set you also need to provide a GitHub personal access token", ShortName = "gu", LongName = "github-username")]
-        string githubUsername { get; set; }
-        [Option(Description = "DEPRECATED: Optionally provide a GitHub personal access token for license resolution. If set you also need to provide a GitHub username", ShowInHelpText = false, ShortName = "gtdeprecated", LongName = "githubToken")]
-        string githubTokenDeprecated { get; set; }
-        [Option(Description = "Optionally provide a GitHub personal access token for license resolution. If set you also need to provide a GitHub username", ShortName = "gt", LongName = "github-token")]
-        string githubToken { get; set; }
-        [Option(Description = "DEPRECATED: Optionally provide a GitHub bearer token for license resolution. This is useful in GitHub actions", ShowInHelpText = false, ShortName = "gbtdeprecated", LongName = "githubBearerToken")]
-        string githubBearerTokenDeprecated { get; set; }
-        [Option(Description = "Optionally provide a GitHub bearer token for license resolution. This is useful in GitHub actions", ShortName = "gbt", LongName = "github-bearer-token")]
-        string githubBearerToken { get; set; }
-        [Option(Description = "DEPRECATED: Optionally disable GitHub license resolution", ShowInHelpText = false, ShortName = "dgldeprecated", LongName = "disableGithubLicenses")]
-        bool disableGithubLicensesDeprecated { get; set; }
-        [Option(Description = "Optionally disable GitHub license resolution", ShortName = "dgl", LongName = "disable-github-licenses")]
-        bool disableGithubLicenses { get; set; }
-
-        [Option(Description = "Optionally disable package restore", ShortName = "dpr", LongName = "disable-package-restore")]
-        bool disablePackageRestore { get; set; }
-
-        [Option(Description = "Optionally disable hash computation for packages", ShortName = "dhc", LongName = "disable-hash-computation")]
-        bool disableHashComputation { get; set; }
-
-        [Option(Description = "dotnet command timeout in milliseconds (primarily used for long dotnet restore operations)", ShortName = "dct", LongName = "dotnet-command-timeout")]
-        int dotnetCommandTimeout { get; set; } = 300000;
-
-        [Option(Description = "Optionally provide a folder for customized build environment. Required if folder 'obj' is relocated.", ShortName = "biop", LongName = "base-intermediate-output-path")]
-        public string baseIntermediateOutputPath { get; }
-
-        [Option(Description = "Optionally provide a metadata template which has project specific details.", ShortName = "imp", LongName = "import-metadata-path")]
-        public string importMetadataPath { get; }
-
-        [Option(Description = "Override the autogenerated BOM metadata component name.", ShortName = "sn", LongName = "set-name")]
-        public string setName { get; }
-
-        [Option(Description = "Override the default BOM metadata component version (defaults to 0.0.0).", ShortName = "sv", LongName = "set-version")]
-        public string setVersion { get; }
-
-        [Option(Description = "Override the default BOM metadata component type (defaults to application).", ShortName = "st", LongName = "set-type")]
-        public Component.Classification setType { get; }
-#endregion options
+    public static class Program
+    {
 
         internal static IFileSystem fileSystem = new FileSystem();
         internal static readonly IJsonDocs jsonDoc = new JsonDocs();
@@ -136,43 +44,98 @@ namespace CycloneDX
         internal static readonly IProjectFileService projectFileService = new ProjectFileService(fileSystem, dotnetUtilsService, packagesFileService, projectAssetsFileService);
         internal static ISolutionFileService solutionFileService = new SolutionFileService(fileSystem, projectFileService);
 
-        public static async Task<int> Main(string[] args)
-            => await CommandLineApplication.ExecuteAsync<Program>(args).ConfigureAwait(false);
+        #region alias
+        internal static string SolutionOrProjectFile;
+        internal static string outputDirectory;
+        internal static string outputFilename;
+        internal static string baseUrl;
+        internal static bool scanProjectReferences;
+        internal static int dotnetCommandTimeout;
+        internal static bool isPasswordClearText;
 
-        async Task<int> OnExecuteAsync(CommandLineApplication app) {
-            if (version)
+        #endregion alias
+
+        public static async Task<int> Main(string[] args)
+        {
+
+            var root = new RootCommand()
             {
-                Console.WriteLine(Assembly.GetExecutingAssembly().GetName().Version?.ToString());
-                return 0;
-            }
+            new Argument<string>("path", description: "The path to a .sln, .csproj, .fsproj, .vbproj, or packages.config file or the path to a directory which will be recursively analyzed for packages.config files."  ),
+            new Option<string?>(new[] { "--framework", "-tfm" }, "The target framework to use. If not defined, all will be aggregated."),
+            new Option<string?>(new[] { "--runtime", "-rt" }, "The runtime to use. If not defined, all will be aggregated."),
+            new Option<string>(new[] { "--output", "-o" }, description: "The directory to write the BOM"),
+            new Option<string?>(new[] { "--filename", "-f" }, "Optionally provide a filename for the BOM (default: bom.xml or bom.json"),
+            new Option<bool?>(new[] { "--json", "-j" }, "Produce a JSON BOM instead of XML"),
+            new Option<bool?>(new[] { "--exclude-dev", "-d" }, "Exclude development dependencies from the BOM"),
+            new Option<bool?>(new[] { "--exclude-test-projects", "-t" }, "Exclude test projects from the BOM"),
+            new Option<string?>(new[] { "--url", "-u" }, "Alternative NuGet repository URL to https://<yoururl>/nuget/<yourrepository>/v3/index.json"),
+            new Option<string?>(new[] { "--baseUrlUsername", "-us" }, "Alternative NuGet repository username"),
+            new Option<string?>(new[] { "--baseUrlUserPassword", "-usp" }, "Alternative NuGet repository username password/apikey"),
+            new Option<bool?>(new[] { "--isBaseUrlPasswordClearText", "-uspct" }, "Alternative NuGet repository password is cleartext"),
+            new Option<bool?>(new[] { "--recursive", "-r" }, "To be used with a single project file, it will recursively scan project references of the supplied project file"),
+            new Option<string?>(new[] { "--no-serial-number", "-ns" }, "Optionally omit the serial number from the resulting BOM"),
+            new Option<string?>(new[] { "--github-username", "-gu" }, "Optionally provide a GitHub username for license resolution. If set you also need to provide a GitHub personal access token"),
+            new Option<string?>(new[] { "--github-token", "-gt" }, "Optionally provide a GitHub personal access token for license resolution. If set you also need to provide a GitHub username"),
+            new Option<string?>(new[] { "--github-bearer-token", "-gbt" }, "Optionally provide a GitHub bearer token for license resolution. This is useful in GitHub actions"),
+            new Option<bool?>(new[] { "--disable-github-licenses", "-dgl" }, "Optionally disable GitHub license resolution"),
+            new Option<bool?>(new[] { "--disable-package-restore", "-dpr" }, "Optionally disable package restore"),
+            new Option<bool?>(new[] { "--disable-hash-computation", "-dhc" }, "Optionally disable hash computation for packages"),
+            new Option<int>(new[] { "--dotnet-command-timeout", "-dct" }, description: "dotnet command timeout in milliseconds (primarily used for long dotnet restore operations)", getDefaultValue: () => 300000),
+            new Option<string?>(new[] { "--base-intermediate-output-path", "-biop" }, "Optionally provide a folder for customized build environment. Required if folder 'obj' is relocated."),
+            new Option<string?>(new[] { "--import-metadata-path", "-imp" }, "Optionally provide a metadata template which has project specific details."),
+            new Option<string?>(new[] { "--set-name", "-sn" }, "Override the autogenerated BOM metadata component name."),
+            new Option<string?>(new[] { "--set-version", "-sv" }, "Override the default BOM metadata component version (defaults to 0.0.0)."),
+            new Option<Component.Classification?>(new[] { "--set-type", "-st" }, "Override the default BOM metadata component type (defaults to application).")
+            }.WithHandler(nameof(HandleCommandAsync));
+
+            root.Description = "A .NET Core global tool which creates CycloneDX Software Bill-of-Materials (SBOM) from .NET projects.";
+
+            //root.AddGlobalOption(new Option<bool>(new string[] { "--verbose", "-v" }, "Show verbose output"));
+
+            return await root.InvokeAsync(args);
+        }
+
+
+        private static async Task<int> HandleCommandAsync(string path,
+                                                          string framework,
+                                                          string runtime,
+                                                          string output,
+                                                          string filename,
+                                                          bool json,
+                                                          bool ExcludeDev,
+                                                          bool ExcludeTestProjects,
+                                                          string url,
+                                                          string BaseUrlUserName,
+                                                          string BaseUrlUserPassword,
+                                                          bool IsBaseUrlPasswordClearText,
+                                                          bool recursive,
+                                                          bool NoSerialNumber,
+                                                          string GithubUsername,
+                                                          string GithubToken,
+                                                          string GithubBearerToken,
+                                                          bool DisableGithubLicenses,
+                                                          bool DisablePackageRestore,
+                                                          bool DisableHashComputation,
+                                                          int dotnetCommandTimeout,
+                                                          string BaseIntermediateOutputPath,
+                                                          string ImportMetadataPath,
+                                                          string SetName,
+                                                          string SetVersion,
+                                                          Component.Classification SetType
+            )
+        {
+            SolutionOrProjectFile = path;
+            outputDirectory = output;
+            outputFilename = filename;
+            scanProjectReferences = recursive;
+            baseUrl = url;
+            isPasswordClearText = IsBaseUrlPasswordClearText;
+
 
             Console.WriteLine();
 
-            // check parameter values
-            if (string.IsNullOrEmpty(SolutionOrProjectFile))
-            {
-                app.ExtendedHelpText = Environment.NewLine + "A path is required";
-                app.ShowHelp();
-                return (int)ExitCode.SolutionOrProjectFileParameterMissing;
-            }
-
-            if (string.IsNullOrEmpty(outputDirectory))
-            {
-                app.ExtendedHelpText = Environment.NewLine + "The output directory is required";
-                app.ShowHelp();
-                return (int)ExitCode.OutputDirectoryParameterMissing;
-            }
-
-            if ((string.IsNullOrEmpty(githubUsername) ^ string.IsNullOrEmpty(githubToken)) ||
-                (string.IsNullOrEmpty(githubUsernameDeprecated) ^ string.IsNullOrEmpty(githubTokenDeprecated)))
-            {
-                app.ExtendedHelpText = Environment.NewLine + "Both GitHub username and token are required";
-                app.ShowHelp();
-                return (int)ExitCode.GitHubParameterMissing;
-            }
-
             dotnetCommandService.TimeoutMilliseconds = dotnetCommandTimeout;
-            projectFileService.DisablePackageRestore = disablePackageRestore;
+            projectFileService.DisablePackageRestore = DisablePackageRestore;
 
             // retrieve nuget package cache paths
             var packageCachePathsResult = dotnetUtilsService.GetPackageCachePaths();
@@ -184,37 +147,30 @@ namespace CycloneDX
             }
 
             Console.WriteLine("Found the following local nuget package cache locations:");
-            foreach (var path in packageCachePathsResult.Result)
+            foreach (var cachePath in packageCachePathsResult.Result)
             {
-                Console.WriteLine($"    {path}");
+                Console.WriteLine($"    {cachePath}");
             }
 
             // instantiate services
 
             var fileDiscoveryService = new FileDiscoveryService(Program.fileSystem);
             GithubService githubService = null;
-            if (!(disableGithubLicenses || disableGithubLicensesDeprecated))
+            if (!(DisableGithubLicenses))
             {
                 // GitHubService requires its own HttpClient as it adds a default authorization header
-                HttpClient httpClient = new HttpClient(new HttpClientHandler {
+                HttpClient httpClient = new HttpClient(new HttpClientHandler
+                {
                     AllowAutoRedirect = false
                 });
-                
-                if (!string.IsNullOrEmpty(githubBearerToken))
+
+                if (!string.IsNullOrEmpty(GithubBearerToken))
                 {
-                    githubService = new GithubService(httpClient, githubBearerToken);
+                    githubService = new GithubService(httpClient, GithubBearerToken);
                 }
-                else if (!string.IsNullOrEmpty(githubBearerTokenDeprecated))
+                else if (!string.IsNullOrEmpty(GithubUsername))
                 {
-                    githubService = new GithubService(httpClient, githubBearerTokenDeprecated);
-                }
-                else if (!string.IsNullOrEmpty(githubUsername))
-                {
-                    githubService = new GithubService(httpClient, githubUsername, githubToken);
-                }
-                else if (!string.IsNullOrEmpty(githubUsernameDeprecated))
-                {
-                    githubService = new GithubService(httpClient, githubUsernameDeprecated, githubTokenDeprecated);
+                    githubService = new GithubService(httpClient, GithubUsername, GithubToken);
                 }
                 else
                 {
@@ -223,8 +179,8 @@ namespace CycloneDX
             }
             var nugetLogger = new NuGet.Common.NullLogger();
             var nugetInput =
-                NugetInputFactory.Create(baseUrl, baseUrlUserName, baseUrlUserPassword, isPasswordClearText);
-            var nugetService = new NugetV3Service(nugetInput, fileSystem, packageCachePathsResult.Result, githubService, nugetLogger, disableHashComputation);
+                NugetInputFactory.Create(baseUrl, BaseUrlUserName, BaseUrlUserPassword, isPasswordClearText);
+            var nugetService = new NugetV3Service(nugetInput, fileSystem, packageCachePathsResult.Result, githubService, nugetLogger, DisableHashComputation);
 
             var packages = new HashSet<NugetPackage>();
 
@@ -234,25 +190,26 @@ namespace CycloneDX
             var topLevelComponent = new Component
             {
                 // name is set below
-                Version = string.IsNullOrEmpty(setVersion) ? "0.0.0" : setVersion,
-                Type = setType == Component.Classification.Null ? Component.Classification.Application : setType,
+                Version = string.IsNullOrEmpty(SetVersion) ? "0.0.0" : SetVersion,
+                Type = SetType == Component.Classification.Null ? Component.Classification.Application : SetType
+
             };
 
             try
             {
                 if (SolutionOrProjectFile.ToLowerInvariant().EndsWith(".sln", StringComparison.OrdinalIgnoreCase))
                 {
-                    packages = await solutionFileService.GetSolutionNugetPackages(fullSolutionOrProjectFilePath, baseIntermediateOutputPath, excludetestprojects, excludeDev, framework, runtime).ConfigureAwait(false);
+                    packages = await solutionFileService.GetSolutionNugetPackages(fullSolutionOrProjectFilePath, BaseIntermediateOutputPath, ExcludeTestProjects, ExcludeDev, framework, runtime).ConfigureAwait(false);
                     topLevelComponent.Name = fileSystem.Path.GetFileNameWithoutExtension(SolutionOrProjectFile);
                 }
                 else if (Utils.IsSupportedProjectType(SolutionOrProjectFile) && scanProjectReferences)
                 {
-                    packages = await projectFileService.RecursivelyGetProjectNugetPackagesAsync(fullSolutionOrProjectFilePath, baseIntermediateOutputPath, excludetestprojects, excludeDev, framework, runtime).ConfigureAwait(false);
+                    packages = await projectFileService.RecursivelyGetProjectNugetPackagesAsync(fullSolutionOrProjectFilePath, BaseIntermediateOutputPath, ExcludeTestProjects, ExcludeDev, framework, runtime).ConfigureAwait(false);
                     topLevelComponent.Name = fileSystem.Path.GetFileNameWithoutExtension(SolutionOrProjectFile);
                 }
                 else if (Utils.IsSupportedProjectType(SolutionOrProjectFile))
                 {
-                    packages = await projectFileService.GetProjectNugetPackagesAsync(fullSolutionOrProjectFilePath, baseIntermediateOutputPath, excludetestprojects, excludeDev, framework, runtime).ConfigureAwait(false);
+                    packages = await projectFileService.GetProjectNugetPackagesAsync(fullSolutionOrProjectFilePath, BaseIntermediateOutputPath, ExcludeTestProjects, ExcludeDev, framework, runtime).ConfigureAwait(false);
                     topLevelComponent.Name = fileSystem.Path.GetFileNameWithoutExtension(SolutionOrProjectFile);
                 }
                 else if (Program.fileSystem.Path.GetFileName(SolutionOrProjectFile).ToLowerInvariant().Equals("packages.config", StringComparison.OrdinalIgnoreCase))
@@ -276,9 +233,9 @@ namespace CycloneDX
                 return (int)ExitCode.DotnetRestoreFailed;
             }
 
-            if (!string.IsNullOrEmpty(setName))
+            if (!string.IsNullOrEmpty(SetName))
             {
-                topLevelComponent.Name = setName;
+                topLevelComponent.Name = SetName;
             }
 
             // get all the components and dependency graph from the NuGet packages
@@ -295,7 +252,7 @@ namespace CycloneDX
                     var component = await nugetService.GetComponentAsync(package).ConfigureAwait(false);
                     if (component != null)
                     {
-                        if (component.Scope != Component.ComponentScope.Excluded || !excludeDev)
+                        if (component.Scope != Component.ComponentScope.Excluded || !ExcludeDev)
                         {
                             components.Add(component);
                         }
@@ -373,16 +330,16 @@ namespace CycloneDX
                 Version = 1,
             };
 
-            if (!string.IsNullOrEmpty(importMetadataPath))
+            if (!string.IsNullOrEmpty(ImportMetadataPath))
             {
-                if (!File.Exists(importMetadataPath))
+                if (!File.Exists(ImportMetadataPath))
                 {
-                    Console.Error.WriteLine($"Metadata template '{importMetadataPath}' does not exist.");
+                    Console.Error.WriteLine($"Metadata template '{ImportMetadataPath}' does not exist.");
                     return (int)ExitCode.InvalidOptions;
                 }
                 else
                 {
-                    bom = ReadMetaDataFromFile(bom, importMetadataPath);
+                    bom = ReadMetaDataFromFile(bom, ImportMetadataPath);
                 }
             }
 
@@ -420,7 +377,7 @@ namespace CycloneDX
 
             AddMetadataTool(bom);
 
-            if (!(noSerialNumber || noSerialNumberDeprecated)) bom.SerialNumber = "urn:uuid:" + System.Guid.NewGuid().ToString();
+            if (!(NoSerialNumber)) bom.SerialNumber = "urn:uuid:" + System.Guid.NewGuid().ToString();
             bom.Components = new List<Component>(components);
             bom.Components.Sort((x, y) =>
             {
@@ -497,5 +454,15 @@ namespace CycloneDX
                 bom.Metadata.Tools[index].Version = Assembly.GetExecutingAssembly().GetName().Version.ToString();
             }
         }
+        private static Command WithHandler(this Command command, string methodName)
+        {
+            var method = typeof(Program).GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Static);
+            var handler = CommandHandler.Create(method!);
+            command.Handler = handler;
+            return command;
+        }
+
     }
+
+
 }

--- a/CycloneDX/Program.cs
+++ b/CycloneDX/Program.cs
@@ -44,53 +44,40 @@ namespace CycloneDX
         internal static readonly IProjectFileService projectFileService = new ProjectFileService(fileSystem, dotnetUtilsService, packagesFileService, projectAssetsFileService);
         internal static ISolutionFileService solutionFileService = new SolutionFileService(fileSystem, projectFileService);
 
-        #region alias
-        internal static string SolutionOrProjectFile;
-        internal static string outputDirectory;
-        internal static string outputFilename;
-        internal static string baseUrl;
-        internal static bool scanProjectReferences;
-        internal static int dotnetCommandTimeout;
-        internal static bool isPasswordClearText;
-
-        #endregion alias
-
         public static async Task<int> Main(string[] args)
         {
 
-            var root = new RootCommand()
+            var root = new RootCommand
             {
             new Argument<string>("path", description: "The path to a .sln, .csproj, .fsproj, .vbproj, or packages.config file or the path to a directory which will be recursively analyzed for packages.config files."  ),
-            new Option<string?>(new[] { "--framework", "-tfm" }, "The target framework to use. If not defined, all will be aggregated."),
-            new Option<string?>(new[] { "--runtime", "-rt" }, "The runtime to use. If not defined, all will be aggregated."),
-            new Option<string>(new[] { "--output", "-o" }, description: "The directory to write the BOM"),
-            new Option<string?>(new[] { "--filename", "-f" }, "Optionally provide a filename for the BOM (default: bom.xml or bom.json"),
-            new Option<bool?>(new[] { "--json", "-j" }, "Produce a JSON BOM instead of XML"),
-            new Option<bool?>(new[] { "--exclude-dev", "-d" }, "Exclude development dependencies from the BOM"),
-            new Option<bool?>(new[] { "--exclude-test-projects", "-t" }, "Exclude test projects from the BOM"),
-            new Option<string?>(new[] { "--url", "-u" }, "Alternative NuGet repository URL to https://<yoururl>/nuget/<yourrepository>/v3/index.json"),
-            new Option<string?>(new[] { "--baseUrlUsername", "-us" }, "Alternative NuGet repository username"),
-            new Option<string?>(new[] { "--baseUrlUserPassword", "-usp" }, "Alternative NuGet repository username password/apikey"),
-            new Option<bool?>(new[] { "--isBaseUrlPasswordClearText", "-uspct" }, "Alternative NuGet repository password is cleartext"),
-            new Option<bool?>(new[] { "--recursive", "-r" }, "To be used with a single project file, it will recursively scan project references of the supplied project file"),
-            new Option<string?>(new[] { "--no-serial-number", "-ns" }, "Optionally omit the serial number from the resulting BOM"),
-            new Option<string?>(new[] { "--github-username", "-gu" }, "Optionally provide a GitHub username for license resolution. If set you also need to provide a GitHub personal access token"),
-            new Option<string?>(new[] { "--github-token", "-gt" }, "Optionally provide a GitHub personal access token for license resolution. If set you also need to provide a GitHub username"),
-            new Option<string?>(new[] { "--github-bearer-token", "-gbt" }, "Optionally provide a GitHub bearer token for license resolution. This is useful in GitHub actions"),
-            new Option<bool?>(new[] { "--disable-github-licenses", "-dgl" }, "Optionally disable GitHub license resolution"),
-            new Option<bool?>(new[] { "--disable-package-restore", "-dpr" }, "Optionally disable package restore"),
-            new Option<bool?>(new[] { "--disable-hash-computation", "-dhc" }, "Optionally disable hash computation for packages"),
+            new Option<string>(new[] { "--framework", "-tfm" }, "The target framework to use. If not defined, all will be aggregated."),
+            new Option<string>(new[] { "--runtime", "-rt" }, "The runtime to use. If not defined, all will be aggregated."),
+            new Option<string>(new[] { "--output", "-o" }, description: "The directory to write the BOM") {IsRequired = true},
+            new Option<string>(new[] { "--filename", "-f" }, "Optionally provide a filename for the BOM (default: bom.xml or bom.json"),
+            new Option<bool>(new[] { "--json", "-j" }, "Produce a JSON BOM instead of XML"),
+            new Option<bool>(new[] { "--exclude-dev", "-d" }, "Exclude development dependencies from the BOM"),
+            new Option<bool>(new[] { "--exclude-test-projects", "-t" }, "Exclude test projects from the BOM"),
+            new Option<string>(new[] { "--url", "-u" }, "Alternative NuGet repository URL to https://<yoururl>/nuget/<yourrepository>/v3/index.json"),
+            new Option<string>(new[] { "--baseUrlUsername", "-us" }, "Alternative NuGet repository username"),
+            new Option<string>(new[] { "--baseUrlUserPassword", "-usp" }, "Alternative NuGet repository username password/apikey"),
+            new Option<bool>(new[] { "--isBaseUrlPasswordClearText", "-uspct" }, "Alternative NuGet repository password is cleartext"),
+            new Option<bool>(new[] { "--recursive", "-r" }, "To be used with a single project file, it will recursively scan project references of the supplied project file"),
+            new Option<string>(new[] { "--no-serial-number", "-ns" }, "Optionally omit the serial number from the resulting BOM"),
+            new Option<string>(new[] { "--github-username", "-gu" }, "Optionally provide a GitHub username for license resolution. If set you also need to provide a GitHub personal access token"),
+            new Option<string>(new[] { "--github-token", "-gt" }, "Optionally provide a GitHub personal access token for license resolution. If set you also need to provide a GitHub username"),
+            new Option<string>(new[] { "--github-bearer-token", "-gbt" }, "Optionally provide a GitHub bearer token for license resolution. This is useful in GitHub actions"),
+            new Option<bool>(new[] { "--disable-github-licenses", "-dgl" }, "Optionally disable GitHub license resolution"),
+            new Option<bool>(new[] { "--disable-package-restore", "-dpr" }, "Optionally disable package restore"),
+            new Option<bool>(new[] { "--disable-hash-computation", "-dhc" }, "Optionally disable hash computation for packages"),
             new Option<int>(new[] { "--dotnet-command-timeout", "-dct" }, description: "dotnet command timeout in milliseconds (primarily used for long dotnet restore operations)", getDefaultValue: () => 300000),
-            new Option<string?>(new[] { "--base-intermediate-output-path", "-biop" }, "Optionally provide a folder for customized build environment. Required if folder 'obj' is relocated."),
-            new Option<string?>(new[] { "--import-metadata-path", "-imp" }, "Optionally provide a metadata template which has project specific details."),
-            new Option<string?>(new[] { "--set-name", "-sn" }, "Override the autogenerated BOM metadata component name."),
-            new Option<string?>(new[] { "--set-version", "-sv" }, "Override the default BOM metadata component version (defaults to 0.0.0)."),
-            new Option<Component.Classification?>(new[] { "--set-type", "-st" }, "Override the default BOM metadata component type (defaults to application).")
+            new Option<string>(new[] { "--base-intermediate-output-path", "-biop" }, "Optionally provide a folder for customized build environment. Required if folder 'obj' is relocated."),
+            new Option<string>(new[] { "--import-metadata-path", "-imp" }, "Optionally provide a metadata template which has project specific details."),
+            new Option<string>(new[] { "--set-name", "-sn" }, "Override the autogenerated BOM metadata component name."),
+            new Option<string>(new[] { "--set-version", "-sv" }, "Override the default BOM metadata component version (defaults to 0.0.0)."),
+            new Option<Component.Classification>(new[] { "--set-type", "-st" }, "Override the default BOM metadata component type (defaults to application).")
             }.WithHandler(nameof(HandleCommandAsync));
 
             root.Description = "A .NET Core global tool which creates CycloneDX Software Bill-of-Materials (SBOM) from .NET projects.";
-
-            //root.AddGlobalOption(new Option<bool>(new string[] { "--verbose", "-v" }, "Show verbose output"));
 
             return await root.InvokeAsync(args);
         }
@@ -124,12 +111,12 @@ namespace CycloneDX
                                                           Component.Classification SetType
             )
         {
-            SolutionOrProjectFile = path;
-            outputDirectory = output;
-            outputFilename = filename;
-            scanProjectReferences = recursive;
-            baseUrl = url;
-            isPasswordClearText = IsBaseUrlPasswordClearText;
+            string SolutionOrProjectFile = path;
+            string outputDirectory = output;
+            string outputFilename = filename;
+            bool scanProjectReferences = recursive;
+            string baseUrl = url;
+            bool isPasswordClearText = IsBaseUrlPasswordClearText;
 
 
             Console.WriteLine();
@@ -377,7 +364,10 @@ namespace CycloneDX
 
             AddMetadataTool(bom);
 
-            if (!(NoSerialNumber)) bom.SerialNumber = "urn:uuid:" + System.Guid.NewGuid().ToString();
+            if (!(NoSerialNumber))
+            {
+                bom.SerialNumber = "urn:uuid:" + System.Guid.NewGuid().ToString();
+            }
             bom.Components = new List<Component>(components);
             bom.Components.Sort((x, y) =>
             {

--- a/CycloneDX/Services/DotnetCommandService.cs
+++ b/CycloneDX/Services/DotnetCommandService.cs
@@ -15,13 +15,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) OWASP Foundation. All Rights Reserved.
 
+using System;
 using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 using CycloneDX.Interfaces;
-using McMaster.Extensions.CommandLineUtils;
 using CycloneDX.Models;
 
 namespace CycloneDX.Services
@@ -38,7 +39,8 @@ namespace CycloneDX.Services
         public DotnetCommandResult Run(string workingDirectory, string arguments)
         {
             Contract.Requires(arguments != null);
-            var psi = new ProcessStartInfo(DotNetExe.FullPathOrDefault(), arguments)
+
+            var psi = new ProcessStartInfo(GetDotnetPathOrDefault(), arguments)
             {
                 CreateNoWindow = true,
                 RedirectStandardOutput = true,
@@ -46,7 +48,7 @@ namespace CycloneDX.Services
                 UseShellExecute = false,
                 WorkingDirectory = workingDirectory
             };
-            
+
             using (var p = Process.Start(psi))
             {
                 var output = new StringBuilder();
@@ -80,8 +82,29 @@ namespace CycloneDX.Services
                 }
             }
         }
-        
-        private static async Task ConsumeStreamReaderAsync(StreamReader reader, StringBuilder lines)
+        private static string? GetDotnetPathOrDefault()
+        {
+            var fileName = "dotnet.exe";
+            var mainModule = Process.GetCurrentProcess().MainModule;
+            if (!string.IsNullOrEmpty(mainModule?.FileName)
+                && Path.GetFileName(mainModule.FileName).Equals(fileName, StringComparison.OrdinalIgnoreCase))
+            {
+                return mainModule.FileName;
+            }
+            // DOTNET_ROOT specifies the location of the .NET runtimes, if they are not installed in the default location.
+            var dotnetRoot = Environment.GetEnvironmentVariable("DOTNET_ROOT");
+
+            if (string.IsNullOrEmpty(dotnetRoot))
+            {
+                // fall back to default location
+                // https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-environment-variables#dotnet_root-dotnet_rootx86
+                dotnetRoot = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "C:\\Program Files\\dotnet" : "/usr/local/share/dotnet";
+            }
+
+            return Path.Combine(dotnetRoot, fileName);
+        }
+
+    private static async Task ConsumeStreamReaderAsync(StreamReader reader, StringBuilder lines)
         {
             await Task.Yield();
 

--- a/CycloneDX/Services/DotnetCommandService.cs
+++ b/CycloneDX/Services/DotnetCommandService.cs
@@ -82,11 +82,18 @@ namespace CycloneDX.Services
                 }
             }
         }
-        private static string? GetDotnetPathOrDefault()
+
+        // origin: https://github.com/natemcmaster/CommandLineUtils/blob/main/src/CommandLineUtils/Utilities/DotNetExe.cs
+        // extracted and modified TryFindDotNetExePath
+        private static string GetDotnetPathOrDefault()
         {
-            var fileName = "dotnet.exe";
+            var fileName = "dotnet";
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                fileName += ".exe";
+            }
             var mainModule = Process.GetCurrentProcess().MainModule;
-            if (!string.IsNullOrEmpty(mainModule?.FileName)
+            if (!string.IsNullOrEmpty(mainModule.FileName)
                 && Path.GetFileName(mainModule.FileName).Equals(fileName, StringComparison.OrdinalIgnoreCase))
             {
                 return mainModule.FileName;

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,6 @@
 
   <ItemGroup>
     <PackageVersion Include="CycloneDX.Core" Version="5.4.0" />
-    <!--<PackageVersion Include="McMaster.Extensions.CommandLineUtils" Version="4.0.2" />-->
     <PackageVersion Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageVersion Include="NuGet.ProjectModel" Version="6.5.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
 
   <ItemGroup>
     <PackageVersion Include="CycloneDX.Core" Version="5.4.0" />
-    <PackageVersion Include="McMaster.Extensions.CommandLineUtils" Version="4.0.2" />
+    <!--<PackageVersion Include="McMaster.Extensions.CommandLineUtils" Version="4.0.2" />-->
     <PackageVersion Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageVersion Include="NuGet.ProjectModel" Version="6.5.0" />
@@ -21,6 +21,8 @@
     <PackageVersion Include="coverlet.collector" Version="3.2.0" />
     <PackageVersion Include="coverlet.msbuild" Version="3.2.0" />
 
+    <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    <PackageVersion Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1" />
     <PackageVersion Include="System.IO.Abstractions" Version="19.2.26" />
     <PackageVersion Include="System.IO.Abstractions.TestingHelpers" Version="19.2.26" />
   </ItemGroup>


### PR DESCRIPTION
System.ComponentModel.Annotations V5.0.0 is deprecated (see also https://github.com/natemcmaster/CommandLineUtils/issues/533)

**BREAKING CHANGE**: commandline option names are updated and deprecated options are dropped.
- option name `--output` is used instead of former `--out`. This avoids conflict with **_out parameter modifier_** and is compliant to recommendations [Options as parameters](https://learn.microsoft.com/en-us/dotnet/standard/commandline/syntax#options-as-parameters)
![image](https://github.com/CycloneDX/cyclonedx-dotnet/assets/2315215/00af00d4-f857-4534-a42d-9fc17d1d0db9)
