### PR TITLE
Fix json validation when using license url

### DIFF
--- a/CycloneDX.Tests/ValidationTests.cs
+++ b/CycloneDX.Tests/ValidationTests.cs
@@ -26,7 +26,7 @@ namespace CycloneDX.Tests
                 { MockUnixSupport.Path(@"c:\ProjectPath\Project.csproj"), new MockFileData(CsprojContents) }
             });
 
-            var packages = new HashSet<NugetPackage>()
+            var packages = new HashSet<NugetPackage>
             {
                 new() { Name = "DotNetEnv", Version = "1.4.0" },
                 new() { Name = "HtmlAgilityPack", Version = "1.11.30" },

--- a/CycloneDX.Tests/ValidationTests.cs
+++ b/CycloneDX.Tests/ValidationTests.cs
@@ -1,0 +1,102 @@
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Abstractions.TestingHelpers;
+using System.Threading.Tasks;
+using CycloneDX.Interfaces;
+using CycloneDX.Models;
+using Moq;
+using Xunit;
+
+namespace CycloneDX.Tests
+{
+    /// <summary>
+    /// Ensures that generated BOM files are valid.
+    /// </summary>
+    public class ValidationTests
+    {
+        [Theory]
+        [InlineData("xml", false)]
+        [InlineData("xml", true)]
+        [InlineData("json", false)]
+        [InlineData("json", true)]
+        public async Task Validation(string fileFormat, bool disableGitHubLicenses)
+        {
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { MockUnixSupport.Path(@"c:\ProjectPath\Project.csproj"), new MockFileData(CsprojContents) }
+            });
+
+            var packages = new HashSet<NugetPackage>()
+            {
+                new() { Name = "DotNetEnv", Version = "1.4.0" },
+                new() { Name = "HtmlAgilityPack", Version = "1.11.30" },
+                new() { Name = "LibGit2Sharp", Version = "0.27.0-preview-0096" },
+                new() { Name = "NLog", Version = "4.7.7" },
+                new() { Name = "RestSharp", Version = "106.11.7" },
+            };
+
+            var mockProjectFileService = new Mock<IProjectFileService>();
+            mockProjectFileService.Setup(mock =>
+                mock.GetProjectNugetPackagesAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<string>())
+            ).ReturnsAsync(packages);
+            Program.fileSystem = mockFileSystem;
+            Program.projectFileService = mockProjectFileService.Object;
+
+            var args = new List<string>
+            {
+                MockUnixSupport.Path(@"c:\ProjectPath\Project.csproj"),
+                "-o", MockUnixSupport.Path(@"c:\NewDirectory"),
+            };
+
+            if (fileFormat == "json")
+            {
+                args.Add("--json");
+            }
+
+            if (disableGitHubLicenses)
+            {
+                args.Add("--disable-github-licenses");
+            }
+
+            var exitCode = await Program.Main(args.ToArray()).ConfigureAwait(false);
+
+            Assert.Equal((int)ExitCode.OK, exitCode);
+
+            var expectedFileName = @"c:\NewDirectory\bom.xml";
+            if (fileFormat == "json")
+            {
+                expectedFileName = @"c:\NewDirectory\bom.json";
+            }
+            Assert.True(mockFileSystem.FileExists(MockUnixSupport.Path(expectedFileName)));
+
+            var mockBomFile = mockFileSystem.GetFile(MockUnixSupport.Path(expectedFileName));
+            var mockBomFileStream = new MemoryStream(mockBomFile.Contents);
+            ValidationResult validationResult;
+            if (fileFormat == "json")
+            {
+                validationResult = await Json.Validator.ValidateAsync(mockBomFileStream, SpecificationVersion.v1_4).ConfigureAwait(false);
+            }
+            else
+            {
+                validationResult = Xml.Validator.Validate(mockBomFileStream, SpecificationVersion.v1_4);
+            }
+
+            Assert.True(validationResult.Valid);
+        }
+
+        private const string CsprojContents =
+            "<Project Sdk=\"Microsoft.NET.Sdk\">\n\n  " +
+                "<PropertyGroup>\n    " +
+                    "<OutputType>Exe</OutputType>\n    " +
+                    "<PackageId>SampleProject</PackageId>\n    " +
+                "</PropertyGroup>\n\n  " +
+                "<ItemGroup>\n    " +
+                    "<PackageReference Include=\"DotNetEnv\" Version=\"1.4.0\" />\n      " +
+                    "<PackageReference Include=\"HtmlAgilityPack\" Version=\"1.11.30\" />\n      " +
+                    "<PackageReference Include=\"LibGit2Sharp\" Version=\"0.27.0-preview-0096\" />\n      " +
+                    "<PackageReference Include=\"NLog\" Version=\"4.7.7\" />\n      " +
+                    "<PackageReference Include=\"RestSharp\" Version=\"106.11.7\" />\n" +
+                "</ItemGroup>\n" +
+            "</Project>\n";
+    }
+}

--- a/CycloneDX/Program.cs
+++ b/CycloneDX/Program.cs
@@ -131,7 +131,7 @@ namespace CycloneDX
         internal static readonly IProjectAssetsFileService projectAssetsFileService = new ProjectAssetsFileService(fileSystem, dotnetCommandService, () => new AssetFileReader());
         internal static readonly IDotnetUtilsService dotnetUtilsService = new DotnetUtilsService(fileSystem, dotnetCommandService);
         internal static readonly IPackagesFileService packagesFileService = new PackagesFileService(fileSystem);
-        internal static readonly IProjectFileService projectFileService = new ProjectFileService(fileSystem, dotnetUtilsService, packagesFileService, projectAssetsFileService);
+        internal static IProjectFileService projectFileService = new ProjectFileService(fileSystem, dotnetUtilsService, packagesFileService, projectAssetsFileService);
         internal static ISolutionFileService solutionFileService = new SolutionFileService(fileSystem, projectFileService);
 
         public static async Task<int> Main(string[] args)
@@ -197,7 +197,7 @@ namespace CycloneDX
                 HttpClient httpClient = new HttpClient(new HttpClientHandler {
                     AllowAutoRedirect = false
                 });
-                
+
                 if (!string.IsNullOrEmpty(githubBearerToken))
                 {
                     githubService = new GithubService(httpClient, githubBearerToken);

--- a/CycloneDX/Services/NugetV3Service.cs
+++ b/CycloneDX/Services/NugetV3Service.cs
@@ -197,7 +197,7 @@ namespace CycloneDX.Services
             else if (_githubService == null)
             {
                 var licenseUrl = nuspecModel.nuspecReader.GetLicenseUrl();
-                var license = new License { Url = licenseUrl };
+                var license = new License { Name = "Unknown - See URL", Url = licenseUrl };
                 component.Licenses = new List<LicenseChoice> { new LicenseChoice { License = license } };
             }
             else


### PR DESCRIPTION
This sets the license name to `Unknown - See URL` if the `--disable-github-licenses` parameter has been specified. Leaving the name unspecified causes the resulting JSON formatted BOM to not validate against the [1.4 JSON schema](https://github.com/CycloneDX/specification/blob/1.4/schema/bom-1.4.schema.json#L600-L610) because it requires that either `id` or `name` is specified.

Fixes #754.