### PR TITLE
Recursive package config dependency graph

### DIFF
--- a/CycloneDX.Tests/CycloneDX.Tests.csproj
+++ b/CycloneDX.Tests/CycloneDX.Tests.csproj
@@ -57,6 +57,18 @@
     <None Update="FunctionalTests\TestcaseFiles\SimpleNETStandardLibrary.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="FunctionalTests\TestcaseFrameworkPackagesConfigRecursive\packages1.config">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="FunctionalTests\TestcaseFrameworkPackagesConfigRecursive\packages2.config">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="FunctionalTests\TestcaseFrameworkPackagesConfigRecursive\project1csproj.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="FunctionalTests\TestcaseFrameworkPackagesConfigRecursive\project2csproj.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="Resources\metadata\cycloneDX-metadata-template.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/CycloneDX.Tests/FunctionalTests/TestcaseFrameworkPackagesConfigRecursive/FrameworkPackagesConfigRecursive.cs
+++ b/CycloneDX.Tests/FunctionalTests/TestcaseFrameworkPackagesConfigRecursive/FrameworkPackagesConfigRecursive.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.IO;
+using System.IO.Abstractions;
+using System.IO.Abstractions.TestingHelpers;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using CycloneDX.Models;
+using Xunit;
+
+namespace CycloneDX.Tests.FunctionalTests
+{
+    public class FrameworkPackagesConfigRecursive
+    {
+        private MockFileSystem getMockFS()
+        {
+            return new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { MockUnixSupport.Path("c:/ProjectPath/Project.csproj"),
+                        new MockFileData(
+                            File.ReadAllText(Path.Combine("FunctionalTests", "TestcaseFrameworkPackagesConfigRecursive", "project1csproj.xml"))) },
+                { MockUnixSupport.Path("c:/ProjectPath/packages.config"),
+                     new MockFileData(
+                            File.ReadAllText(Path.Combine("FunctionalTests", "TestcaseFrameworkPackagesConfigRecursive", "packages1.config"))) },
+                 { MockUnixSupport.Path("c:/ConsoleApp2/ConsoleApp2.csproj"),
+                     new MockFileData(
+                            File.ReadAllText(Path.Combine("FunctionalTests", "TestcaseFrameworkPackagesConfigRecursive", "project2csproj.xml"))) },
+                 { MockUnixSupport.Path("c:/ConsoleApp2/packages.config"),
+                     new MockFileData(
+                            File.ReadAllText(Path.Combine("FunctionalTests", "TestcaseFrameworkPackagesConfigRecursive", "packages2.config"))) }
+            });
+        }
+
+        [Fact]
+        public async Task WithoutRecursiveScan()
+        {
+            var options = new RunOptions
+            {             
+            };
+
+            var bom = await FunctionalTestHelper.Test(options, getMockFS());
+
+            Assert.True(bom.Components.Count == 7, $"Unexpected number of components. Expected 7, got {bom.Components.Count}");
+            Assert.DoesNotContain(bom.Components, c => string.Compare(c.Name, "log4net", true) == 0 && c.Version == "2.0.15");
+            FunctionalTestHelper.AssertHasDependencyWithChild(bom, "Project@0.0.0", "pkg:nuget/Stubble.Core@1.10.8");
+            
+
+        }
+
+        [Fact]
+        public async Task WithRecursiveScan()
+        {
+            var options = new RunOptions
+            {
+                scanProjectReferences = true
+            };
+
+            var bom = await FunctionalTestHelper.Test(options, getMockFS());
+
+            Assert.True(bom.Components.Count == 8, $"Unexpected number of components. Expected 8, got {bom.Components.Count}");
+            Assert.Contains(bom.Components, c => string.Compare(c.Name, "log4net", true) == 0 && c.Version == "2.0.15");
+            FunctionalTestHelper.AssertHasDependencyWithChild(bom, "Project@0.0.0", "pkg:nuget/Stubble.Core@1.10.8");
+            FunctionalTestHelper.AssertHasDependencyWithChild(bom, "Project@0.0.0", "pkg:nuget/log4net@2.0.15");
+
+        }
+    }
+}

--- a/CycloneDX.Tests/FunctionalTests/TestcaseFrameworkPackagesConfigRecursive/FrameworkPackagesConfigRecursive.cs
+++ b/CycloneDX.Tests/FunctionalTests/TestcaseFrameworkPackagesConfigRecursive/FrameworkPackagesConfigRecursive.cs
@@ -65,5 +65,25 @@ namespace CycloneDX.Tests.FunctionalTests
             FunctionalTestHelper.AssertHasDependencyWithChild(bom, "Project@0.0.0", "pkg:nuget/log4net@2.0.15");
 
         }
+
+        [Fact]
+        public async Task WithRecursiveScanIPR()
+        {
+            var options = new RunOptions
+            {
+                includeProjectReferences = true,
+                scanProjectReferences = true
+            };
+
+            var bom = await FunctionalTestHelper.Test(options, getMockFS());
+
+            Assert.True(bom.Components.Count == 9, $"Unexpected number of components. Expected 9, got {bom.Components.Count}");
+            Assert.Contains(bom.Components, c => string.Compare(c.Name, "log4net", true) == 0 && c.Version == "2.0.15");
+            Assert.Contains(bom.Components, c => string.Compare(c.Name, "ConsoleApp2", true) == 0 && c.Version == "undefined");
+            FunctionalTestHelper.AssertHasDependencyWithChild(bom, "Project@0.0.0", "pkg:nuget/Stubble.Core@1.10.8");
+            FunctionalTestHelper.AssertHasDependencyWithChild(bom, "Project@0.0.0", "ConsoleApp2@undefined");
+            FunctionalTestHelper.AssertHasDependencyWithChild(bom, "ConsoleApp2@undefined", "pkg:nuget/log4net@2.0.15");
+
+        }
     }
 }

--- a/CycloneDX.Tests/FunctionalTests/TestcaseFrameworkPackagesConfigRecursive/packages1.config
+++ b/CycloneDX.Tests/FunctionalTests/TestcaseFrameworkPackagesConfigRecursive/packages1.config
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages xmlns="urn:packages">
+  <package id="Stubble.Core" version="1.10.8" targetFramework="net48" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net48" />
+  <package id="System.Collections.Immutable" version="5.0.0" targetFramework="net48" />
+  <package id="System.Memory" version="4.5.4" targetFramework="net48" />
+  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net48" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
+</packages>

--- a/CycloneDX.Tests/FunctionalTests/TestcaseFrameworkPackagesConfigRecursive/packages2.config
+++ b/CycloneDX.Tests/FunctionalTests/TestcaseFrameworkPackagesConfigRecursive/packages2.config
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages xmlns="urn:packages">
+  <package id="log4net" version="2.0.15" targetFramework="net48" />
+</packages>

--- a/CycloneDX.Tests/FunctionalTests/TestcaseFrameworkPackagesConfigRecursive/project1csproj.xml
+++ b/CycloneDX.Tests/FunctionalTests/TestcaseFrameworkPackagesConfigRecursive/project1csproj.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{3E167814-3226-46E5-8B1A-6A3962350F08}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>PackageConfig</RootNamespace>
+    <AssemblyName>PackageConfig</AssemblyName>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Stubble.Core, Version=1.10.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Stubble.Core.1.10.8\lib\net45\Stubble.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Collections.Immutable, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.5.0.0\lib\net461\System.Collections.Immutable.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Core" />
+    <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.3\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="Packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ConsoleApp2\ConsoleApp2.csproj">
+      <Project>{7abb510c-f4de-4413-a9f4-a04db9a3f55f}</Project>
+      <Name>ConsoleApp2</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/CycloneDX.Tests/FunctionalTests/TestcaseFrameworkPackagesConfigRecursive/project2csproj.xml
+++ b/CycloneDX.Tests/FunctionalTests/TestcaseFrameworkPackagesConfigRecursive/project2csproj.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{7ABB510C-F4DE-4413-A9F4-A04DB9A3F55F}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>ConsoleApp2</RootNamespace>
+    <AssemblyName>ConsoleApp2</AssemblyName>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="log4net, Version=2.0.15.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\packages\log4net.2.0.15\lib\net45\log4net.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Collections.Immutable, Version=1.2.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.1.5.0\lib\netstandard2.0\System.Collections.Immutable.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.0\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.1\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/CycloneDX/Services/ProjectFileService.cs
+++ b/CycloneDX/Services/ProjectFileService.cs
@@ -324,7 +324,6 @@ namespace CycloneDX.Services
                 dependency.Dependencies = foundProjectReferences.ToDictionary(key => key, value => (string)null);
                 dependency.Scope = Component.ComponentScope.Required;
                 dependency.DependencyType = DependencyType.Project;
-                dependency.Dependencies = new Dictionary<string, string>();
                 projectReferences.Add(dependency);
 
                 // Add unvisited project files to the queue

--- a/CycloneDX/Services/ProjectFileService.cs
+++ b/CycloneDX/Services/ProjectFileService.cs
@@ -221,11 +221,6 @@ namespace CycloneDX.Services
             {
                 var projectDotnetDependencys = await GetProjectDotnetDependencysAsync(project.Path, baseIntermediateOutputPath, excludeTestProjects, framework, runtime).ConfigureAwait(false);
 
-                foreach (var dependency in projectDotnetDependencys)
-                {
-                    project.Dependencies.Add(dependency.Name, dependency.Version);
-                }
-
                 DotnetDependencys.UnionWith(projectDotnetDependencys);
             }
 


### PR DESCRIPTION
Added a testcase for `-rs` with `packages.config`.
Fixed a bug, that dependencies in that case were not linked in the dependency graph.