### PR TITLE
[Issue] XML Serialization of Bom with multiple licenses produces invalid XML

### DIFF
--- a/CycloneDX.Tests/ValidationTests.cs
+++ b/CycloneDX.Tests/ValidationTests.cs
@@ -34,6 +34,7 @@ namespace CycloneDX.Tests
                 new() { Name = "LibGit2Sharp", Version = "0.27.0-preview-0096" },
                 new() { Name = "NLog", Version = "4.7.7" },
                 new() { Name = "RestSharp", Version = "106.11.7" },
+                new() { Name = "CsvHelper", Version = "32.0.3" },
             };
 
             var mockProjectFileService = new Mock<IProjectFileService>();


### PR DESCRIPTION
This really should be logged as an issue rather than a PR, but doing a PR allows me to extend an existing validation test-case to provoke the error that I am seeing.

The `CsvHelper` nuget package is listed on nuget.org with this license info:
![image](https://github.com/CycloneDX/cyclonedx-dotnet/assets/19572699/b64aee22-c772-4607-a3f7-0d2e206bf5e6)

This can also be confirmed by looking in the *.nuspec file of the package:
![image](https://github.com/CycloneDX/cyclonedx-dotnet/assets/19572699/cee11452-6379-4891-9faa-94fe90c26a60)

The BOM (all versions I have dealt with so far) schema definition states that the `<licenses>` element should appear 0 or 1 times. This is why the serialized Bom is invalid, because the output looks like the snippet below where there are 2 `licenses` elements instead of nesting both `license` elements into a single "collection":

```xml
﻿<?xml version="1.0" encoding="utf-8"?>
<bom xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" ... version="1" xmlns="http://cyclonedx.org/schema/bom/1.5">
  <metadata>
    ...
  </metadata>
  <components>
    <component type="library" bom-ref="pkg:nuget/CsvHelper@32.0.3">
      ...
      <licenses>
        <license>
          <id>MS-PL</id>
        </license>
      </licenses>
      <licenses>
        <license>
          <id>Apache-2.0</id>
        </license>
      </licenses>
      ...
    </component>
    ...
  </components>
  ...
</bom>
```

Expected something like this instead:
```xml
<licenses>
  <license>
    <id>MS-PL</id>
  </license>
  <license>
    <id>Apache-2.0</id>
  </license>
</licenses>
```

I suspect the issue may even be in the [cyclonedx-dotnet-library](https://github.com/CycloneDX/cyclonedx-dotnet-library) rather than in this repository, but it was easier to demonstrate the issue here.

When I run the test suite including my change below, you can see that it passes the JSON variant, but fails the XML. I suspect the same will happen in the pipeline upon opening this PR. I have ticked "Allow edits by maintainers" so feel free to add the fix directly on my fork/branch if you think that is appropriate (and even possible).
![image](https://github.com/CycloneDX/cyclonedx-dotnet/assets/19572699/2d54743c-7c1c-41bf-83e2-701a02f5b83b)
