### PR TITLE
fix: issue 894 - remove dependencies, that have no belonging library

### DIFF
--- a/CycloneDX.Tests/CycloneDX.Tests.csproj
+++ b/CycloneDX.Tests/CycloneDX.Tests.csproj
@@ -72,6 +72,15 @@
     <None Update="FunctionalTests\Issue830-rsMultipleFrameworks\project2csproj.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="FunctionalTests\Issue894\project1assets.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="FunctionalTests\Issue894\project1csproj.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="FunctionalTests\Issue894\project2csproj.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="FunctionalTests\ProjectReferencesUseAssemblyNames\project1assets.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/CycloneDX.Tests/FunctionalTests/Issue894/Issue894.cs
+++ b/CycloneDX.Tests/FunctionalTests/Issue894/Issue894.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.IO;
+using System.IO.Abstractions;
+using System.IO.Abstractions.TestingHelpers;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using CycloneDX.Models;
+using Xunit;
+
+namespace CycloneDX.Tests.FunctionalTests
+{
+    public class Issue894
+    {
+        readonly string testFileFolder = "Issue894";
+
+        private MockFileSystem getMockFS()
+        {
+            return new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {
+                    MockUnixSupport.Path("c:/ProjectPath/Project.csproj"),
+                        new MockFileData(
+                            File.ReadAllText(Path.Combine("FunctionalTests", testFileFolder, "project1csproj.xml")))
+                },{
+                    MockUnixSupport.Path("c:/projectB/projectB.csproj"),
+                        new MockFileData(
+                            File.ReadAllText(Path.Combine("FunctionalTests", testFileFolder, "project2csproj.xml")))
+                },{
+                    MockUnixSupport.Path("c:/ProjectPath/obj/project.assets.json"),
+                        new MockFileData(
+                            File.ReadAllText(Path.Combine("FunctionalTests",testFileFolder, "project1assets.json")))
+                }
+            }); 
+        }
+
+        [Fact]
+        public async Task NoExceptionHappens()
+        {
+            var options = new RunOptions
+            {
+                scanProjectReferences = false
+            };
+
+            //Just test that there is no exception
+            var bom = await FunctionalTestHelper.Test(options, getMockFS());
+        }
+    }
+}

--- a/CycloneDX.Tests/FunctionalTests/Issue894/project1assets.json
+++ b/CycloneDX.Tests/FunctionalTests/Issue894/project1assets.json
@@ -1,0 +1,206 @@
+{
+  "version": 3,
+  "targets": {
+    "net9.0": {
+      "Google.Api.CommonProtos/2.16.0": {
+        "type": "package",
+        "dependencies": {
+          "Google.Protobuf": "[3.28.2, 4.0.0)"
+        },
+        "compile": {
+          "lib/netstandard2.0/Google.Api.CommonProtos.dll": {
+            "related": ".pdb;.xml"
+          }
+        },
+        "runtime": {
+          "lib/netstandard2.0/Google.Api.CommonProtos.dll": {
+            "related": ".pdb;.xml"
+          }
+        },
+        "build": {
+          "build/_._": {}
+        }
+      },
+      "ProjectB/1.0.0": {
+        "type": "project",
+        "framework": ".NETCoreApp,Version=v9.0",
+        "dependencies": {
+          "Google.Api.CommonProtos": "2.16.0"
+        },
+        "compile": {
+          "bin/placeholder/ProjectB.dll": {}
+        },
+        "runtime": {
+          "bin/placeholder/ProjectB.dll": {}
+        }
+      }
+    }
+  },
+  "libraries": {
+    "Google.Api.CommonProtos/2.16.0": {
+      "sha512": "37MuZrE9AAqHAdYgFLoTHydAiXDRriQZGVKEg6fr6ASnrY5GtauYXnQrGk5x2K3NmYzEXe+wkpaPVmxjb3NKjg==",
+      "type": "package",
+      "path": "google.api.commonprotos/2.16.0",
+      "files": [
+        ".nupkg.metadata",
+        ".signature.p7s",
+        "LICENSE",
+        "NuGetIcon.png",
+        "build/Google.Api.CommonProtos.targets",
+        "content/protos/google/api/annotations.proto",
+        "content/protos/google/api/auth.proto",
+        "content/protos/google/api/backend.proto",
+        "content/protos/google/api/billing.proto",
+        "content/protos/google/api/client.proto",
+        "content/protos/google/api/config_change.proto",
+        "content/protos/google/api/consumer.proto",
+        "content/protos/google/api/context.proto",
+        "content/protos/google/api/control.proto",
+        "content/protos/google/api/distribution.proto",
+        "content/protos/google/api/documentation.proto",
+        "content/protos/google/api/endpoint.proto",
+        "content/protos/google/api/error_reason.proto",
+        "content/protos/google/api/field_behavior.proto",
+        "content/protos/google/api/field_info.proto",
+        "content/protos/google/api/http.proto",
+        "content/protos/google/api/httpbody.proto",
+        "content/protos/google/api/label.proto",
+        "content/protos/google/api/launch_stage.proto",
+        "content/protos/google/api/log.proto",
+        "content/protos/google/api/logging.proto",
+        "content/protos/google/api/metric.proto",
+        "content/protos/google/api/monitored_resource.proto",
+        "content/protos/google/api/monitoring.proto",
+        "content/protos/google/api/policy.proto",
+        "content/protos/google/api/quota.proto",
+        "content/protos/google/api/resource.proto",
+        "content/protos/google/api/routing.proto",
+        "content/protos/google/api/service.proto",
+        "content/protos/google/api/source_info.proto",
+        "content/protos/google/api/system_parameter.proto",
+        "content/protos/google/api/usage.proto",
+        "content/protos/google/api/visibility.proto",
+        "content/protos/google/rpc/code.proto",
+        "content/protos/google/rpc/context/attribute_context.proto",
+        "content/protos/google/rpc/context/audit_context.proto",
+        "content/protos/google/rpc/error_details.proto",
+        "content/protos/google/rpc/http.proto",
+        "content/protos/google/rpc/status.proto",
+        "content/protos/google/type/calendar_period.proto",
+        "content/protos/google/type/color.proto",
+        "content/protos/google/type/date.proto",
+        "content/protos/google/type/datetime.proto",
+        "content/protos/google/type/dayofweek.proto",
+        "content/protos/google/type/decimal.proto",
+        "content/protos/google/type/expr.proto",
+        "content/protos/google/type/fraction.proto",
+        "content/protos/google/type/interval.proto",
+        "content/protos/google/type/latlng.proto",
+        "content/protos/google/type/localized_text.proto",
+        "content/protos/google/type/money.proto",
+        "content/protos/google/type/month.proto",
+        "content/protos/google/type/phone_number.proto",
+        "content/protos/google/type/postal_address.proto",
+        "content/protos/google/type/quaternion.proto",
+        "content/protos/google/type/timeofday.proto",
+        "google.api.commonprotos.2.16.0.nupkg.sha512",
+        "google.api.commonprotos.nuspec",
+        "lib/net461/Google.Api.CommonProtos.dll",
+        "lib/net461/Google.Api.CommonProtos.pdb",
+        "lib/net461/Google.Api.CommonProtos.xml",
+        "lib/netstandard2.0/Google.Api.CommonProtos.dll",
+        "lib/netstandard2.0/Google.Api.CommonProtos.pdb",
+        "lib/netstandard2.0/Google.Api.CommonProtos.xml"
+      ]
+    },
+    "ProjectB/1.0.0": {
+      "type": "project",
+      "path": "../ProjectB/ProjectB.csproj",
+      "msbuildProject": "../ProjectB/ProjectB.csproj"
+    }
+  },
+  "projectFileDependencyGroups": {
+    "net9.0": [
+      "ProjectB >= 1.0.0"
+    ]
+  },
+  "packageFolders": {
+    "C:\\Users\\user\\.nuget\\packages\\": {},
+    "C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\NuGetPackages": {}
+  },
+  "project": {
+    "version": "1.0.0",
+    "restore": {
+      "projectUniqueName": "C:\\Users\\user\\AppData\\Local\\Temp\\GrpcRepro\\ProjectA\\ProjectA.csproj",
+      "projectName": "ProjectA",
+      "projectPath": "C:\\Users\\user\\AppData\\Local\\Temp\\GrpcRepro\\ProjectA\\ProjectA.csproj",
+      "packagesPath": "C:\\Users\\user\\.nuget\\packages\\",
+      "outputPath": "C:\\Users\\user\\AppData\\Local\\Temp\\GrpcRepro\\ProjectA\\obj\\",
+      "projectStyle": "PackageReference",
+      "fallbackFolders": [
+        "C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\NuGetPackages"
+      ],
+      "configFilePaths": [
+        "C:\\Users\\user\\AppData\\Roaming\\NuGet\\NuGet.Config",
+        "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.FallbackLocation.config",
+        "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.Offline.config"
+      ],
+      "originalTargetFrameworks": [
+        "net9.0"
+      ],
+      "sources": {
+        "C:\\Program Files\\dotnet\\library-packs": {},
+        "E:\\src\\repos\\CycloneDX.Build\\CycloneDX.Build\\bin\\Debug\\": {},
+        "https://api.nuget.org/v3/index.json": {}
+      },
+      "frameworks": {
+        "net9.0": {
+          "targetAlias": "net9.0",
+          "projectReferences": {
+            "C:\\Users\\user\\AppData\\Local\\Temp\\GrpcRepro\\ProjectB\\ProjectB.csproj": {
+              "projectPath": "C:\\Users\\user\\AppData\\Local\\Temp\\GrpcRepro\\ProjectB\\ProjectB.csproj"
+            }
+          }
+        }
+      },
+      "warningProperties": {
+        "warnAsError": [
+          "NU1605"
+        ]
+      },
+      "restoreAuditProperties": {
+        "enableAudit": "true",
+        "auditLevel": "low",
+        "auditMode": "all"
+      }
+    },
+    "frameworks": {
+      "net9.0": {
+        "targetAlias": "net9.0",
+        "imports": [
+          "net461",
+          "net462",
+          "net47",
+          "net471",
+          "net472",
+          "net48",
+          "net481"
+        ],
+        "assetTargetFallback": true,
+        "warn": true,
+        "downloadDependencies": [
+          {
+            "name": "Microsoft.Net.Sdk.Compilers.Toolset",
+            "version": "[9.0.103, 9.0.103]"
+          }
+        ],
+        "frameworkReferences": {
+          "Microsoft.NETCore.App": {
+            "privateAssets": "all"
+          }
+        },
+        "runtimeIdentifierGraphPath": "C:\\Program Files\\dotnet\\sdk\\9.0.103/PortableRuntimeIdentifierGraph.json"
+      }
+    }
+  }
+}

--- a/CycloneDX.Tests/FunctionalTests/Issue894/project1csproj.xml
+++ b/CycloneDX.Tests/FunctionalTests/Issue894/project1csproj.xml
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ProjectB\ProjectB.csproj" />
+  </ItemGroup>
+</Project>

--- a/CycloneDX.Tests/FunctionalTests/Issue894/project2csproj.xml
+++ b/CycloneDX.Tests/FunctionalTests/Issue894/project2csproj.xml
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Google.Api.CommonProtos" Version="2.16.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.28.2">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
@Falco20019 This is my intended fix for issue #894. I simply kick out dependencies that have no corresponding library in the assets file as described as step 1 previously [here](https://github.com/CycloneDX/cyclonedx-dotnet/pull/929#issuecomment-2692962569).

This should work for you, shouldn't it?
A future step then would be to still find those dev-dependencies in a recursive scan of package-references. 

I'd appreciate a short review, otherwise I will just release it tomorrow over the day.