### PR TITLE
fix: exluded DevDependencies won't appear in the dependencyTree anymore #761

### DIFF
--- a/CycloneDX.Tests/CycloneDX.Tests.csproj
+++ b/CycloneDX.Tests/CycloneDX.Tests.csproj
@@ -33,6 +33,15 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="FunctionalTests\TestcaseFiles\DevDependencies.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="FunctionalTests\TestcaseFiles\DevDependencies_WithPackageConfig_CsProj.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="FunctionalTests\TestcaseFiles\DevDependencies_WithPackageConfig_PackageConfig.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="FunctionalTests\TestcaseFiles\Issue-758.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/CycloneDX.Tests/CycloneDX.Tests.csproj
+++ b/CycloneDX.Tests/CycloneDX.Tests.csproj
@@ -37,10 +37,10 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Update="FunctionalTests\TestcaseFiles\DevDependencies_WithPackageConfig_CsProj.xml">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Update="FunctionalTests\TestcaseFiles\DevDependencies_WithPackageConfig_PackageConfig.xml">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Update="FunctionalTests\TestcaseFiles\Issue-758.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
@@ -52,7 +52,7 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Update="FunctionalTests\TestcaseFiles\SimpleNETStandardLibrary.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Update="Resources\metadata\cycloneDX-metadata-template.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/CycloneDX.Tests/FunctionalTests/DevDependnciesWithPackageConfig.cs
+++ b/CycloneDX.Tests/FunctionalTests/DevDependnciesWithPackageConfig.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.IO;
+using System.IO.Abstractions;
+using System.IO.Abstractions.TestingHelpers;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using CycloneDX.Models;
+using Xunit;
+
+namespace CycloneDX.Tests.FunctionalTests
+{
+    public class ExcludeDevDependnciesWithPackageConfig
+    {
+        private MockFileSystem getMockFS()
+        {
+            return new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { MockUnixSupport.Path("c:/ProjectPath/project.csproj"),
+                        new MockFileData(
+                            File.ReadAllText(Path.Combine("FunctionalTests", "TestcaseFiles", "DevDependencies_WithPackageConfig_CsProj.xml"))) },
+                { MockUnixSupport.Path("c:/ProjectPath/packages.config"),
+                     new MockFileData(
+                            File.ReadAllText(Path.Combine("FunctionalTests", "TestcaseFiles", "DevDependencies_WithPackageConfig_PackageConfig.xml"))) }
+            });
+        }
+
+        [Fact]
+        public async Task DevDependenciesNormalyGoIntoTheBom()
+        {            
+            var options = new RunOptions
+            {
+            };
+
+
+            var bom = await FunctionalTestHelper.Test(options, getMockFS());
+
+            Assert.True(bom.Components.Count == 1);
+            Assert.Contains(bom.Components, c => string.Compare(c.Name, "SonarAnalyzer.CSharp", true) == 0 && c.Version == "9.16.0.82469");
+
+        }
+
+        [Fact]
+        public async Task DevDependenciesAreExcludedWithExcludeDevDependencies()
+        {            
+            var options = new RunOptions
+            {
+                excludeDev = true
+            };
+
+
+            var bom = await FunctionalTestHelper.Test(options, getMockFS());
+
+            Assert.True(bom.Components.Count == 0);
+            
+
+        }
+
+
+    }
+}

--- a/CycloneDX.Tests/FunctionalTests/ExcludeDevDepenceny.cs
+++ b/CycloneDX.Tests/FunctionalTests/ExcludeDevDepenceny.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using System.Threading.Tasks;
+using CycloneDX.Models;
+using Xunit;
+
+namespace CycloneDX.Tests.FunctionalTests
+{
+    public class ExcludeDevDepenceny
+    {
+        [Fact]
+        public async Task DevDependenciesNormalyGoIntoTheBom()
+        {
+            var assetsJson = File.ReadAllText(Path.Combine("FunctionalTests", "TestcaseFiles", "DevDependencies.json"));
+            var options = new RunOptions
+            {
+            };
+
+
+            var bom = await FunctionalTestHelper.Test(assetsJson, options);
+
+            Assert.True(bom.Components.Count == 1);
+            Assert.Contains(bom.Components, c => string.Compare(c.Name, "SonarAnalyzer.CSharp", true) == 0 && c.Version == "9.16.0.82469");
+
+        }
+
+        [Fact]
+        public async Task DevDependenciesAreExcludedWithExcludeDevDependencies()
+        {
+            var assetsJson = File.ReadAllText(Path.Combine("FunctionalTests", "TestcaseFiles", "DevDependencies.json"));
+            var options = new RunOptions
+            {
+                excludeDev = true
+            };
+
+
+            var bom = await FunctionalTestHelper.Test(assetsJson, options);
+
+            Assert.True(bom.Components.Count == 0);
+            Assert.True(bom.Dependencies.Count == 1); // only the meta component
+
+
+        }
+    }
+}

--- a/CycloneDX.Tests/FunctionalTests/ExcludeDevDependnciesWithPackageConfig.cs
+++ b/CycloneDX.Tests/FunctionalTests/ExcludeDevDependnciesWithPackageConfig.cs
@@ -18,10 +18,10 @@ namespace CycloneDX.Tests.FunctionalTests
         {
             return new MockFileSystem(new Dictionary<string, MockFileData>
             {
-                { "c:/ProjectPath/project.csproj",
+                { MockUnixSupport.Path("c:/ProjectPath/project.csproj"),
                         new MockFileData(
                             File.ReadAllText(Path.Combine("FunctionalTests", "TestcaseFiles", "DevDependencies_WithPackageConfig_CsProj.xml"))) },
-                { "c:/ProjectPath/packages.config",
+                { MockUnixSupport.Path("c:/ProjectPath/packages.config"),
                      new MockFileData(
                             File.ReadAllText(Path.Combine("FunctionalTests", "TestcaseFiles", "DevDependencies_WithPackageConfig_PackageConfig.xml"))) }
             });

--- a/CycloneDX.Tests/FunctionalTests/ExcludeDevDependnciesWithPackageConfig.cs
+++ b/CycloneDX.Tests/FunctionalTests/ExcludeDevDependnciesWithPackageConfig.cs
@@ -18,7 +18,7 @@ namespace CycloneDX.Tests.FunctionalTests
         {
             return new MockFileSystem(new Dictionary<string, MockFileData>
             {
-                { MockUnixSupport.Path("c:/ProjectPath/project.csproj"),
+                { MockUnixSupport.Path("c:/ProjectPath/Project.csproj"),
                         new MockFileData(
                             File.ReadAllText(Path.Combine("FunctionalTests", "TestcaseFiles", "DevDependencies_WithPackageConfig_CsProj.xml"))) },
                 { MockUnixSupport.Path("c:/ProjectPath/packages.config"),

--- a/CycloneDX.Tests/FunctionalTests/ExcludeDevDependnciesWithPackageConfig.cs
+++ b/CycloneDX.Tests/FunctionalTests/ExcludeDevDependnciesWithPackageConfig.cs
@@ -30,17 +30,13 @@ namespace CycloneDX.Tests.FunctionalTests
         [Fact]
         public async Task DevDependenciesNormalyGoIntoTheBom()
         {
-            await Console.Out.WriteLineAsync($"Run test: DevDependenciesNormalyGoIntoTheBom");            
-            Console.SetError(Console.Out);            
-
             var options = new RunOptions
             {
             };
 
-
             var bom = await FunctionalTestHelper.Test(options, getMockFS());
 
-            Assert.True(bom.Components.Count == 1, $"Unexpected number of components. Expected 1 was {bom.Components.Count}");
+            Assert.True(bom.Components.Count == 1, $"Unexpected number of components. Expected 1, got {bom.Components.Count}");
             Assert.Contains(bom.Components, c => string.Compare(c.Name, "SonarAnalyzer.CSharp", true) == 0 && c.Version == "9.16.0.82469");
 
         }

--- a/CycloneDX.Tests/FunctionalTests/ExcludeDevDependnciesWithPackageConfig.cs
+++ b/CycloneDX.Tests/FunctionalTests/ExcludeDevDependnciesWithPackageConfig.cs
@@ -30,7 +30,8 @@ namespace CycloneDX.Tests.FunctionalTests
         [Fact]
         public async Task DevDependenciesNormalyGoIntoTheBom()
         {
-            await Console.Out.WriteLineAsync($"Run test: DevDependenciesNormalyGoIntoTheBom");
+            await Console.Out.WriteLineAsync($"Run test: DevDependenciesNormalyGoIntoTheBom");            
+            Console.SetError(Console.Out);            
 
             var options = new RunOptions
             {

--- a/CycloneDX.Tests/FunctionalTests/ExcludeDevDependnciesWithPackageConfig.cs
+++ b/CycloneDX.Tests/FunctionalTests/ExcludeDevDependnciesWithPackageConfig.cs
@@ -37,7 +37,7 @@ namespace CycloneDX.Tests.FunctionalTests
 
             var bom = await FunctionalTestHelper.Test(options, getMockFS());
 
-            Assert.True(bom.Components.Count == 1);
+            Assert.True(bom.Components.Count == 1, $"Unexpected number of components. Expected 1 was {bom.Components.Count}");
             Assert.Contains(bom.Components, c => string.Compare(c.Name, "SonarAnalyzer.CSharp", true) == 0 && c.Version == "9.16.0.82469");
 
         }

--- a/CycloneDX.Tests/FunctionalTests/ExcludeDevDependnciesWithPackageConfig.cs
+++ b/CycloneDX.Tests/FunctionalTests/ExcludeDevDependnciesWithPackageConfig.cs
@@ -18,10 +18,10 @@ namespace CycloneDX.Tests.FunctionalTests
         {
             return new MockFileSystem(new Dictionary<string, MockFileData>
             {
-                { MockUnixSupport.Path("c:/ProjectPath/project.csproj"),
+                { "c:/ProjectPath/project.csproj",
                         new MockFileData(
                             File.ReadAllText(Path.Combine("FunctionalTests", "TestcaseFiles", "DevDependencies_WithPackageConfig_CsProj.xml"))) },
-                { MockUnixSupport.Path("c:/ProjectPath/packages.config"),
+                { "c:/ProjectPath/packages.config",
                      new MockFileData(
                             File.ReadAllText(Path.Combine("FunctionalTests", "TestcaseFiles", "DevDependencies_WithPackageConfig_PackageConfig.xml"))) }
             });
@@ -29,7 +29,9 @@ namespace CycloneDX.Tests.FunctionalTests
 
         [Fact]
         public async Task DevDependenciesNormalyGoIntoTheBom()
-        {            
+        {
+            await Console.Out.WriteLineAsync($"Run test: DevDependenciesNormalyGoIntoTheBom");
+
             var options = new RunOptions
             {
             };

--- a/CycloneDX.Tests/FunctionalTests/FunctionalTestHelper.cs
+++ b/CycloneDX.Tests/FunctionalTests/FunctionalTestHelper.cs
@@ -56,12 +56,11 @@ namespace CycloneDX.Tests.FunctionalTests
         /// <returns></returns>
         public static async Task<Bom> Test(string assetsJson, RunOptions options, INugetServiceFactory nugetService)
         {
-            options.SolutionOrProjectFile ??= MockUnixSupport.Path("c:/ProjectPath/Project.csproj");
             nugetService ??= CreateMockNugetServiceFactory();
 
             var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
-                { MockUnixSupport.Path( options.SolutionOrProjectFile), new MockFileData(CsprojContents) },
+                { MockUnixSupport.Path("c:/ProjectPath/Project.csproj"), new MockFileData(CsprojContents) },
                 { MockUnixSupport.Path("c:/ProjectPath/obj/project.assets.json"), new MockFileData(assetsJson) }
             });
 

--- a/CycloneDX.Tests/FunctionalTests/FunctionalTestHelper.cs
+++ b/CycloneDX.Tests/FunctionalTests/FunctionalTestHelper.cs
@@ -56,11 +56,12 @@ namespace CycloneDX.Tests.FunctionalTests
         /// <returns></returns>
         public static async Task<Bom> Test(string assetsJson, RunOptions options, INugetServiceFactory nugetService)
         {
+            options.SolutionOrProjectFile ??= MockUnixSupport.Path("c:/ProjectPath/Project.csproj");
             nugetService ??= CreateMockNugetServiceFactory();
 
             var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
-                { MockUnixSupport.Path("c:/ProjectPath/Project.csproj"), new MockFileData(CsprojContents) },
+                { MockUnixSupport.Path( options.SolutionOrProjectFile), new MockFileData(CsprojContents) },
                 { MockUnixSupport.Path("c:/ProjectPath/obj/project.assets.json"), new MockFileData(assetsJson) }
             });
 

--- a/CycloneDX.Tests/FunctionalTests/TestcaseFiles/DevDependencies.json
+++ b/CycloneDX.Tests/FunctionalTests/TestcaseFiles/DevDependencies.json
@@ -1,0 +1,109 @@
+{
+  "version": 3,
+  "targets": {
+    "net6.0": {
+      "SonarAnalyzer.CSharp/9.16.0.82469": {
+        "type": "package"
+      }
+    }
+  },
+  "libraries": {
+    "SonarAnalyzer.CSharp/9.16.0.82469": {
+      "sha512": "Lt8Ogx+O3fowiELb9Km/5LRW0GjgIccompIv8gOK8PDdAgh2ycWTfe/9RORmym2dsqmFNR3GqcB42vx7lLaqJg==",
+      "type": "package",
+      "path": "sonaranalyzer.csharp/9.16.0.82469",
+      "hasTools": true,
+      "files": [
+        ".nupkg.metadata",
+        ".signature.p7s",
+        "analyzers/Google.Protobuf.dll",
+        "analyzers/SonarAnalyzer.CFG.dll",
+        "analyzers/SonarAnalyzer.CSharp.dll",
+        "analyzers/SonarAnalyzer.dll",
+        "images/sonarsource_64.png",
+        "license/THIRD-PARTY-NOTICES.txt",
+        "sonaranalyzer.csharp.9.16.0.82469.nupkg.sha512",
+        "sonaranalyzer.csharp.nuspec",
+        "tools/install.ps1",
+        "tools/uninstall.ps1"
+      ]
+    }
+  },
+  "projectFileDependencyGroups": {
+    "net6.0": [
+      "SonarAnalyzer.CSharp >= 9.16.0.82469"
+    ]
+  },
+  "packageFolders": {
+    "C:\\Users\\user\\.nuget\\packages\\": {},
+    "C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\NuGetPackages": {}
+  },
+  "project": {
+    "version": "1.0.0",
+    "restore": {
+      "projectUniqueName": "E:\\src\\CycloneDX-785\\WithDevDependency\\WithDevDependency\\WithDevDependency.csproj",
+      "projectName": "WithDevDependency",
+      "projectPath": "E:\\src\\CycloneDX-785\\WithDevDependency\\WithDevDependency\\WithDevDependency.csproj",
+      "packagesPath": "C:\\Users\\user\\.nuget\\packages\\",
+      "outputPath": "E:\\src\\CycloneDX-785\\WithDevDependency\\WithDevDependency\\obj\\",
+      "projectStyle": "PackageReference",
+      "fallbackFolders": [
+        "C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\NuGetPackages"
+      ],
+      "configFilePaths": [
+        "C:\\Users\\user\\AppData\\Roaming\\NuGet\\NuGet.Config",
+        "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.FallbackLocation.config",
+        "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.Offline.config"
+      ],
+      "originalTargetFrameworks": [
+        "net6.0"
+      ],
+      "sources": {
+        "C:\\Program Files (x86)\\Microsoft SDKs\\NuGetPackages\\": {},
+        "C:\\Program Files\\dotnet\\library-packs": {},
+        "https://api.nuget.org/v3/index.json": {}
+      },
+      "frameworks": {
+        "net6.0": {
+          "targetAlias": "net6.0",
+          "projectReferences": {}
+        }
+      },
+      "warningProperties": {
+        "warnAsError": [
+          "NU1605"
+        ]
+      }
+    },
+    "frameworks": {
+      "net6.0": {
+        "targetAlias": "net6.0",
+        "dependencies": {
+          "SonarAnalyzer.CSharp": {
+            "include": "Runtime, Build, Native, ContentFiles, Analyzers, BuildTransitive",
+            "suppressParent": "All",
+            "target": "Package",
+            "version": "[9.16.0.82469, )"
+          }
+        },
+        "imports": [
+          "net461",
+          "net462",
+          "net47",
+          "net471",
+          "net472",
+          "net48",
+          "net481"
+        ],
+        "assetTargetFallback": true,
+        "warn": true,
+        "frameworkReferences": {
+          "Microsoft.NETCore.App": {
+            "privateAssets": "all"
+          }
+        },
+        "runtimeIdentifierGraphPath": "C:\\Program Files\\dotnet\\sdk\\8.0.100\\RuntimeIdentifierGraph.json"
+      }
+    }
+  }
+}

--- a/CycloneDX.Tests/FunctionalTests/TestcaseFiles/DevDependencies_WithPackageConfig_CsProj.xml
+++ b/CycloneDX.Tests/FunctionalTests/TestcaseFiles/DevDependencies_WithPackageConfig_CsProj.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{34ACA412-85EF-4D18-8CCB-2351C9FE8AE7}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>DevDepencyPackageConfig</RootNamespace>
+    <AssemblyName>DevDepencyPackageConfig</AssemblyName>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="Packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\SonarAnalyzer.CSharp.9.16.0.82469\analyzers\Google.Protobuf.dll" />
+    <Analyzer Include="..\packages\SonarAnalyzer.CSharp.9.16.0.82469\analyzers\SonarAnalyzer.CFG.dll" />
+    <Analyzer Include="..\packages\SonarAnalyzer.CSharp.9.16.0.82469\analyzers\SonarAnalyzer.CSharp.dll" />
+    <Analyzer Include="..\packages\SonarAnalyzer.CSharp.9.16.0.82469\analyzers\SonarAnalyzer.dll" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/CycloneDX.Tests/FunctionalTests/TestcaseFiles/DevDependencies_WithPackageConfig_PackageConfig.xml
+++ b/CycloneDX.Tests/FunctionalTests/TestcaseFiles/DevDependencies_WithPackageConfig_PackageConfig.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="SonarAnalyzer.CSharp" version="9.16.0.82469" targetFramework="net48" developmentDependency="true" />
+</packages>

--- a/CycloneDX.Tests/ProgramTests.cs
+++ b/CycloneDX.Tests/ProgramTests.cs
@@ -55,7 +55,7 @@ namespace CycloneDX.Tests
                 });
             var mockSolutionFileService = new Mock<ISolutionFileService>();
             mockSolutionFileService
-                .Setup(s => s.GetSolutionDotnetDependencys(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<string>()))
+                .Setup(s => s.GetSolutionDotnetDependencys(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync(new HashSet<DotnetDependency>());
 
             Runner runner = new Runner(fileSystem: mockFileSystem, null, null, null, null, null, solutionFileService: mockSolutionFileService.Object, null);
@@ -80,7 +80,7 @@ namespace CycloneDX.Tests
                 });
             var mockSolutionFileService = new Mock<ISolutionFileService>();
             mockSolutionFileService
-                .Setup(s => s.GetSolutionDotnetDependencys(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<string>()))
+                .Setup(s => s.GetSolutionDotnetDependencys(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync(new HashSet<DotnetDependency>());
 
             Runner runner = new Runner(fileSystem: mockFileSystem, null, null, null, null, null, solutionFileService: mockSolutionFileService.Object, null);            

--- a/CycloneDX.Tests/ProjectAssetsFileServiceTests.cs
+++ b/CycloneDX.Tests/ProjectAssetsFileServiceTests.cs
@@ -244,7 +244,7 @@ namespace CycloneDX.Tests
             });
 
             var projectAssetsFileService = new ProjectAssetsFileService(mockFileSystem, mockDotnetCommandsService.Object, () => mockAssetReader.Object);
-            var packages = projectAssetsFileService.GetDotnetDependencys(XFS.Path(@"c:\SolutionPath\Project1\Project1.csproj"), XFS.Path(@"c:\SolutionPath\Project1\obj\project.assets.json"), false, false);
+            var packages = projectAssetsFileService.GetDotnetDependencys(XFS.Path(@"c:\SolutionPath\Project1\Project1.csproj"), XFS.Path(@"c:\SolutionPath\Project1\obj\project.assets.json"), false);
             var sortedPackages = new List<DotnetDependency>(packages);
             sortedPackages.Sort();
 
@@ -409,7 +409,7 @@ namespace CycloneDX.Tests
             });
 
             var projectAssetsFileService = new ProjectAssetsFileService(mockFileSystem, mockDotnetCommandsService.Object, () => mockAssetReader.Object);
-            var packages = projectAssetsFileService.GetDotnetDependencys(XFS.Path(@"c:\SolutionPath\Project1\Project1.csproj"), XFS.Path(@"c:\SolutionPath\Project1\obj\project.assets.json"), false, false);
+            var packages = projectAssetsFileService.GetDotnetDependencys(XFS.Path(@"c:\SolutionPath\Project1\Project1.csproj"), XFS.Path(@"c:\SolutionPath\Project1\obj\project.assets.json"), false);
             var sortedPackages = new List<DotnetDependency>(packages);
             sortedPackages.Sort();
 
@@ -549,7 +549,7 @@ namespace CycloneDX.Tests
             });
 
             var projectAssetsFileService = new ProjectAssetsFileService(mockFileSystem, mockDotnetCommandsService.Object, () => mockAssetReader.Object);
-            var packages = projectAssetsFileService.GetDotnetDependencys(XFS.Path(@"c:\SolutionPath\Project1\Project1.csproj"), XFS.Path(@"c:\SolutionPath\Project1\obj\project.assets.json"), false, false);
+            var packages = projectAssetsFileService.GetDotnetDependencys(XFS.Path(@"c:\SolutionPath\Project1\Project1.csproj"), XFS.Path(@"c:\SolutionPath\Project1\obj\project.assets.json"), false);
             var sortedPackages = new List<DotnetDependency>(packages);
             sortedPackages.Sort();
 

--- a/CycloneDX.Tests/ProjectFileServiceTests.cs
+++ b/CycloneDX.Tests/ProjectFileServiceTests.cs
@@ -82,7 +82,7 @@ namespace CycloneDX.Tests
             var mockPackageFileService = new Mock<IPackagesFileService>();
             var mockProjectAssetsFileService = new Mock<IProjectAssetsFileService>();
             mockProjectAssetsFileService
-                .Setup(s => s.GetDotnetDependencys(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()))
+                .Setup(s => s.GetDotnetDependencys(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()))
                 .Returns(new HashSet<DotnetDependency>
                 {
                     new DotnetDependency { Name = "Package", Version = "1.2.3" },
@@ -93,7 +93,7 @@ namespace CycloneDX.Tests
                 mockPackageFileService.Object,
                 mockProjectAssetsFileService.Object);
 
-            var packages = await projectFileService.GetProjectDotnetDependencysAsync(XFS.Path(@"c:\Project\Project.csproj"), "", false, false, "", "").ConfigureAwait(false);
+            var packages = await projectFileService.GetProjectDotnetDependencysAsync(XFS.Path(@"c:\Project\Project.csproj"), "", false, "", "").ConfigureAwait(false);
 
             Assert.Collection(packages,
                 item => {
@@ -117,7 +117,7 @@ namespace CycloneDX.Tests
             var mockPackageFileService = new Mock<IPackagesFileService>();
             var mockProjectAssetsFileService = new Mock<IProjectAssetsFileService>();
             mockProjectAssetsFileService
-                .Setup(s => s.GetDotnetDependencys(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()))
+                .Setup(s => s.GetDotnetDependencys(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()))
                 .Returns(new HashSet<DotnetDependency>
                 {
                     new DotnetDependency { Name = "Package", Version = "1.2.3" },
@@ -129,7 +129,7 @@ namespace CycloneDX.Tests
                 mockProjectAssetsFileService.Object);
             projectFileService.DisablePackageRestore = true;
 
-            var packages = await projectFileService.GetProjectDotnetDependencysAsync(XFS.Path(@"c:\Project\Project.csproj"), "", false, false, "", "").ConfigureAwait(false);
+            var packages = await projectFileService.GetProjectDotnetDependencysAsync(XFS.Path(@"c:\Project\Project.csproj"), "", false, "", "").ConfigureAwait(false);
 
             Assert.Collection(packages,
                 item => {
@@ -153,7 +153,7 @@ namespace CycloneDX.Tests
             var mockPackageFileService = new Mock<IPackagesFileService>();
             var mockProjectAssetsFileService = new Mock<IProjectAssetsFileService>();
             mockProjectAssetsFileService
-                .Setup(s => s.GetDotnetDependencys(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()))
+                .Setup(s => s.GetDotnetDependencys(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()))
                 .Returns(new HashSet<DotnetDependency>
                 {
                     new DotnetDependency { Name = "Package1", Version = "1.2.3" },
@@ -166,7 +166,7 @@ namespace CycloneDX.Tests
                 mockPackageFileService.Object,
                 mockProjectAssetsFileService.Object);
 
-            var packages = await projectFileService.GetProjectDotnetDependencysAsync(XFS.Path(@"c:\Project\Project.csproj"), "", false, false, "", "").ConfigureAwait(false);
+            var packages = await projectFileService.GetProjectDotnetDependencysAsync(XFS.Path(@"c:\Project\Project.csproj"), "", false, "", "").ConfigureAwait(false);
             var sortedPackages = new List<DotnetDependency>(packages);
             sortedPackages.Sort();
 
@@ -199,7 +199,7 @@ namespace CycloneDX.Tests
                 );
             var mockProjectAssetsFileService = new Mock<IProjectAssetsFileService>();
             mockProjectAssetsFileService
-                .Setup(s => s.GetDotnetDependencys(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()))
+                .Setup(s => s.GetDotnetDependencys(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()))
                 .Returns(new HashSet<DotnetDependency>());
             var projectFileService = new ProjectFileService(
                 mockFileSystem,
@@ -207,7 +207,7 @@ namespace CycloneDX.Tests
                 mockPackageFileService.Object,
                 mockProjectAssetsFileService.Object);
 
-            var packages = await projectFileService.GetProjectDotnetDependencysAsync(XFS.Path(@"c:\Project\Project.csproj"), "", false, false, "", "").ConfigureAwait(false);
+            var packages = await projectFileService.GetProjectDotnetDependencysAsync(XFS.Path(@"c:\Project\Project.csproj"), "", false, "", "").ConfigureAwait(false);
 
             Assert.Collection(packages,
                 item => {
@@ -241,7 +241,7 @@ namespace CycloneDX.Tests
                 );
             var mockProjectAssetsFileService = new Mock<IProjectAssetsFileService>();
             mockProjectAssetsFileService
-                .Setup(s => s.GetDotnetDependencys(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()))
+                .Setup(s => s.GetDotnetDependencys(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()))
                 .Returns(new HashSet<DotnetDependency>());
             var projectFileService = new ProjectFileService(
                 mockFileSystem,
@@ -249,7 +249,7 @@ namespace CycloneDX.Tests
                 mockPackageFileService.Object,
                 mockProjectAssetsFileService.Object);
 
-            var packages = await projectFileService.GetProjectDotnetDependencysAsync(XFS.Path(@"c:\Project\Project.csproj"), "", false, false, "", "").ConfigureAwait(false);
+            var packages = await projectFileService.GetProjectDotnetDependencysAsync(XFS.Path(@"c:\Project\Project.csproj"), "", false, "", "").ConfigureAwait(false);
             var sortedPackages = new List<DotnetDependency>(packages);
             sortedPackages.Sort();
 

--- a/CycloneDX.Tests/ValidationTests.cs
+++ b/CycloneDX.Tests/ValidationTests.cs
@@ -38,7 +38,7 @@ namespace CycloneDX.Tests
 
             var mockProjectFileService = new Mock<IProjectFileService>();
             mockProjectFileService.Setup(mock =>
-                mock.GetProjectDotnetDependencysAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<string>())
+                mock.GetProjectDotnetDependencysAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<string>())
             ).ReturnsAsync(packages);
 
             Runner runner = new Runner(fileSystem: mockFileSystem, null, null, null, null, projectFileService: mockProjectFileService.Object, solutionFileService: null, null);

--- a/CycloneDX/Interfaces/IProjectAssetsFileService.cs
+++ b/CycloneDX/Interfaces/IProjectAssetsFileService.cs
@@ -22,6 +22,6 @@ namespace CycloneDX.Interfaces
 {
     public interface IProjectAssetsFileService 
     {
-        HashSet<DotnetDependency> GetDotnetDependencys(string projectFilePath, string projectAssetsFilePath, bool IsTestProject, bool excludeDev);
+        HashSet<DotnetDependency> GetDotnetDependencys(string projectFilePath, string projectAssetsFilePath, bool IsTestProject);
     }
 }

--- a/CycloneDX/Interfaces/IProjectFileService.cs
+++ b/CycloneDX/Interfaces/IProjectFileService.cs
@@ -24,9 +24,9 @@ namespace CycloneDX.Interfaces
     public interface IProjectFileService
     {
         bool DisablePackageRestore { get; set; }
-        Task<HashSet<DotnetDependency>> GetProjectDotnetDependencysAsync(string projectFilePath, string baseIntermediateOutputPath, bool excludeTestProjects, bool excludeDev, string framework, string runtime);
+        Task<HashSet<DotnetDependency>> GetProjectDotnetDependencysAsync(string projectFilePath, string baseIntermediateOutputPath, bool excludeTestProjects, string framework, string runtime);
         Task<HashSet<string>> GetProjectReferencesAsync(string projectFilePath);
-        Task<HashSet<DotnetDependency>> RecursivelyGetProjectDotnetDependencysAsync(string projectFilePath, string baseIntermediateOutputPath, bool excludeTestProjects, bool excludeDev, string framework, string runtime);
+        Task<HashSet<DotnetDependency>> RecursivelyGetProjectDotnetDependencysAsync(string projectFilePath, string baseIntermediateOutputPath, bool excludeTestProjects, string framework, string runtime);
         Task<HashSet<DotnetDependency>> RecursivelyGetProjectReferencesAsync(string projectFilePath);
         Component GetComponent(DotnetDependency dotnetDependency);
         bool IsTestProject(string projectFilePath);

--- a/CycloneDX/Interfaces/ISolutionFileService.cs
+++ b/CycloneDX/Interfaces/ISolutionFileService.cs
@@ -24,6 +24,6 @@ namespace CycloneDX.Interfaces
     public interface ISolutionFileService
     {
         Task<HashSet<string>> GetSolutionProjectReferencesAsync(string solutionFilePath);
-        Task<HashSet<DotnetDependency>> GetSolutionDotnetDependencys(string solutionFilePath, string baseIntermediateOutputPath, bool excludeTestProjects, bool excludeDev, string framework, string runtime);
+        Task<HashSet<DotnetDependency>> GetSolutionDotnetDependencys(string solutionFilePath, string baseIntermediateOutputPath, bool excludeTestProjects, string framework, string runtime);
     }
 }

--- a/CycloneDX/Runner.cs
+++ b/CycloneDX/Runner.cs
@@ -142,6 +142,7 @@ namespace CycloneDX
 
             // determine what we are analyzing and do the analysis
             var fullSolutionOrProjectFilePath = this.fileSystem.Path.GetFullPath(SolutionOrProjectFile);
+            await Console.Out.WriteLineAsync($"Scan at {fullSolutionOrProjectFilePath}");
 
             var topLevelComponent = new Component
             {

--- a/CycloneDX/Runner.cs
+++ b/CycloneDX/Runner.cs
@@ -203,6 +203,9 @@ namespace CycloneDX
                 return (int)ExitCode.DotnetRestoreFailed;
             }
 
+            await Console.Out.WriteLineAsync($"Found {packages.Count()} packages so far");
+
+
             if (!string.IsNullOrEmpty(setName))
             {
                 topLevelComponent.Name = setName;
@@ -215,7 +218,13 @@ namespace CycloneDX
                 {
                     item.Scope = ComponentScope.Excluded;
                 }
+
+
+                await Console.Out.WriteLineAsync($"{packages.Where(p => p.IsDevDependency).Count()} packages being excluded as DevDependencies");
             }
+
+
+            
 
             // get all the components and dependency graph from the NuGet packages
             var components = new HashSet<Component>();

--- a/CycloneDX/Runner.cs
+++ b/CycloneDX/Runner.cs
@@ -142,7 +142,7 @@ namespace CycloneDX
 
             // determine what we are analyzing and do the analysis
             var fullSolutionOrProjectFilePath = this.fileSystem.Path.GetFullPath(SolutionOrProjectFile);
-            await Console.Out.WriteLineAsync($"Scan at {fullSolutionOrProjectFilePath}");
+            await Console.Out.WriteLineAsync($"Scanning at {fullSolutionOrProjectFilePath}");
 
             var topLevelComponent = new Component
             {

--- a/CycloneDX/Runner.cs
+++ b/CycloneDX/Runner.cs
@@ -203,7 +203,7 @@ namespace CycloneDX
                 return (int)ExitCode.DotnetRestoreFailed;
             }
 
-            await Console.Out.WriteLineAsync($"Found {packages.Count()} packages so far");
+            await Console.Out.WriteLineAsync($"Found {packages.Count()} packages");
 
 
             if (!string.IsNullOrEmpty(setName))

--- a/CycloneDX/Services/PackagesFileService.cs
+++ b/CycloneDX/Services/PackagesFileService.cs
@@ -23,6 +23,7 @@ using System.Threading.Tasks;
 using CycloneDX.Interfaces;
 using CycloneDX.Models;
 using System.Linq;
+using System;
 
 namespace CycloneDX.Services
 {
@@ -65,7 +66,7 @@ namespace CycloneDX.Services
                                 IsDevDependency = reader["developmentDependency"] == "true",
                                 Scope = Component.ComponentScope.Required
                             };
-
+                            await Console.Out.WriteLineAsync($"\tFound Package:{newPackage.Name}");
                             packages.Add(newPackage);                            
                         }
                     }

--- a/CycloneDX/Services/PackagesFileService.cs
+++ b/CycloneDX/Services/PackagesFileService.cs
@@ -22,6 +22,7 @@ using System.IO.Abstractions;
 using System.Threading.Tasks;
 using CycloneDX.Interfaces;
 using CycloneDX.Models;
+using System.Linq;
 
 namespace CycloneDX.Services
 {
@@ -57,11 +58,15 @@ namespace CycloneDX.Services
                     {
                         if (reader.IsStartElement() && reader.Name == "package")
                         {
-                            packages.Add(new DotnetDependency
+                            var newPackage = new DotnetDependency
                             {
                                 Name = reader["id"],
                                 Version = reader["version"],
-                            });
+                                IsDevDependency = reader["developmentDependency"] == "true",
+                                Scope = Component.ComponentScope.Required
+                            };
+
+                            packages.Add(newPackage);                            
                         }
                     }
                 }

--- a/CycloneDX/Services/ProjectAssetsFileService.cs
+++ b/CycloneDX/Services/ProjectAssetsFileService.cs
@@ -41,7 +41,7 @@ namespace CycloneDX.Services
             _assetFileReaderFactory = assetFileReaderFactory;
         }
 
-        public HashSet<DotnetDependency> GetDotnetDependencys(string projectFilePath, string projectAssetsFilePath, bool isTestProject, bool excludeDev)
+        public HashSet<DotnetDependency> GetDotnetDependencys(string projectFilePath, string projectAssetsFilePath, bool isTestProject)
         {
             var packages = new HashSet<DotnetDependency>();
 
@@ -84,7 +84,7 @@ namespace CycloneDX.Services
                         };
 
                         // is this a test project dependency or only a development dependency
-                        if ( isTestProject || (package.IsDevDependency && excludeDev))
+                        if ( isTestProject)
                         {
                             package.Scope = Component.ComponentScope.Excluded;
                         }

--- a/CycloneDX/Services/ProjectFileService.cs
+++ b/CycloneDX/Services/ProjectFileService.cs
@@ -146,7 +146,7 @@ namespace CycloneDX.Services
         /// </summary>
         /// <param name="projectFilePath"></param>
         /// <returns></returns>
-        public async Task<HashSet<DotnetDependency>> GetProjectDotnetDependencysAsync(string projectFilePath, string baseIntermediateOutputPath, bool excludeTestProjects, bool excludeDev, string framework, string runtime)
+        public async Task<HashSet<DotnetDependency>> GetProjectDotnetDependencysAsync(string projectFilePath, string baseIntermediateOutputPath, bool excludeTestProjects, string framework, string runtime)
         {
             if (!_fileSystem.File.Exists(projectFilePath))
             {
@@ -187,7 +187,7 @@ namespace CycloneDX.Services
             {
                 Console.WriteLine($"File not found: \"{assetsFilename}\", \"{projectFilePath}\" ");
             }
-            var packages = _projectAssetsFileService.GetDotnetDependencys(projectFilePath, assetsFilename, isTestProject, excludeDev);
+            var packages = _projectAssetsFileService.GetDotnetDependencys(projectFilePath, assetsFilename, isTestProject);
 
 
             // if there are no project file package references look for a packages.config
@@ -210,9 +210,9 @@ namespace CycloneDX.Services
         /// </summary>
         /// <param name="projectFilePath"></param>
         /// <returns></returns>
-        public async Task<HashSet<DotnetDependency>> RecursivelyGetProjectDotnetDependencysAsync(string projectFilePath, string baseIntermediateOutputPath, bool excludeTestProjects, bool excludeDev, string framework, string runtime)
+        public async Task<HashSet<DotnetDependency>> RecursivelyGetProjectDotnetDependencysAsync(string projectFilePath, string baseIntermediateOutputPath, bool excludeTestProjects, string framework, string runtime)
         {
-            var DotnetDependencys = await GetProjectDotnetDependencysAsync(projectFilePath, baseIntermediateOutputPath, excludeTestProjects, excludeDev, framework, runtime).ConfigureAwait(false);
+            var DotnetDependencys = await GetProjectDotnetDependencysAsync(projectFilePath, baseIntermediateOutputPath, excludeTestProjects, framework, runtime).ConfigureAwait(false);
             var projectReferences = await RecursivelyGetProjectReferencesAsync(projectFilePath).ConfigureAwait(false);
 
             //Remove root-project, it will be added to the metadata
@@ -223,7 +223,7 @@ namespace CycloneDX.Services
 
             foreach (var project in projectReferences)
             {
-                var projectDotnetDependencys = await GetProjectDotnetDependencysAsync(project.Path, baseIntermediateOutputPath, excludeTestProjects, excludeDev, framework, runtime).ConfigureAwait(false);
+                var projectDotnetDependencys = await GetProjectDotnetDependencysAsync(project.Path, baseIntermediateOutputPath, excludeTestProjects, framework, runtime).ConfigureAwait(false);
 
                 foreach (var dependency in projectDotnetDependencys)
                 {

--- a/CycloneDX/Services/SolutionFileService.cs
+++ b/CycloneDX/Services/SolutionFileService.cs
@@ -82,7 +82,7 @@ namespace CycloneDX.Services
         /// </summary>
         /// <param name="solutionFilePath"></param>
         /// <returns></returns>
-        public async Task<HashSet<DotnetDependency>> GetSolutionDotnetDependencys(string solutionFilePath, string baseIntermediateOutputPath, bool excludeTestProjects, bool excludeDev, string framework, string runtime)
+        public async Task<HashSet<DotnetDependency>> GetSolutionDotnetDependencys(string solutionFilePath, string baseIntermediateOutputPath, bool excludeTestProjects, string framework, string runtime)
         {
             if (!_fileSystem.File.Exists(solutionFilePath))
             {
@@ -113,7 +113,7 @@ namespace CycloneDX.Services
             foreach (var projectFilePath in projectQuery)
             {
                 Console.WriteLine();
-                var projectPackages = await _projectFileService.GetProjectDotnetDependencysAsync(projectFilePath, baseIntermediateOutputPath, excludeTestProjects, excludeDev, framework, runtime).ConfigureAwait(false);
+                var projectPackages = await _projectFileService.GetProjectDotnetDependencysAsync(projectFilePath, baseIntermediateOutputPath, excludeTestProjects, framework, runtime).ConfigureAwait(false);
                 directReferencePackages.UnionWith(projectPackages.Where(p => p.IsDirectReference));
                 packages.UnionWith(projectPackages);
             }


### PR DESCRIPTION
feat: DevDependencies also work for packages.config
fix: excluded DevDependencies won't appear in the dependencyTree any more #761