### PR TITLE
Create bom.json in docker container as smoke test (#806)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,13 +64,10 @@ jobs:
           path: ./CycloneDX.sln
           github-bearer-token: ${{ secrets.GITHUB_TOKEN }}
 
+      # Generate the JSON with the docker container as additional smoke test
       - name: Generate JSON SBOM
-        uses: CycloneDX/gh-dotnet-generate-sbom@master
-        with:
-          path: ./CycloneDX.sln
-          json: true
-          github-bearer-token: ${{ secrets.GITHUB_TOKEN }}
-
+        run: docker run --rm -v ${GITHUB_WORKSPACE}:/usr/src/project cyclonedx/cyclonedx-dotnet:${{ steps.package_release.outputs.version }} /usr/src/project/CycloneDX.sln -j -o /usr/src/project 
+        
       - name: Publish package to NuGet
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}


### PR DESCRIPTION
This should have prevented #806 

Generally, it's a good idea to check if the container works before publishing it.