### PR TITLE
Replace licenseID NOASSERTION with null

### DIFF
--- a/CycloneDX.Tests/GithubServiceTests.cs
+++ b/CycloneDX.Tests/GithubServiceTests.cs
@@ -493,5 +493,30 @@ namespace CycloneDX.Tests
             Assert.Equal("Test License", license.Name);
             Assert.Equal("https://licenceurl.com/", license.Url);
         }
+
+        [Fact]
+        public async Task GitLicense_ReplacesNoAssertionWithNull()
+        {
+            //See also https://github.com/CycloneDX/cyclonedx-dotnet/issues/525
+
+            var mockResponseContent = @"{
+                ""license"": {                    
+                    ""name"": ""Other"",
+                    ""spdx_id"": ""NOASSERTION""                  
+                }, 
+                ""html_url"": ""https://licenceUrl.com""
+            }";
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp.When("https://api.github.com/repos/CycloneDX/cyclonedx-dotnet/license")
+                .Respond("application/json", mockResponseContent);
+            var client = mockHttp.ToHttpClient();
+            var githubService = new GithubService(client);
+
+            var license = await githubService.GetLicenseAsync("https://raw.github.com/CycloneDX/cyclonedx-dotnet").ConfigureAwait(false);
+
+            Assert.Null(license.Id);
+            Assert.Equal("Other", license.Name);
+            Assert.Equal("https://licenceurl.com/", license.Url);
+        }
     }
 }

--- a/CycloneDX/Services/GithubService.cs
+++ b/CycloneDX/Services/GithubService.cs
@@ -170,7 +170,7 @@ namespace CycloneDX.Services
             // If we have a license we can map it to its return format
             return new License
             {
-                Id = githubLicense.License.SpdxId,
+                Id = githubLicense.License.SpdxId != "NOASSERTION" ? githubLicense.License.SpdxId : null,
                 Name = githubLicense.License.Name,
                 Url = githubLicense.HtmlUrl?.ToString() ?? licenseUrl
             };


### PR DESCRIPTION
There are cases where the GitHub licence call returns a JSON that has a spdxId and a license name.

Example: https://api.github.com/repos/aspnet/AspNetWebStack/license
`  "license": {
    "key": "other",
    "name": "Other",
    "spdx_id": "NOASSERTION",
    "url": null,
    "node_id": "MDc6TGljZW5zZTA="
  }`
  
This is problematic for two reason:

- A cycloneDX licence tag must have either a name or an spdx_id, not both.
- NOASSERTION is not a valid value for the spdx_id enumeration.

Obviously, NOASSERTION is not a meaningful value, which makes an easy solution to just replace it with null. In the given example, the licence is more or less correctly identified by its name "other" as it cannot be matched to a licence.

For the future, it might be worth the consideration that the class GithubService should only return licence objects that adhere to the standard.

Fixes #525 