### PR TITLE
Prevent `Unable to locate valid bom ref for package` error when using a range and there are multiple versions of a package referenced

### DIFF
--- a/CycloneDX.Tests/ProgramTests.cs
+++ b/CycloneDX.Tests/ProgramTests.cs
@@ -18,12 +18,17 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Abstractions;
 using System.IO.Abstractions.TestingHelpers;
+using System.Runtime.Serialization.Formatters;
+using System.Security.Cryptography;
 using System.Threading.Tasks;
 using CycloneDX.Interfaces;
 using CycloneDX.Models;
+using CycloneDX.Services;
 using Moq;
 using Xunit;
+using static CycloneDX.Models.Component;
 using XFS = System.IO.Abstractions.TestingHelpers.MockUnixSupport;
 
 namespace CycloneDX.Tests
@@ -75,7 +80,7 @@ namespace CycloneDX.Tests
                 .Setup(s => s.GetSolutionDotnetDependencys(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync(new HashSet<DotnetDependency>());
 
-            Runner runner = new Runner(fileSystem: mockFileSystem, null, null, null, null, null, solutionFileService: mockSolutionFileService.Object, null);            
+            Runner runner = new Runner(fileSystem: mockFileSystem, null, null, null, null, null, solutionFileService: mockSolutionFileService.Object, null);
 
             RunOptions runOptions = new RunOptions
             {
@@ -128,7 +133,55 @@ namespace CycloneDX.Tests
 
             var exitCode = await runner.HandleCommandAsync(runOptions);
 
-            Assert.NotEqual((int)ExitCode.OK, exitCode);            
+            Assert.NotEqual((int)ExitCode.OK, exitCode);
+        }
+
+        [Fact]
+        public async Task CallingCycloneDX_WithMultipleReferencesToPackage_ResolvesOne()
+        {
+            var solutionFile = "test.sln";
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {solutionFile,new MockFileData("") },
+            });
+            var mockSolutionFileService = new Mock<ISolutionFileService>();
+            mockSolutionFileService
+                .Setup(s => s.GetSolutionDotnetDependencys(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(new HashSet<DotnetDependency>
+                {
+                    new DotnetDependency { Name = "Package 1", Version = "1.2.3" },
+                    new DotnetDependency { Name = "Package 1", Version = "1.3.5" },
+                    new DotnetDependency { Name = "Package 2", Version = "2.0.0", Dependencies = new Dictionary<string, string>{{"Package 1", "[1.2.3, 1.2.3]" }} },
+                });
+
+            var mockNugetService = new Mock<INugetService>();
+            mockNugetService.Setup(s => s.GetComponentAsync(It.Is<DotnetDependency>(o => o.Name == "Package 1" && o.Version == "1.2.3")))
+                .ReturnsAsync(new Component { Name = "Package 1", Version = "1.2.3", });
+            mockNugetService.Setup(s => s.GetComponentAsync(It.Is<DotnetDependency>(o => o.Name == "Package 1" && o.Version == "1.3.5")))
+                .ReturnsAsync(new Component { Name = "Package 1", Version = "1.3.5", });
+            mockNugetService.Setup(s => s.GetComponentAsync(It.Is<DotnetDependency>(o => o.Name == "Package 2" && o.Version == "2.0.0")))
+                .ReturnsAsync(new Component { Name = "Package 2", Version = "2.0.0", });
+
+            var mockNugetServiceFactory = new Mock<INugetServiceFactory>();
+            mockNugetServiceFactory
+                .Setup(s => s.Create(It.IsAny<RunOptions>(), It.IsAny<IFileSystem>(), It.IsAny<IGithubService>(), It.IsAny<List<string>>()))
+                .Returns(mockNugetService.Object);
+
+            Runner runner = new Runner(fileSystem: mockFileSystem, null, null, null, null, null, solutionFileService: mockSolutionFileService.Object, nugetServiceFactory: mockNugetServiceFactory.Object);
+
+            RunOptions runOptions = new RunOptions
+            {
+                SolutionOrProjectFile = XFS.Path(solutionFile),
+                scanProjectReferences = true,
+                outputDirectory = XFS.Path(@"c:\NewDirectory"),
+                outputFilename = XFS.Path(@"my_bom.xml")
+            };
+
+            var exitCode = await runner.HandleCommandAsync(runOptions);
+
+            Assert.Equal((int)ExitCode.OK, exitCode);
+            var output = mockFileSystem.GetFile("/NewDirectory/my_bom.xml");
+            Assert.NotNull(output);
         }
     }
 }

--- a/CycloneDX/Runner.cs
+++ b/CycloneDX/Runner.cs
@@ -312,7 +312,7 @@ namespace CycloneDX
                             if (!bomRefLookup.ContainsKey(lookupKey))
                             {
                                 var packageNameMatch = bomRefLookup.Where(x => x.Key.Item1 == dep.Key.ToLower(CultureInfo.InvariantCulture)).ToList();
-                                if (packageNameMatch.Count == 1)
+                                if (packageNameMatch.Count >= 1)
                                 {
                                     lookupKey = packageNameMatch.First().Key;
                                 }


### PR DESCRIPTION
## Context

I have come across an issue while using this tool to generate an SBOM for one of our larger solutions.

When the following occurs:
1. Package dependency is specified with range syntax, e.g. `[1.4.0, 1.4.0]`
2. Multiple versions of the package referenced throughout the solution

We get an error message as below, even though there are packages available.

`Unable to locate valid bom ref for TrueLayer.Observability.Abstractions [1.4.0, 1.4.0]`

## Solution

The proposed solution chooses the first referenced package, rather than assuming none exists if the found packages != 1.