### PR TITLE
Enable `RollForward` to run on the latest .NET SDKs

### DIFF
--- a/CycloneDX/CycloneDX.csproj
+++ b/CycloneDX/CycloneDX.csproj
@@ -11,6 +11,9 @@
     <ToolCommandName>dotnet-CycloneDX</ToolCommandName>
     <_SkipUpgradeNetAnalyzersNuGetWarning>true</_SkipUpgradeNetAnalyzersNuGetWarning>
     <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+
+    <!-- Always run on the latest runtime installed. -->
+    <RollForward>Major</RollForward>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OsEnvironment )'=='windows'">


### PR DESCRIPTION
Enables installing and running `CycloneDX` on runtimes/SDKs newer than those that it targets when published. (For instance, allows v4.0.0 to run with only .NET SDK 9.0 installed, and no 8.0, 7.0 or 6.0 present.)

ref. https://learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-core-3-0#major-version-runtime-roll-forward
ref. https://github.com/dotnet/sdk/issues/26824

Examples of other tools which have this setting enabled:
- `dotnet-format` (MS): https://github.com/dotnet/format/blob/ad8125a6fc036fe1eb4e57aa604a79f2d98d5aa0/src/dotnet-format.csproj#L11  -- added in https://github.com/dotnet/format/commit/7a5df81d357992e66bf88b6dd664d70569bd7f21
- `dotnet-ef` (MS): https://github.com/dotnet/efcore/blob/486047c7422ec04530ca66c7c55256fa89b0ffc2/src/dotnet-ef/dotnet-ef.csproj#L24 -- added in https://github.com/dotnet/efcore/commit/11e7fc66f23edf3df7eb41d3b8ed311cb2dd2b60
- `docfx` (MS): https://github.com/dotnet/docfx/blob/dbd57048f68411fa39aeea9ccc6c00dc88ecde9f/src/docfx/docfx.csproj#L5 -- added in https://github.com/dotnet/docfx/commit/c641c038a9ee20a25500c454c57339cd98ebf8cd
- my own `dotnet-xdt`: https://github.com/nil4/dotnet-transform-xdt/blob/6272bb1152e8535ec40da5b0d68ff950bc13735b/dotnet-xdt/dotnet-xdt.csproj#L47 -- added in https://github.com/nil4/dotnet-transform-xdt/issues/42