### PR TITLE
Removed a code snippet in ProjectFileService.cs that caused a crash and has no use

### DIFF
--- a/CycloneDX/Services/ProjectFileService.cs
+++ b/CycloneDX/Services/ProjectFileService.cs
@@ -221,11 +221,6 @@ namespace CycloneDX.Services
             {
                 var projectDotnetDependencys = await GetProjectDotnetDependencysAsync(project.Path, baseIntermediateOutputPath, excludeTestProjects, framework, runtime).ConfigureAwait(false);
 
-                foreach (var dependency in projectDotnetDependencys)
-                {
-                    project.Dependencies.Add(dependency.Name, dependency.Version);
-                }
-
                 DotnetDependencys.UnionWith(projectDotnetDependencys);
             }
 


### PR DESCRIPTION
We encountered a problem with the current 3.0.4 version of the tool. We had a weird crash of the tool in some of our build pipelines. It seems to be a problem regarding duplicate keys in a dictionary. 

We debugged the code and found a foreach loop that added dependencies into a unused object property. We removed the code since we don't see the use in it and removing the code also fixed our crash.

This is the stack trace of the error we encountered:
```
Unhandled exception: System.ArgumentException: An item with the same key has already been added. Key: Microsoft.IO.RecyclableMemoryStream
   at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
   at System.Collections.Generic.Dictionary`2.Add(TKey key, TValue value)
   at CycloneDX.Services.ProjectFileService.RecursivelyGetProjectDotnetDependencysAsync(String projectFilePath, String baseIntermediateOutputPath, Boolean excludeTestProjects, String framework, String runtime) in /home/runner/work/cyclonedx-dotnet/cyclonedx-dotnet/CycloneDX/Services/ProjectFileService.cs:line 226
```