### PR TITLE
Fix Error with Uppercase Characters in Version Strings

### DIFF
--- a/CycloneDX/Services/NugetV3Service.cs
+++ b/CycloneDX/Services/NugetV3Service.cs
@@ -80,11 +80,12 @@ namespace CycloneDX.Services
             if (string.IsNullOrEmpty(name) || string.IsNullOrEmpty(version)) { return null; }
 
             var lowerName = name.ToLowerInvariant();
+            var lowerVersion = version.ToLowerInvariant();
             string nuspecFilename = null;
 
             foreach (var packageCachePath in _packageCachePaths)
             {
-                var currentDirectory = _fileSystem.Path.Combine(packageCachePath, lowerName, NormalizeVersion(version));
+                var currentDirectory = _fileSystem.Path.Combine(packageCachePath, lowerName, NormalizeVersion(lowerVersion));
                 var currentFilename = _fileSystem.Path.Combine(currentDirectory, lowerName + _nuspecExtension);
                 if (_fileSystem.File.Exists(currentFilename))
                 {


### PR DESCRIPTION
Resolve an issue where versions with uppercase characters (e.g., 1.0.0-Beta, 1.0.0.BETA.1) caused CycloneDX to throw errors. The
problem occurred because the NuGet cache converted version strings to lowercase for path names. This caused the .nuspec file to not be found.