### PR TITLE
automation for issues (close inactive, triage)

### DIFF
--- a/.github/workflows/issue-close-inactive.yml
+++ b/.github/workflows/issue-close-inactive.yml
@@ -14,6 +14,7 @@ jobs:
     steps:
       - uses: actions/stale@v8
         with:
+          exempt-issue-labels: "ready for development"
           days-before-issue-stale: 90
           days-before-issue-close: 275
           stale-issue-label: "stale"

--- a/.github/workflows/issue-close-inactive.yml
+++ b/.github/workflows/issue-close-inactive.yml
@@ -1,0 +1,24 @@
+# see https://docs.github.com/en/actions/managing-issues-and-pull-requests/closing-inactive-issues
+
+name: Close inactive issues
+on:
+  schedule:
+    - cron: "0 1 * * 0"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v8
+        with:
+          days-before-issue-stale: 90
+          days-before-issue-close: 275
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it has been open for 3 months with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 9 months since being marked as stale."
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/issue-label-triage.yml
+++ b/.github/workflows/issue-label-triage.yml
@@ -1,0 +1,24 @@
+# https://docs.github.com/en/actions/managing-issues-and-pull-requests/adding-labels-to-issues
+
+name: Label issues
+on:
+  issues:
+    types:
+      - reopened
+      - opened
+jobs:
+  label_issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["triage"]
+            })
+


### PR DESCRIPTION
- many issues are outdated and should be closed (older than 1 year)
- new issues should be checked and appropriate labels assigned (contributor need permission to assign labels)