### PR TITLE
feat: Support X# Project files (#895)

### DIFF
--- a/CycloneDX.Tests/ProjectFileServiceTests.cs
+++ b/CycloneDX.Tests/ProjectFileServiceTests.cs
@@ -370,5 +370,28 @@ namespace CycloneDX.Tests
 
             Assert.Equal("3.2.1.0", projects.FirstOrDefault().Version);
         }
+
+        [Fact]
+        public async Task RecursivelyGetProjectReferences_ReturnsXSharpAssemblyVersion()
+        {
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\SolutionPath\Project1\Project1.xsproj"), new MockFileData(@"<Project></Project>") },
+                { XFS.Path(@"c:\SolutionPath\Project1\Properties\AssemblyInfo.prg"), new MockFileData(@"[assembly: AssemblyVersion(""3.2.1.0"")]")}
+            });
+            var mockDotnetUtilsService = new Mock<IDotnetUtilsService>();
+            var mockPackageFileService = new Mock<IPackagesFileService>();
+            var mockProjectAssetsFileService = new Mock<IProjectAssetsFileService>();
+            var projectFileService = new ProjectFileService(
+                mockFileSystem,
+                mockDotnetUtilsService.Object,
+                mockPackageFileService.Object,
+                mockProjectAssetsFileService.Object);
+
+            var projects = await projectFileService.RecursivelyGetProjectReferencesAsync(XFS.Path(@"c:\SolutionPath\Project1\Project1.xsproj")).ConfigureAwait(true);
+
+            Assert.Equal("3.2.1.0", projects.FirstOrDefault().Version);
+        }
+
     }
 }

--- a/CycloneDX.Tests/SolutionFileServiceTests.cs
+++ b/CycloneDX.Tests/SolutionFileServiceTests.cs
@@ -85,7 +85,7 @@ Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""CycloneDX"", ""Project3\
         }
 
         [Fact]
-        public async Task GetSolutionProjectReferences_ReturnsListOfProjectsIncludingFSharpAndVB()
+        public async Task GetSolutionProjectReferences_ReturnsListOfProjectsIncludingFSharpAndVBAndXSharp()
         {
             var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
                 {
@@ -93,14 +93,17 @@ Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""CycloneDX"", ""Project3\
 Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""CycloneDX"", ""Project1\Project1.csproj"", ""{88DFA76C-1C0A-4A83-AA48-EA1D28A9ABED}""
 Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""CycloneDX"", ""Project2\Project2.fsproj"", ""{88DFA76C-1C0A-4A83-AA48-EA1D28A9ABED}""
 Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""CycloneDX"", ""Project3\Project3.vbproj"", ""{88DFA76C-1C0A-4A83-AA48-EA1D28A9ABED}""
+Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""CycloneDX"", ""Project4\Project4.xsproj"", ""{88DFA76C-1C0A-4A83-AA48-EA1D28A9ABED}""
                         ")},
                     { XFS.Path(@"c:\SolutionPath\Project1\Project1.csproj"), Helpers.GetEmptyProjectFile() },
                     { XFS.Path(@"c:\SolutionPath\Project2\Project2.fsproj"), Helpers.GetEmptyProjectFile() },
                     { XFS.Path(@"c:\SolutionPath\Project3\Project3.vbproj"), Helpers.GetEmptyProjectFile() },
+                    { XFS.Path(@"c:\SolutionPath\Project4\Project4.xsproj"), Helpers.GetEmptyProjectFile() },
                 });
             var mockProjectFileService = new Mock<IProjectFileService>();
             mockProjectFileService
                 .SetupSequence(s => s.RecursivelyGetProjectReferencesAsync(It.IsAny<string>()))
+                .ReturnsAsync(new HashSet<DotnetDependency>())
                 .ReturnsAsync(new HashSet<DotnetDependency>())
                 .ReturnsAsync(new HashSet<DotnetDependency>())
                 .ReturnsAsync(new HashSet<DotnetDependency>());
@@ -113,7 +116,8 @@ Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""CycloneDX"", ""Project3\
             Assert.Collection(sortedProjects,
                 item => Assert.Equal(XFS.Path(@"c:\SolutionPath\Project1\Project1.csproj"), item),
                 item => Assert.Equal(XFS.Path(@"c:\SolutionPath\Project2\Project2.fsproj"), item),
-                item => Assert.Equal(XFS.Path(@"c:\SolutionPath\Project3\Project3.vbproj"), item));
+                item => Assert.Equal(XFS.Path(@"c:\SolutionPath\Project3\Project3.vbproj"), item),
+                item => Assert.Equal(XFS.Path(@"c:\SolutionPath\Project4\Project4.xsproj"), item));
         }
 
         [Fact]

--- a/CycloneDX/Program.cs
+++ b/CycloneDX/Program.cs
@@ -29,7 +29,7 @@ namespace CycloneDX
         {
 
 
-            var SolutionOrProjectFile = new Argument<string>("path", description: "The path to a .sln, .csproj, .fsproj, .vbproj, or packages.config file or the path to a directory which will be recursively analyzed for packages.config files.");
+            var SolutionOrProjectFile = new Argument<string>("path", description: "The path to a .sln, .csproj, .fsproj, .vbproj, .xsproj, or packages.config file or the path to a directory which will be recursively analyzed for packages.config files.");
             var framework = new Option<string>(new[] { "--framework", "-tfm" }, "The target framework to use. If not defined, all will be aggregated.");
             var runtime = new Option<string>(new[] { "--runtime", "-rt" }, "The runtime to use. If not defined, all will be aggregated.");
             var outputDirectory = new Option<string>(new[] { "--output", "-o" }, description: "The directory to write the BOM");

--- a/CycloneDX/Runner.cs
+++ b/CycloneDX/Runner.cs
@@ -209,7 +209,7 @@ namespace CycloneDX
                 }
                 else
                 {
-                    Console.Error.WriteLine($"Only .sln, .csproj, .fsproj, .vbproj, and packages.config files are supported");
+                    Console.Error.WriteLine($"Only .sln, .csproj, .fsproj, .vbproj, .xsproj, and packages.config files are supported");
                     return (int)ExitCode.InvalidOptions;
                 }
             }

--- a/CycloneDX/Services/ProjectFileService.cs
+++ b/CycloneDX/Services/ProjectFileService.cs
@@ -117,10 +117,16 @@ namespace CycloneDX.Services
             {
                 string assemblyInfoPath;
                 string pattern;
-                if (Path.GetExtension(projectFilePath).Equals(".vbproj", StringComparison.Ordinal))
+                string projectFileExtension = Path.GetExtension(projectFilePath);
+                if (projectFileExtension.Equals(".vbproj", StringComparison.Ordinal))
                 {
                     assemblyInfoPath = Path.Combine(Path.GetDirectoryName(projectFilePath), "My Project", "AssemblyInfo.vb");
                     pattern = @"^\<Assembly: AssemblyVersion\(""(?<Version>.*?)""\)\>$";
+                }
+                else if (projectFileExtension.Equals(".xsproj", StringComparison.Ordinal))
+                {
+                    assemblyInfoPath = Path.Combine(Path.GetDirectoryName(projectFilePath), "Properties", "AssemblyInfo.prg");
+                    pattern = @"^\[assembly: AssemblyVersion\(""(?<Version>.*?)""\)\]$";
                 }
                 else
                 {

--- a/CycloneDX/Utils.cs
+++ b/CycloneDX/Utils.cs
@@ -33,9 +33,11 @@ namespace CycloneDX
         }
         public static bool IsSupportedProjectType(string filename) {
             Contract.Requires(filename != null);
-            return filename.ToLowerInvariant().EndsWith(".csproj", StringComparison.OrdinalIgnoreCase) ||
-                filename.ToLowerInvariant().EndsWith(".fsproj", StringComparison.OrdinalIgnoreCase) ||
-                filename.ToLowerInvariant().EndsWith(".vbproj", StringComparison.OrdinalIgnoreCase);
+            string filenameLowerInvariant = filename.ToLowerInvariant();
+            return filenameLowerInvariant.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase) ||
+                filenameLowerInvariant.EndsWith(".fsproj", StringComparison.OrdinalIgnoreCase) ||
+                filenameLowerInvariant.EndsWith(".vbproj", StringComparison.OrdinalIgnoreCase) ||
+                filenameLowerInvariant.EndsWith(".xsproj", StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Usage:
   CycloneDX <path> [options]
 
 Arguments:
-  <path>  The path to a .sln, .csproj, .fsproj, .vbproj, or packages.config file or the path to a directory which will be recursively analyzed for packages.config files.
+  <path>  The path to a .sln, .csproj, .fsproj, .vbproj, .xsproj, or packages.config file or the path to a directory which will be recursively analyzed for packages.config files.
 
 Options:
   -tfm, --framework <framework>                                                The target framework to use. If not defined, all will be aggregated.


### PR DESCRIPTION
* add support for X# project files with the .xsproj extension
* add support for extracting version from AssemblyInfo.prg file for X# project files

Signed-off-by: Volkmar Rigo <Volkmar.rigo@Infominds.eu>