### PR TITLE
feat: Enable .slnx solutions to be analyzed

### DIFF
--- a/CycloneDX.Tests/SolutionFileServiceTests.cs
+++ b/CycloneDX.Tests/SolutionFileServiceTests.cs
@@ -31,6 +31,28 @@ namespace CycloneDX.Tests
     public class SolutionFileServiceTests
     {
         [Fact]
+        public async Task GetSolutionXProjectReferences_ReturnsProjectThatExists()
+        {
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\SolutionPath\SolutionFile.slnx"), new MockFileData(@"<Solution>
+  <Project Path=""Project\Project.csproj"" Type=""Classic C#"" />
+</Solution>")},
+                { XFS.Path(@"c:\SolutionPath\Project\Project.csproj"), Helpers.GetEmptyProjectFile() },
+            });
+            var mockProjectFileService = new Mock<IProjectFileService>();
+            mockProjectFileService
+                .Setup(s => s.RecursivelyGetProjectReferencesAsync(It.IsAny<string>()))
+                .ReturnsAsync(new HashSet<DotnetDependency>());
+            var solutionFileService = new SolutionFileService(mockFileSystem, mockProjectFileService.Object);
+
+            var projects = await solutionFileService.GetSolutionProjectReferencesAsync(XFS.Path(@"c:\SolutionPath\SolutionFile.slnx")).ConfigureAwait(true);
+
+            Assert.Collection(projects,
+                item => Assert.Equal(XFS.Path(@"c:\SolutionPath\Project\Project.csproj"), item));
+        }
+
+        [Fact]
         public async Task GetSolutionProjectReferences_ReturnsProjectThatExists()
         {
             var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -47,8 +69,8 @@ Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""CycloneDX"", ""Project\P
             var solutionFileService = new SolutionFileService(mockFileSystem, mockProjectFileService.Object);
 
             var projects = await solutionFileService.GetSolutionProjectReferencesAsync(XFS.Path(@"c:\SolutionPath\SolutionFile.sln")).ConfigureAwait(true);
-            
-            Assert.Collection(projects, 
+
+            Assert.Collection(projects,
                 item => Assert.Equal(XFS.Path(@"c:\SolutionPath\Project\Project.csproj"), item));
         }
 
@@ -77,7 +99,7 @@ Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""CycloneDX"", ""Project3\
             var projects = await solutionFileService.GetSolutionProjectReferencesAsync(XFS.Path(@"c:\SolutionPath\SolutionFile.sln")).ConfigureAwait(true);
             var sortedProjects = new List<string>(projects);
             sortedProjects.Sort();
-            
+
             Assert.Collection(sortedProjects,
                 item => Assert.Equal(XFS.Path(@"c:\SolutionPath\Project1\Project1.csproj"), item),
                 item => Assert.Equal(XFS.Path(@"c:\SolutionPath\Project2\Project2.csproj"), item),
@@ -112,7 +134,7 @@ Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""CycloneDX"", ""Project4\
             var projects = await solutionFileService.GetSolutionProjectReferencesAsync(XFS.Path(@"c:\SolutionPath\SolutionFile.sln")).ConfigureAwait(true);
             var sortedProjects = new List<string>(projects);
             sortedProjects.Sort();
-            
+
             Assert.Collection(sortedProjects,
                 item => Assert.Equal(XFS.Path(@"c:\SolutionPath\Project1\Project1.csproj"), item),
                 item => Assert.Equal(XFS.Path(@"c:\SolutionPath\Project2\Project2.fsproj"), item),
@@ -147,7 +169,7 @@ Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""CycloneDX"", ""Project1\
             var projects = await solutionFileService.GetSolutionProjectReferencesAsync(XFS.Path(@"c:\SolutionPath\SolutionFile.sln")).ConfigureAwait(true);
             var sortedProjects = new List<string>(projects);
             sortedProjects.Sort();
-            
+
             Assert.Collection(sortedProjects,
                 item => Assert.Equal(XFS.Path(@"c:\SolutionPath\Project1\Project1.csproj"), item),
                 item => Assert.Equal(XFS.Path(@"c:\SolutionPath\Project2\Project2.csproj"), item));

--- a/CycloneDX/Program.cs
+++ b/CycloneDX/Program.cs
@@ -29,7 +29,7 @@ namespace CycloneDX
         {
 
 
-            var SolutionOrProjectFile = new Argument<string>("path", description: "The path to a .sln, .csproj, .fsproj, .vbproj, .xsproj, or packages.config file or the path to a directory which will be recursively analyzed for packages.config files.");
+            var SolutionOrProjectFile = new Argument<string>("path", description: "The path to a .sln, .slnx, .csproj, .fsproj, .vbproj, .xsproj, or packages.config file or the path to a directory which will be recursively analyzed for packages.config files.");
             var framework = new Option<string>(new[] { "--framework", "-tfm" }, "The target framework to use. If not defined, all will be aggregated.");
             var runtime = new Option<string>(new[] { "--runtime", "-rt" }, "The runtime to use. If not defined, all will be aggregated.");
             var outputDirectory = new Option<string>(new[] { "--output", "-o" }, description: "The directory to write the BOM");
@@ -131,7 +131,7 @@ namespace CycloneDX
                     setVersion = context.ParseResult.GetValueForOption(setVersion),
                     setType = context.ParseResult.GetValueForOption(setType),
                     includeProjectReferences = context.ParseResult.GetValueForOption(includeProjectReferences)
-                };                
+                };
 
                 Runner runner = new Runner();
                 var taskStatus = await runner.HandleCommandAsync(options);

--- a/CycloneDX/Runner.cs
+++ b/CycloneDX/Runner.cs
@@ -71,13 +71,13 @@ namespace CycloneDX
             string outputFilename = options.outputFilename;
             bool json = options.json;
             bool excludeDev = options.excludeDev;
-            bool excludetestprojects = options.excludeTestProjects;            
+            bool excludetestprojects = options.excludeTestProjects;
             bool scanProjectReferences = options.scanProjectReferences;
             bool noSerialNumber = options.noSerialNumber;
             string githubUsername = options.githubUsername;
             string githubT = options.githubT;
-            string githubBT = options.githubBT;            
-            bool disablePackageRestore = options.disablePackageRestore;            
+            string githubBT = options.githubBT;
+            bool disablePackageRestore = options.disablePackageRestore;
             int dotnetCommandTimeout = options.dotnetCommandTimeout;
             string baseIntermediateOutputPath = options.baseIntermediateOutputPath;
             string importMetadataPath = options.importMetadataPath;
@@ -106,7 +106,7 @@ namespace CycloneDX
                 Console.WriteLine($"    {cachePath}");
             }
 
-            // instantiate services            
+            // instantiate services
             GithubService githubService = null;
             if (options.enableGithubLicenses)
             {
@@ -162,7 +162,7 @@ namespace CycloneDX
 
             try
             {
-                if (SolutionOrProjectFile.ToLowerInvariant().EndsWith(".sln", StringComparison.OrdinalIgnoreCase))
+                if (SolutionOrProjectFile.ToLowerInvariant().EndsWith(".sln", StringComparison.OrdinalIgnoreCase) || SolutionOrProjectFile.ToLowerInvariant().EndsWith(".slnx", StringComparison.OrdinalIgnoreCase))
                 {
                     if (!fileSystem.File.Exists(SolutionOrProjectFile))
                     {
@@ -177,17 +177,17 @@ namespace CycloneDX
                     if(!fileSystem.File.Exists(SolutionOrProjectFile))
                     {
                         Console.Error.WriteLine($"No file found at path {SolutionOrProjectFile}");
-                        return (int)ExitCode.InvalidOptions;                        
+                        return (int)ExitCode.InvalidOptions;
                     }
                     packages = await projectFileService.RecursivelyGetProjectDotnetDependencysAsync(fullSolutionOrProjectFilePath, baseIntermediateOutputPath, excludetestprojects, framework, runtime).ConfigureAwait(false);
                     topLevelComponent.Name = fileSystem.Path.GetFileNameWithoutExtension(SolutionOrProjectFile);
                 }
                 else if (Utils.IsSupportedProjectType(SolutionOrProjectFile))
-                {                    
+                {
                     if(!fileSystem.File.Exists(SolutionOrProjectFile))
                     {
                         Console.Error.WriteLine($"No file found at path {SolutionOrProjectFile}");
-                        return (int)ExitCode.InvalidOptions;                        
+                        return (int)ExitCode.InvalidOptions;
                     }
                     packages = await projectFileService.GetProjectDotnetDependencysAsync(fullSolutionOrProjectFilePath, baseIntermediateOutputPath, excludetestprojects, framework, runtime).ConfigureAwait(false);
                     topLevelComponent.Name = fileSystem.Path.GetFileNameWithoutExtension(SolutionOrProjectFile);
@@ -226,7 +226,7 @@ namespace CycloneDX
                 topLevelComponent.Name = setName;
             }
 
-                        
+
             if (excludeDev)
             {
                 foreach (var item in packages.Where(p => p.IsDevDependency))
@@ -239,7 +239,7 @@ namespace CycloneDX
             }
 
 
-            
+
 
             // get all the components and dependency graph from the NuGet packages
             var components = new HashSet<Component>();
@@ -423,7 +423,7 @@ namespace CycloneDX
             Console.WriteLine("Writing to: " + bomFilePath);
             this.fileSystem.File.WriteAllText(bomFilePath, bomContents);
 
-            return 0;    
+            return 0;
         }
 
 
@@ -465,7 +465,7 @@ namespace CycloneDX
             {
                 bom.Metadata.Timestamp = DateTime.UtcNow;
             }
-            
+
         }
 
         internal static Bom ReadMetaDataFromFile(Bom bom, string templatePath)


### PR DESCRIPTION
This Pull Request aim to support the new solution format .slnx, that was released together with .NET 9.0.200.

It goes with the old approach and uses regex to read the projects path, before start reading the solution file it checks if it is a .sln or .slnx and then call the macthing private method.