### PR TITLE
Unsupported project types are included in the..

### DIFF
--- a/CycloneDX/Services/ProjectFileService.cs
+++ b/CycloneDX/Services/ProjectFileService.cs
@@ -344,6 +344,12 @@ namespace CycloneDX.Services
             while (files.Count > 0)
             {
                 var currentFile = files.Dequeue();
+
+                if (!Utils.IsSupportedProjectType(currentFile))
+                {
+                    continue;
+                }
+
                 // Find all project references inside of currentFile
                 var foundProjectReferences = await GetProjectReferencesAsync(currentFile).ConfigureAwait(false);
 


### PR DESCRIPTION
A fix for #896.  When processing recursively through projects to get references, apply the supported project test and skip any projects that do not satisfy the test.  It uses the existing utility method IsSupportedProjectType