### PR TITLE
Update CycloneDX to 8.0.0 and BOM validation to v1_6

### DIFF
--- a/CycloneDX.Tests/FunctionalTests/FunctionalTestHelper.cs
+++ b/CycloneDX.Tests/FunctionalTests/FunctionalTestHelper.cs
@@ -95,11 +95,11 @@ namespace CycloneDX.Tests.FunctionalTests
             ValidationResult validationResult;
             if (options.json)
             {
-                validationResult = await Json.Validator.ValidateAsync(mockBomFileStream, SpecificationVersion.v1_5).ConfigureAwait(false);
+                validationResult = await Json.Validator.ValidateAsync(mockBomFileStream, SpecificationVersion.v1_6).ConfigureAwait(false);
             }
             else
             {
-                validationResult = Xml.Validator.Validate(mockBomFileStream, SpecificationVersion.v1_5);
+                validationResult = Xml.Validator.Validate(mockBomFileStream, SpecificationVersion.v1_6);
             }
             Assert.True(validationResult.Valid);
 

--- a/CycloneDX.Tests/ValidationTests.cs
+++ b/CycloneDX.Tests/ValidationTests.cs
@@ -69,11 +69,11 @@ namespace CycloneDX.Tests
             ValidationResult validationResult;
             if (fileFormat == "json")
             {
-                validationResult = await Json.Validator.ValidateAsync(mockBomFileStream, SpecificationVersion.v1_5).ConfigureAwait(true);
+                validationResult = await Json.Validator.ValidateAsync(mockBomFileStream, SpecificationVersion.v1_6).ConfigureAwait(true);
             }
             else
             {
-                validationResult = Xml.Validator.Validate(mockBomFileStream, SpecificationVersion.v1_5);
+                validationResult = Xml.Validator.Validate(mockBomFileStream, SpecificationVersion.v1_6);
             }
 
             Assert.True(validationResult.Valid);

--- a/CycloneDX/Services/NugetV3Service.cs
+++ b/CycloneDX/Services/NugetV3Service.cs
@@ -278,7 +278,7 @@ namespace CycloneDX.Services
 
         private static Component SetupComponentProperties(Component component, NuspecModel nuspecModel)
         {
-            component.Author = nuspecModel.nuspecReader.GetAuthors();
+            component.Authors = new List<OrganizationalContact> { new OrganizationalContact { Name = nuspecModel.nuspecReader.GetAuthors() } };
             component.Copyright = nuspecModel.nuspecReader.GetCopyright();
             // this prevents empty copyright values in the JSON BOM
             if (string.IsNullOrEmpty(component.Copyright))

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="CycloneDX.Core" Version="7.0.1" />
+    <PackageVersion Include="CycloneDX.Core" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Build" Version="17.3.2" />
     <PackageVersion Include="Microsoft.Build.Engine" Version="17.8.3" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />


### PR DESCRIPTION
Updated FunctionalTestHelper.cs and ValidationTests.cs to support BOM validation for Specification Version v1_6 in both JSON and XML formats. Upgraded CycloneDX.Core package version in Directory.Packages.props from 7.0.1 to 8.0.0. Also corrected a minor formatting issue in Directory.Packages.props.