### PR TITLE
Fix crash when a projectfile doesn't existent #826

### DIFF
--- a/CycloneDX.Tests/CycloneDX.Tests.csproj
+++ b/CycloneDX.Tests/CycloneDX.Tests.csproj
@@ -33,6 +33,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="FunctionalTests\Issue826-ProjectFileDoesntExist\project1csproj.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="FunctionalTests\Issue826-ProjectFileDoesntExist\solution1sln.text">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="FunctionalTests\TestcaseFiles\DevDependencies.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/CycloneDX.Tests/FunctionalTests/Issue826-ProjectFileDoesntExist/ReferencedProjectFileDoesntExists.cs
+++ b/CycloneDX.Tests/FunctionalTests/Issue826-ProjectFileDoesntExist/ReferencedProjectFileDoesntExists.cs
@@ -12,7 +12,7 @@ using Xunit;
 
 namespace CycloneDX.Tests.FunctionalTests
 {
-    public class ReferencedProjectFileDoesntExists
+    public class Issue826ReferencedProjectFileDoesntExists
     {
         private MockFileSystem getMockFS()
         {

--- a/CycloneDX.Tests/FunctionalTests/Issue826-ProjectFileDoesntExist/ReferencedProjectFileDoesntExists.cs
+++ b/CycloneDX.Tests/FunctionalTests/Issue826-ProjectFileDoesntExist/ReferencedProjectFileDoesntExists.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.IO;
+using System.IO.Abstractions;
+using System.IO.Abstractions.TestingHelpers;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using CycloneDX.Models;
+using Xunit;
+
+namespace CycloneDX.Tests.FunctionalTests
+{
+    public class ReferencedProjectFileDoesntExists
+    {
+        private MockFileSystem getMockFS()
+        {
+            return new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {
+                    MockUnixSupport.Path("c:/ProjectPath/sln.sln"),
+                        new MockFileData(
+                            File.ReadAllText(Path.Combine("FunctionalTests", "Issue826-ProjectFileDoesntExist", "solution1sln.text")))
+                },{
+                    MockUnixSupport.Path("c:/ProjectPath/Project.csproj"),
+                        new MockFileData(
+                            File.ReadAllText(Path.Combine("FunctionalTests", "Issue826-ProjectFileDoesntExist", "project1csproj.xml"))) }            
+            });
+        }
+
+        [Fact]
+        public async Task WithoutRecursiveScan()
+        {
+            var options = new RunOptions
+            {
+                scanProjectReferences = true,
+                SolutionOrProjectFile = MockUnixSupport.Path("c:/ProjectPath/sln.sln")
+            };            
+
+            //Just test that there is no exception
+            var bom = await FunctionalTestHelper.Test(options, getMockFS());
+        }
+    }
+}

--- a/CycloneDX.Tests/FunctionalTests/Issue826-ProjectFileDoesntExist/project1csproj.xml
+++ b/CycloneDX.Tests/FunctionalTests/Issue826-ProjectFileDoesntExist/project1csproj.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{3E167814-3226-46E5-8B1A-6A3962350F08}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>PackageConfig</RootNamespace>
+    <AssemblyName>PackageConfig</AssemblyName>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>    
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="Packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+  <Choose>
+    <When Condition=" 'Today' == '30th February'">
+      <ItemGroup>
+        <!-- Project reference that doesn't exist-->
+        <ProjectReference Include="..\foo\bar.csproj">
+          <Project>{7abb510c-f4de-4413-a9f4-a04db9a3f55f}</Project>
+          <Name>foobar</Name>
+        </ProjectReference>
+      </ItemGroup>
+    </When>
+  </Choose>
+
+
+  <ItemGroup>
+    <ProjectReference Include="..\ConsoleApp2\ConsoleApp2.csproj">
+      <Project>{7abb510c-f4de-4413-a9f4-a04db9a3f55f}</Project>
+      <Name>ConsoleApp2</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/CycloneDX.Tests/FunctionalTests/Issue826-ProjectFileDoesntExist/solution1sln.text
+++ b/CycloneDX.Tests/FunctionalTests/Issue826-ProjectFileDoesntExist/solution1sln.text
@@ -1,0 +1,24 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.34330.188
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsoleApp1", "c:/ProjectPath/Project.csproj", "{3E167814-3226-46E5-8B1A-6A3962350F08}"
+EndProject
+Global
+GlobalSection(SolutionConfigurationPlatforms) = preSolution
+Debug|Any CPU = Debug|Any CPU
+Release|Any CPU = Release|Any CPU
+EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+{3E167814-3226-46E5-8B1A-6A3962350F08}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{3E167814-3226-46E5-8B1A-6A3962350F08}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{3E167814-3226-46E5-8B1A-6A3962350F08}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{3E167814-3226-46E5-8B1A-6A3962350F08}.Release|Any CPU.Build.0 = Release|Any CPU
+EndGlobalSection
+GlobalSection(SolutionProperties) = preSolution
+HideSolutionNode = FALSE
+EndGlobalSection
+GlobalSection(ExtensibilityGlobals) = postSolution
+SolutionGuid = {B712ECBA-C73F-46F7-BCC6-F2A4B1A9A101}
+EndGlobalSection
+EndGlobal

--- a/CycloneDX/Services/ProjectFileService.cs
+++ b/CycloneDX/Services/ProjectFileService.cs
@@ -77,9 +77,10 @@ namespace CycloneDX.Services
 
         private (string name, string version) GetProjectNameAndVersion(string projectFilePath)
         {
-            string name = null;
-            string version = null;
-
+            if (!_fileSystem.File.Exists(projectFilePath))
+            {
+                return (_fileSystem.Path.GetFileNameWithoutExtension(projectFilePath), "undefined");
+            }
 
 
             XmlDocument xmldoc = new XmlDocument();
@@ -89,13 +90,13 @@ namespace CycloneDX.Services
             XmlNamespaceManager namespaces = new XmlNamespaceManager(xmldoc.NameTable);
             namespaces.AddNamespace("msbuild", "http://schemas.microsoft.com/developer/msbuild/2003");
 
-            name = (xmldoc.SelectSingleNode("/Project/PropertyGroup/AssemblyName") as XmlElement)?.Value
+            string name = (xmldoc.SelectSingleNode("/Project/PropertyGroup/AssemblyName") as XmlElement)?.Value
                 ?? (xmldoc.SelectSingleNode("/Project/PropertyGroup/msbuild:AssemblyName", namespaces) as XmlElement)?.Value
                 ?? _fileSystem.Path.GetFileNameWithoutExtension(projectFilePath);
 
             // Extract Version
             XmlElement versionElement = xmldoc.SelectSingleNode("/Project/PropertyGroup/Version") as XmlElement;
-            version = versionElement?.Value;
+            string version = versionElement?.Value;
 
             if (version == null)
             {                

--- a/CycloneDX/Services/ProjectFileService.cs
+++ b/CycloneDX/Services/ProjectFileService.cs
@@ -61,6 +61,11 @@ namespace CycloneDX.Services
 
         public bool IsTestProject(string projectFilePath)
         {
+            if (!_fileSystem.File.Exists(projectFilePath))
+            {
+                return false;
+            }
+
             XmlDocument xmldoc = new XmlDocument();
             using var fileStream = _fileSystem.FileStream.New(projectFilePath, FileMode.Open);
             xmldoc.Load(fileStream);


### PR DESCRIPTION
The tool doesn't check condition in .csproj-file. Conditional project references will always be considered regular project references.
Thus, it can happen that a .csproj-file doesn't actually exist in the current environment. The solution is to check if the file exists and return some replacement values if it doesn't.

This is still not really supported, the resulting SBOM might be wrong, but at least it doesn't crash.