### PR TITLE
Add VB assembly version info

### DIFF
--- a/CycloneDX.Tests/ProjectFileServiceTests.cs
+++ b/CycloneDX.Tests/ProjectFileServiceTests.cs
@@ -326,5 +326,49 @@ namespace CycloneDX.Tests
                 item => Assert.Equal(XFS.Path(@"c:\SolutionPath\Project2\Project2.csproj"), item),
                 item => Assert.Equal(XFS.Path(@"c:\SolutionPath\Project3\Project3.csproj"), item));
         }
+
+        [Fact]
+        public async Task RecursivelyGetProjectReferences_ReturnsCSAssemblyVersion()
+        {
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\SolutionPath\Project1\Project1.csproj"), new MockFileData(@"<Project></Project>") },
+                { XFS.Path(@"c:\SolutionPath\Project1\Properties\AssemblyInfo.cs"), new MockFileData(@"[assembly: AssemblyVersion(""3.2.1.0"")]")}
+            });
+            var mockDotnetUtilsService = new Mock<IDotnetUtilsService>();
+            var mockPackageFileService = new Mock<IPackagesFileService>();
+            var mockProjectAssetsFileService = new Mock<IProjectAssetsFileService>();
+            var projectFileService = new ProjectFileService(
+                mockFileSystem,
+                mockDotnetUtilsService.Object,
+                mockPackageFileService.Object,
+                mockProjectAssetsFileService.Object);
+
+            var projects = await projectFileService.RecursivelyGetProjectReferencesAsync(XFS.Path(@"c:\SolutionPath\Project1\Project1.csproj")).ConfigureAwait(true);
+
+            Assert.Equal("3.2.1.0", projects.FirstOrDefault().Version);
+        }
+
+        [Fact]
+        public async Task RecursivelyGetProjectReferences_ReturnsVBAssemblyVersion()
+        {
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\SolutionPath\Project1\Project1.vbproj"), new MockFileData(@"<Project></Project>") },
+                { XFS.Path(@"c:\SolutionPath\Project1\My Project\AssemblyInfo.vb"), new MockFileData(@"<Assembly: AssemblyVersion(""3.2.1.0"")>")}
+            });
+            var mockDotnetUtilsService = new Mock<IDotnetUtilsService>();
+            var mockPackageFileService = new Mock<IPackagesFileService>();
+            var mockProjectAssetsFileService = new Mock<IProjectAssetsFileService>();
+            var projectFileService = new ProjectFileService(
+                mockFileSystem,
+                mockDotnetUtilsService.Object,
+                mockPackageFileService.Object,
+                mockProjectAssetsFileService.Object);
+
+            var projects = await projectFileService.RecursivelyGetProjectReferencesAsync(XFS.Path(@"c:\SolutionPath\Project1\Project1.vbproj")).ConfigureAwait(true);
+
+            Assert.Equal("3.2.1.0", projects.FirstOrDefault().Version);
+        }
     }
 }

--- a/CycloneDX/Services/ProjectFileService.cs
+++ b/CycloneDX/Services/ProjectFileService.cs
@@ -115,13 +115,23 @@ namespace CycloneDX.Services
 
             if (version == null)
             {
-                string assemblyInfoPath = Path.Combine(Path.GetDirectoryName(projectFilePath), "Properties", "AssemblyInfo.cs");
+                string assemblyInfoPath;
+                string pattern;
+                switch (Path.GetExtension(projectFilePath))
+                {
+                    case ".vbproj":
+                        assemblyInfoPath = Path.Combine(Path.GetDirectoryName(projectFilePath), "My Project", "AssemblyInfo.vb");
+                        pattern = @"^\<Assembly: AssemblyVersion\(""(?<Version>.*?)""\)\>$";
+                        break;
+                    default:
+                        assemblyInfoPath = Path.Combine(Path.GetDirectoryName(projectFilePath), "Properties", "AssemblyInfo.cs");
+                        pattern = @"^\[assembly: AssemblyVersion\(""(?<Version>.*?)""\)\]$";
+                        break;
+                }
+
                 if (_fileSystem.File.Exists(assemblyInfoPath))
                 {
-
                     string[] lines = _fileSystem.File.ReadAllLines(assemblyInfoPath);
-                    string pattern = @"^\[assembly: AssemblyVersion\(""(?<Version>.*?)""\)\]$";
-
                     foreach (var line in lines)
                     {
                         Match match = Regex.Match(line, pattern);

--- a/CycloneDX/Services/ProjectFileService.cs
+++ b/CycloneDX/Services/ProjectFileService.cs
@@ -117,16 +117,15 @@ namespace CycloneDX.Services
             {
                 string assemblyInfoPath;
                 string pattern;
-                switch (Path.GetExtension(projectFilePath))
+                if (Path.GetExtension(projectFilePath).Equals(".vbproj", StringComparison.Ordinal))
                 {
-                    case ".vbproj":
-                        assemblyInfoPath = Path.Combine(Path.GetDirectoryName(projectFilePath), "My Project", "AssemblyInfo.vb");
-                        pattern = @"^\<Assembly: AssemblyVersion\(""(?<Version>.*?)""\)\>$";
-                        break;
-                    default:
-                        assemblyInfoPath = Path.Combine(Path.GetDirectoryName(projectFilePath), "Properties", "AssemblyInfo.cs");
-                        pattern = @"^\[assembly: AssemblyVersion\(""(?<Version>.*?)""\)\]$";
-                        break;
+                    assemblyInfoPath = Path.Combine(Path.GetDirectoryName(projectFilePath), "My Project", "AssemblyInfo.vb");
+                    pattern = @"^\<Assembly: AssemblyVersion\(""(?<Version>.*?)""\)\>$";
+                }
+                else
+                {
+                    assemblyInfoPath = Path.Combine(Path.GetDirectoryName(projectFilePath), "Properties", "AssemblyInfo.cs");
+                    pattern = @"^\[assembly: AssemblyVersion\(""(?<Version>.*?)""\)\]$";
                 }
 
                 if (_fileSystem.File.Exists(assemblyInfoPath))


### PR DESCRIPTION
The AssemblyInfo file for VB has a different file path and syntax than C#, so assembly version information for VB projects was not getting picked up by the ProjectFileService.