### PR TITLE
#606 When multiple bom ref are found when cdx runs on a .sln allow bom generation.

### DIFF
--- a/CycloneDX.Tests/CycloneDX.Tests.csproj
+++ b/CycloneDX.Tests/CycloneDX.Tests.csproj
@@ -33,6 +33,21 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="FunctionalTests\Issue606\project2assets.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="FunctionalTests\Issue606\project1assets.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="FunctionalTests\Issue606\project2csproj.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="FunctionalTests\Issue606\project1csproj.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="FunctionalTests\Issue606\solution1sln.text">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="FunctionalTests\Issue826alt-ProjectFileDoesntExistWithAssetsFile\project2assets.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/CycloneDX/Runner.cs
+++ b/CycloneDX/Runner.cs
@@ -159,7 +159,6 @@ namespace CycloneDX
                 return (int)ExitCode.InvalidOptions;
             }
 
-
             try
             {
                 if (SolutionOrProjectFile.ToLowerInvariant().EndsWith(".sln", StringComparison.OrdinalIgnoreCase))
@@ -295,6 +294,14 @@ namespace CycloneDX
                                 if (packageNameMatch.Count == 1)
                                 {
                                     lookupKey = packageNameMatch.First().Key;
+                                }
+                                else if (packageNameMatch.Count > 1 && SolutionOrProjectFile.ToLowerInvariant().EndsWith(".sln", StringComparison.OrdinalIgnoreCase))
+                                {
+                                    Console.ForegroundColor = ConsoleColor.Yellow;
+                                    Console.WriteLine($"Warning: Multiple BOM references were found for {dep.Key} {dep.Value}. It appears that the component has been located multiple times with different versions. To resolve this issue, consider targeting a project file directly that's using a project.assets.json to resolve dependencies and avoid using the --recursive argument.");
+                                    lookupKey = packageNameMatch.First().Key;
+                                    Console.WriteLine($"Choosing first found reference {lookupKey.Item1} {lookupKey.Item2} to resolve.");
+                                    Console.ResetColor();
                                 }
                                 else
                                 {


### PR DESCRIPTION
> I could only reproduce this, calling CycloneDX directly on the .sln-file. That creates the situation that dependencies of each project are gathered separately and then aggregated. This way CycloneDX cannot know, which is the actually used version as depending on which project you build either is true.
> 
> I am not 100% sure if this should be fixed, as the result might not reflect the actual truth.
> 
> However, who generates an SBOM from a .sln-file that includes multiple packages or other output projects (like executables or services, I like to call those root-projects) cannot expect the SBOM to include sensible information.
> 
> So in that case, CycloneDX will show this warning and resolve to the first found reference:
> 
> ```
> Warning: Multiple BOM references were found for rebus [6.0.0, 7.0.0). It appears that the component has been located multiple times with different versions. To resolve this issue, consider targeting a project file directly that's using a project.assets.json to resolve dependencies and avoid using the --recursive argument.
> Choosing first found reference rebus 7.1.0 to resolve.
> ```

https://github.com/CycloneDX/cyclonedx-dotnet/issues/606#issuecomment-1890735523