### PR TITLE
fix: improvement on handling build-only dev dependencies

### DIFF
--- a/CycloneDX.Tests/FunctionalTests/ExcludeDevDepenceny.cs
+++ b/CycloneDX.Tests/FunctionalTests/ExcludeDevDepenceny.cs
@@ -1,9 +1,4 @@
-using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Linq.Expressions;
-using System.Text;
 using System.Threading.Tasks;
 using CycloneDX.Models;
 using Xunit;

--- a/CycloneDX.Tests/FunctionalTests/ExcludeDevDependnciesWithPackageConfig.cs
+++ b/CycloneDX.Tests/FunctionalTests/ExcludeDevDependnciesWithPackageConfig.cs
@@ -1,11 +1,6 @@
-using System;
 using System.Collections.Generic;
-using System.CommandLine;
 using System.IO;
-using System.IO.Abstractions;
 using System.IO.Abstractions.TestingHelpers;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using CycloneDX.Models;
 using Xunit;

--- a/CycloneDX.Tests/FunctionalTests/FloatingVersions.cs
+++ b/CycloneDX.Tests/FunctionalTests/FloatingVersions.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using CycloneDX.Models;
 using Xunit;

--- a/CycloneDX.Tests/FunctionalTests/FunctionalTestHelper.cs
+++ b/CycloneDX.Tests/FunctionalTests/FunctionalTestHelper.cs
@@ -1,10 +1,8 @@
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Abstractions;
 using System.IO.Abstractions.TestingHelpers;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using CycloneDX.Interfaces;
 using CycloneDX.Models;

--- a/CycloneDX.Tests/FunctionalTests/Issue826-ProjectFileDoesntExist/ReferencedProjectFileDoesntExists.cs
+++ b/CycloneDX.Tests/FunctionalTests/Issue826-ProjectFileDoesntExist/ReferencedProjectFileDoesntExists.cs
@@ -1,11 +1,6 @@
-using System;
 using System.Collections.Generic;
-using System.CommandLine;
 using System.IO;
-using System.IO.Abstractions;
 using System.IO.Abstractions.TestingHelpers;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using CycloneDX.Models;
 using Xunit;

--- a/CycloneDX.Tests/FunctionalTests/Issue826alt-ProjectFileDoesntExistWithAssetsFile/ReferencedProjectFileDoesntExists.cs
+++ b/CycloneDX.Tests/FunctionalTests/Issue826alt-ProjectFileDoesntExistWithAssetsFile/ReferencedProjectFileDoesntExists.cs
@@ -1,11 +1,6 @@
-using System;
 using System.Collections.Generic;
-using System.CommandLine;
 using System.IO;
-using System.IO.Abstractions;
 using System.IO.Abstractions.TestingHelpers;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using CycloneDX.Models;
 using Xunit;

--- a/CycloneDX.Tests/FunctionalTests/Issue830-rsMultipleFrameworks/ReferencedProjectFileDoesntExists.cs
+++ b/CycloneDX.Tests/FunctionalTests/Issue830-rsMultipleFrameworks/ReferencedProjectFileDoesntExists.cs
@@ -1,11 +1,6 @@
-using System;
 using System.Collections.Generic;
-using System.CommandLine;
 using System.IO;
-using System.IO.Abstractions;
 using System.IO.Abstractions.TestingHelpers;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using CycloneDX.Models;
 using Xunit;

--- a/CycloneDX.Tests/FunctionalTests/ProjectReferenceWithPackageReferenceWithTransitivePackage.cs
+++ b/CycloneDX.Tests/FunctionalTests/ProjectReferenceWithPackageReferenceWithTransitivePackage.cs
@@ -1,9 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.CommandLine;
 using System.IO;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using CycloneDX.Models;
 using Xunit;

--- a/CycloneDX.Tests/FunctionalTests/ProjectReferencesUseAssemblyNames/ReferencedProjectFileDoesntExists.cs
+++ b/CycloneDX.Tests/FunctionalTests/ProjectReferencesUseAssemblyNames/ReferencedProjectFileDoesntExists.cs
@@ -1,11 +1,6 @@
-using System;
 using System.Collections.Generic;
-using System.CommandLine;
 using System.IO;
-using System.IO.Abstractions;
 using System.IO.Abstractions.TestingHelpers;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using CycloneDX.Models;
 using Xunit;

--- a/CycloneDX.Tests/FunctionalTests/SimpleNET6.0Library.cs
+++ b/CycloneDX.Tests/FunctionalTests/SimpleNET6.0Library.cs
@@ -1,4 +1,3 @@
-using System;
 using System.IO;
 using System.Threading.Tasks;
 using CycloneDX.Models;

--- a/CycloneDX.Tests/FunctionalTests/SimpleNETStandardLibrary.cs
+++ b/CycloneDX.Tests/FunctionalTests/SimpleNETStandardLibrary.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using CycloneDX.Models;
 using Xunit;

--- a/CycloneDX.Tests/FunctionalTests/TestcaseFrameworkPackagesConfigRecursive/FrameworkPackagesConfigRecursive.cs
+++ b/CycloneDX.Tests/FunctionalTests/TestcaseFrameworkPackagesConfigRecursive/FrameworkPackagesConfigRecursive.cs
@@ -1,11 +1,6 @@
-using System;
 using System.Collections.Generic;
-using System.CommandLine;
 using System.IO;
-using System.IO.Abstractions;
 using System.IO.Abstractions.TestingHelpers;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using CycloneDX.Models;
 using Xunit;

--- a/CycloneDX.Tests/ProjectAssetsFileServiceTests.cs
+++ b/CycloneDX.Tests/ProjectAssetsFileServiceTests.cs
@@ -29,7 +29,6 @@ using NuGet.ProjectModel;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
 using System.IO;
-using NuGet.Packaging.Signing;
 
 namespace CycloneDX.Tests
 {
@@ -276,7 +275,7 @@ namespace CycloneDX.Tests
         [Theory]
         [InlineData(".NETStandard", 2, 1, ".NETStandard,Version=v2.1")]
         [InlineData(".NETCoreApp", 6, 0, "net6.0")]
-        public void GetDotnetDependencys_MissingResolvedPackageVersion_MinVersionExcluded(string framework, int frameworkMajor, int frameworkMinor, string projectFileDependencyGroupsName)
+        public void GetDotnetDependencys_MissingResolvedPackageVersion(string framework, int frameworkMajor, int frameworkMinor, string projectFileDependencyGroupsName)
         {
             var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
                 {
@@ -288,7 +287,8 @@ namespace CycloneDX.Tests
                                 Version = "1.5.0",
                                 Dependencies = new Dictionary<string, string>
                                 {
-                                    { "Package2", "(4.5, )" },
+                                    { "Package2", "[4.5, 5)" },
+                                    { "Package3", "[6.7, )" },
                                 },
                             }
                         })
@@ -323,7 +323,8 @@ namespace CycloneDX.Tests
                                         },
                                         Dependencies = new[]
                                         {
-                                            new PackageDependency("Package2", new VersionRange(minVersion: new NuGetVersion("4.5.0"), includeMinVersion: false, originalString:"(4.5, )"))
+                                            new PackageDependency("Package2", VersionRange.Parse("[4.5, 5)")),
+                                            new PackageDependency("Package3", VersionRange.Parse("[6.7, )"))
                                         }
                                     }
                                 }
@@ -344,7 +345,8 @@ namespace CycloneDX.Tests
                                         },
                                         Dependencies = new[]
                                         {
-                                            new PackageDependency("Package2", new VersionRange(minVersion: new NuGetVersion("4.5.0"), includeMinVersion: false, originalString:"(4.5, )"))
+                                            new PackageDependency("Package2", VersionRange.Parse("[4.5, 5)")),
+                                            new PackageDependency("Package3", VersionRange.Parse("[6.7, )"))
                                         }
                                     }
                                 }
@@ -371,6 +373,11 @@ namespace CycloneDX.Tests
                                                 TypeConstraint = LibraryDependencyTarget.Package
                                             }
                                         }
+                                    },
+                                    CentralPackageVersions =
+                                    {
+                                        new("Package2", new CentralPackageVersion("Package2", VersionRange.Parse("[4.5, 5)"))),
+                                        new("Package3", new CentralPackageVersion("Package3", VersionRange.Parse("6.7")))
                                     }
                                 }
                             }
@@ -412,151 +419,12 @@ namespace CycloneDX.Tests
                         dep =>
                         {
                             Assert.Equal(@"Package2", dep.Key);
-                            Assert.Equal(@"(4.5.0, )", dep.Value);
-                        });
-                });
-        }
-
-        [Theory]
-        [InlineData(".NETStandard", 2, 1, ".NETStandard,Version=v2.1")]
-        [InlineData(".NETCoreApp", 6, 0, "net6.0")]
-        public void GetDotnetDependencys_MissingResolvedPackageVersion_MinVersionIncluded(string framework, int frameworkMajor, int frameworkMinor, string projectFileDependencyGroupsName)
-        {
-            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
-                {
-                    { XFS.Path(@"c:\SolutionPath\Project1\Project1.csproj"), Helpers.GetProjectFileWithPackageReferences(
-                        new[] {
-                            new DotnetDependency
-                            {
-                                Name = "Package1",
-                                Version = "1.5.0",
-                                Dependencies = new Dictionary<string, string>
-                                {
-                                    { "Package2", "[4.5, )" },
-                                },
-                            }
-                        })
-                    },
-                    { XFS.Path(@"c:\SolutionPath\Project1\obj\project.assets.json"), new MockFileData("")
-                    }
-                });
-
-            var mockAssetReader = new Mock<IAssetFileReader>(MockBehavior.Strict);
-            mockAssetReader
-                .Setup(m => m.Read(It.IsAny<Stream>(), It.IsAny<string>()))
-                .Returns(() =>
-                {
-                    var nuGetFramework = new NuGet.Frameworks.NuGetFramework(framework, new Version(frameworkMajor, frameworkMinor, 0));
-                    return new LockFile
-                    {
-                        Targets = new[]
-                        {
-                            new LockFileTarget
-                            {
-                                TargetFramework = nuGetFramework,
-                                RuntimeIdentifier = "",
-                                Libraries = new[]
-                                {
-                                    new LockFileTargetLibrary
-                                    {
-                                        Name = "Package1",
-                                        Version = new NuGet.Versioning.NuGetVersion("1.5.0"),
-                                        CompileTimeAssemblies = new[]
-                                        {
-                                            new LockFileItem("Package1.dll")
-                                        },
-                                        Dependencies = new[]
-                                        {
-                                            new PackageDependency("Package2", new VersionRange(minVersion: new NuGetVersion("4.5.0"), originalString:"[4.5, )"))
-                                        }
-                                    }
-                                }
-                            },
-                            new LockFileTarget
-                            {
-                                TargetFramework = nuGetFramework,
-                                RuntimeIdentifier = "win-x64",
-                                Libraries = new[]
-                                {
-                                    new LockFileTargetLibrary
-                                    {
-                                        Name = "Package1",
-                                        Version = new NuGet.Versioning.NuGetVersion("1.5.0"),
-                                        CompileTimeAssemblies = new[]
-                                        {
-                                            new LockFileItem("Package1.dll")
-                                        },
-                                        Dependencies = new[]
-                                        {
-                                            new PackageDependency("Package2", new VersionRange(minVersion: new NuGetVersion("4.5.0"), originalString:"[4.5, )"))
-                                        }
-                                    }
-                                }
-                            }
+                            Assert.Equal(@"[4.5.0, 5.0.0)", dep.Value);
                         },
-                        PackageSpec = new PackageSpec
-                        {
-                            TargetFrameworks =
-                            {
-                                new TargetFrameworkInformation
-                                {
-                                    FrameworkName = nuGetFramework,
-                                    TargetAlias = nuGetFramework.Framework,
-                                    Dependencies = new List<LibraryDependency>
-                                    {
-                                        new()
-                                        {
-                                            SuppressParent = LibraryIncludeFlagUtils.DefaultSuppressParent,
-                                            ReferenceType = LibraryDependencyReferenceType.Direct,
-                                            LibraryRange = new LibraryRange
-                                            {
-                                                Name = "Package1",
-                                                VersionRange = VersionRange.Parse("1.5.0"),
-                                                TypeConstraint = LibraryDependencyTarget.Package
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        Libraries = new[]
-                        {
-                            new LockFileLibrary
-                            {
-                                Name = "Package1",
-                                Version = new NuGetVersion("1.5.0"),
-                                Type = "package"
-                            }
-                        },
-                        ProjectFileDependencyGroups = new[]
-                        {
-
-                            new ProjectFileDependencyGroup(projectFileDependencyGroupsName, new List<string> { "Package1 >= 1.5.0" })
-                        }
-                    };
-                });
-            mockAssetReader.Setup(m => m.ReadAllText(It.IsAny<string>())).Returns(() =>
-            {
-                return "empty";
-            });
-
-            var projectAssetsFileService = new ProjectAssetsFileService(mockFileSystem, () => mockAssetReader.Object);
-            var packages = projectAssetsFileService.GetDotnetDependencys(XFS.Path(@"c:\SolutionPath\Project1\Project1.csproj"), XFS.Path(@"c:\SolutionPath\Project1\obj\project.assets.json"), false);
-            var sortedPackages = new List<DotnetDependency>(packages);
-
-            sortedPackages.Sort();
-
-            Assert.Collection(sortedPackages,
-                item =>
-                {
-                    Assert.Equal(@"Package1", item.Name);
-                    Assert.Equal(@"1.5.0", item.Version);
-                    Assert.True(item.IsDirectReference, "Package1 was expected to be a direct reference.");
-                    Assert.Collection(item.Dependencies,
                         dep =>
                         {
-                            Assert.Equal(@"Package2", dep.Key);
-                            Assert.Equal(@"4.5.0", dep.Value);
+                            Assert.Equal(@"Package3", dep.Key);
+                            Assert.Equal(@"6.7.0", dep.Value);
                         });
                 });
         }

--- a/CycloneDX.Tests/ProjectAssetsFileServiceTests.cs
+++ b/CycloneDX.Tests/ProjectAssetsFileServiceTests.cs
@@ -558,11 +558,6 @@ namespace CycloneDX.Tests
                             Assert.Equal(@"Package2", dep.Key);
                             Assert.Equal(@"4.5.0", dep.Value);
                         });
-                },
-                item =>
-                {
-                    Assert.Equal(@"Package2", item.Name);
-                    Assert.Equal(@"4.5.0", item.Version);
                 });
         }
 

--- a/CycloneDX.Tests/SolutionFileServiceTests.cs
+++ b/CycloneDX.Tests/SolutionFileServiceTests.cs
@@ -24,7 +24,6 @@ using XFS = System.IO.Abstractions.TestingHelpers.MockUnixSupport;
 using Moq;
 using CycloneDX.Services;
 using CycloneDX.Models;
-using System.IO;
 
 namespace CycloneDX.Tests
 {

--- a/CycloneDX/Interfaces/INugetServiceFactory.cs
+++ b/CycloneDX/Interfaces/INugetServiceFactory.cs
@@ -1,9 +1,5 @@
-using System;
 using System.Collections.Generic;
 using System.IO.Abstractions;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using CycloneDX.Models;
 using CycloneDX.Services;
 

--- a/CycloneDX/Models/RunOptions.cs
+++ b/CycloneDX/Models/RunOptions.cs
@@ -15,8 +15,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) OWASP Foundation. All Rights Reserved.
 
-using System.Globalization;
-
 namespace CycloneDX.Models
 {
     public class RunOptions

--- a/CycloneDX/Program.cs
+++ b/CycloneDX/Program.cs
@@ -15,9 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) OWASP Foundation. All Rights Reserved.
 
-using System;
 using System.CommandLine;
-using System.IO;
 using System.Threading.Tasks;
 using CycloneDX.Models;
 

--- a/CycloneDX/Runner.cs
+++ b/CycloneDX/Runner.cs
@@ -521,7 +521,10 @@ namespace CycloneDX
             foreach (var runtimePackage in runtimePackages)
             {
                 var dependencies = runtimePackage.Dependencies?.ToList();
-                if (dependencies == null) continue;
+                if (dependencies == null)
+                {
+                    continue;
+                }
 
                 foreach (var dependency in dependencies)
                 {

--- a/CycloneDX/Services/NugetV3ServiceFactory.cs
+++ b/CycloneDX/Services/NugetV3ServiceFactory.cs
@@ -1,9 +1,5 @@
-using System;
 using System.Collections.Generic;
 using System.IO.Abstractions;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using CycloneDX.Interfaces;
 using CycloneDX.Models;
 

--- a/CycloneDX/Services/PackagesFileService.cs
+++ b/CycloneDX/Services/PackagesFileService.cs
@@ -22,7 +22,6 @@ using System.IO.Abstractions;
 using System.Threading.Tasks;
 using CycloneDX.Interfaces;
 using CycloneDX.Models;
-using System.Linq;
 using System;
 
 namespace CycloneDX.Services
@@ -64,6 +63,7 @@ namespace CycloneDX.Services
                                 Name = reader["id"],
                                 Version = reader["version"],
                                 IsDevDependency = reader["developmentDependency"] == "true",
+                                IsDirectReference = true,
                                 Scope = Component.ComponentScope.Required
                             };
                             await Console.Out.WriteLineAsync($"\tFound Package:{newPackage.Name}");

--- a/CycloneDX/Services/ProjectFileService.cs
+++ b/CycloneDX/Services/ProjectFileService.cs
@@ -25,7 +25,6 @@ using System.Threading.Tasks;
 using CycloneDX.Interfaces;
 using CycloneDX.Models;
 using System.Text.RegularExpressions;
-using System.Reflection;
 
 namespace CycloneDX.Services
 {
@@ -240,11 +239,6 @@ namespace CycloneDX.Services
         public async Task<HashSet<DotnetDependency>> RecursivelyGetProjectDotnetDependencysAsync(string projectFilePath, string baseIntermediateOutputPath, bool excludeTestProjects, string framework, string runtime)
         {
             var dotnetDependencys = await GetProjectDotnetDependencysAsync(projectFilePath, baseIntermediateOutputPath, excludeTestProjects, framework, runtime).ConfigureAwait(false);
-            foreach (var item in dotnetDependencys)
-            {
-                // TODO: This doesn't seem to be really correct as it add's a lot of the indirect refs as-well...
-                item.IsDirectReference = true;
-            }
             var projectReferences = await RecursivelyGetProjectReferencesAsync(projectFilePath).ConfigureAwait(false);
 
             //Remove root-project, it will be added to the metadata


### PR DESCRIPTION
Fixes https://github.com/CycloneDX/cyclonedx-dotnet/issues/894 for `--recursive` project mode and solution mode.

This also fixes the following bugs that were not reported yet to my knowledge but lead to wrong results:
* CentralPackageVersions not being considered for resolving version ranges
* `packages.config` not being considered `IsDirectReference`
* Recursive mode considering ANY dependency as direct that comes from the initial project
* Recursive mode will add old versions from references for already packages updated in main project
* Recursive mode will add dependencies of references partially as direct references

So many bugs were related to `--recursive` not working correctly.