### PR TITLE
feat: add evidence collect option

### DIFF
--- a/CycloneDX.Tests/NugetV3ServiceTests.cs
+++ b/CycloneDX.Tests/NugetV3ServiceTests.cs
@@ -48,7 +48,7 @@ namespace CycloneDX.Tests
             };
             var mockGithubService = new Mock<IGithubService>();
             var nugetService = new NugetV3Service(null, mockFileSystem, cachePaths, mockGithubService.Object,
-                new NullLogger(), false);
+                new NullLogger(), false, EvidenceLicenseTextCollectionMode.None);
 
             var nuspecFilename = nugetService.GetCachedNuspecFilename("TestPackage", "1.2.3");
 
@@ -73,7 +73,7 @@ namespace CycloneDX.Tests
                 mockFileSystem,
                 new List<string> { XFS.Path(@"c:\nugetcache") },
                 new Mock<IGithubService>().Object,
-                new NullLogger(), false);
+                new NullLogger(), false, EvidenceLicenseTextCollectionMode.None);
 
             var component = await nugetService.GetComponentAsync("testpackage", "1.0.0", Component.ComponentScope.Required).ConfigureAwait(true);
 
@@ -115,7 +115,7 @@ namespace CycloneDX.Tests
                 mockFileSystem,
                 new List<string> { XFS.Path(@"c:\nugetcache") },
                 new Mock<IGithubService>().Object,
-                new NullLogger(), false);
+                new NullLogger(), false, EvidenceLicenseTextCollectionMode.None);
 
             var component = await nugetService.GetComponentAsync("testpackage", rawVersion, Component.ComponentScope.Required).ConfigureAwait(true);
 
@@ -145,7 +145,7 @@ namespace CycloneDX.Tests
                 mockFileSystem,
                 new List<string> { XFS.Path(@"c:\nugetcache") },
                 new Mock<IGithubService>().Object,
-                new NullLogger(), false);
+                new NullLogger(), false, EvidenceLicenseTextCollectionMode.None);
 
             var component = await nugetService.GetComponentAsync("testpackage", $"{rawVersion}", Component.ComponentScope.Required).ConfigureAwait(true);
 
@@ -181,7 +181,8 @@ namespace CycloneDX.Tests
                 new List<string> { XFS.Path(@"c:\nugetcache") },
                 new Mock<IGithubService>().Object,
                 new NullLogger(),
-                true);
+                true,
+                EvidenceLicenseTextCollectionMode.None);
 
             var component = await nugetService.GetComponentAsync("testpackage", "1.0.0", Component.ComponentScope.Required).ConfigureAwait(true);
 
@@ -251,7 +252,7 @@ namespace CycloneDX.Tests
                 mockFileSystem,
                 new List<string> { XFS.Path(@"c:\nugetcache") },
                 new Mock<IGithubService>().Object,
-                new NullLogger(), false);
+                new NullLogger(), false, EvidenceLicenseTextCollectionMode.None);
 
             var component = await nugetService.GetComponentAsync("testpackage", "1.0.0", Component.ComponentScope.Required).ConfigureAwait(true);
 
@@ -266,7 +267,7 @@ namespace CycloneDX.Tests
                 new MockFileSystem(),
                 new List<string> { XFS.Path(@"c:\nugetcache") },
                 new Mock<IGithubService>().Object,
-                new NullLogger(), false);
+                new NullLogger(), false, EvidenceLicenseTextCollectionMode.None);
 
             var packageName = "Newtonsoft.Json";
             var packageVersion = "13.0.1";
@@ -285,7 +286,7 @@ namespace CycloneDX.Tests
                 new MockFileSystem(),
                 new List<string> { XFS.Path(@"c:\nugetcache") },
                 new Mock<IGithubService>().Object,
-                new NullLogger(), true);
+                new NullLogger(), true, EvidenceLicenseTextCollectionMode.None);
 
             var packageName = "Newtonsoft.Json";
             var packageVersion = "13.0.1";
@@ -319,7 +320,7 @@ namespace CycloneDX.Tests
                 mockFileSystem,
                 new List<string> { XFS.Path(@"c:\nugetcache") },
                 mockGitHubService.Object,
-                new NullLogger(), false);
+                new NullLogger(), false, EvidenceLicenseTextCollectionMode.None);
 
             var component = await nugetService.GetComponentAsync("testpackage", "1.0.0", Component.ComponentScope.Required).ConfigureAwait(true);
 
@@ -350,7 +351,7 @@ namespace CycloneDX.Tests
                 mockFileSystem,
                 new List<string> { XFS.Path(@"c:\nugetcache") },
                 mockGitHubService.Object,
-                new NullLogger(), false);
+                new NullLogger(), false, EvidenceLicenseTextCollectionMode.None);
 
             var component = await nugetService.GetComponentAsync("testpackage", "1.0.0", Component.ComponentScope.Required).ConfigureAwait(true);
 
@@ -381,7 +382,7 @@ namespace CycloneDX.Tests
                 mockFileSystem,
                 new List<string> { XFS.Path(@"c:\nugetcache") },
                 mockGitHubService.Object,
-                new NullLogger(), false);
+                new NullLogger(), false, EvidenceLicenseTextCollectionMode.None);
 
             var component = await nugetService.GetComponentAsync("testpackage", "1.0.0", Component.ComponentScope.Required).ConfigureAwait(true);
 
@@ -412,7 +413,7 @@ namespace CycloneDX.Tests
                 mockFileSystem,
                 new List<string> { XFS.Path(@"c:\nugetcache") },
                 mockGitHubService.Object,
-                new NullLogger(), false);
+                new NullLogger(), false, EvidenceLicenseTextCollectionMode.None);
 
             var component = await nugetService.GetComponentAsync("testpackage", "1.0.0", Component.ComponentScope.Required).ConfigureAwait(true);
 
@@ -444,7 +445,7 @@ namespace CycloneDX.Tests
                 mockFileSystem,
                 new List<string> { XFS.Path(@"c:\nugetcache") },
                 mockGitHubService.Object,
-                new NullLogger(), false);
+                new NullLogger(), false, EvidenceLicenseTextCollectionMode.None);
 
             var component = await nugetService.GetComponentAsync("testpackage", "1.0.0", Component.ComponentScope.Required).ConfigureAwait(true);
 
@@ -474,7 +475,7 @@ namespace CycloneDX.Tests
                 mockFileSystem,
                 new List<string> { XFS.Path(@"c:\nugetcache") },
                 mockGitHubService.Object,
-                new NullLogger(), false);
+                new NullLogger(), false, EvidenceLicenseTextCollectionMode.None);
 
             var component = await nugetService.GetComponentAsync("testpackage", "1.0.0", Component.ComponentScope.Required).ConfigureAwait(true);
 
@@ -503,7 +504,7 @@ namespace CycloneDX.Tests
                 mockFileSystem,
                 new List<string> { XFS.Path(@"c:\nugetcache") },
                 mockGitHubService.Object,
-                new NullLogger(), false);
+                new NullLogger(), false, EvidenceLicenseTextCollectionMode.None);
 
             var component = await nugetService.GetComponentAsync("testpackage", "1.0.0", Component.ComponentScope.Required).ConfigureAwait(true);
 
@@ -532,13 +533,270 @@ namespace CycloneDX.Tests
                 mockFileSystem,
                 new List<string> { XFS.Path(@"c:\nugetcache") },
                 null,
-                new NullLogger(), false);
+                new NullLogger(), false, EvidenceLicenseTextCollectionMode.None);
 
             var component = await nugetService.GetComponentAsync("testpackage", "1.0.0", Component.ComponentScope.Required).ConfigureAwait(true);
 
             Assert.Single(component.Licenses);
             Assert.Equal("https://not-licence.url", component.Licenses.First().License.Url);
             Assert.Equal("Unknown - See URL", component.Licenses.First().License.Name);
+        }
+
+        [Theory]
+        [InlineData("LICENSE.txt", true)]
+        [InlineData("LICENCE.txt", true)]
+        [InlineData("LICENCE", true)]
+        [InlineData("LICENSE", true)]
+        [InlineData("LICENSE.md", true)]
+        [InlineData("LICENCE.md", true)]
+        [InlineData("LIC.md", true)]
+        [InlineData("LICENSE.txt.txt", true)]
+        [InlineData("LIC.md", false)]
+        public async Task GetComponent_CollectLicenseText_GetsTextAndSettingsCorrectly(string licenseFileName, bool isValidName)
+        {
+            var hintFileName = isValidName ? licenseFileName : "LICENSE.txt";
+            var nuspecFileContents = $@"<?xml version=""1.0"" encoding=""utf-8""?>
+                <package xmlns=""http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd"">
+                <metadata>
+                    <id>testpackage</id>
+                    <license type=""file"">{hintFileName}</license>
+                </metadata>
+                </package>";
+            var licenseFileContents = @"this is license text";
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\nugetcache\testpackage\1.0.0\testpackage.nuspec"), new MockFileData(nuspecFileContents) },
+                { XFS.Path($@"c:\nugetcache\testpackage\1.0.0\{licenseFileName}"), new MockFileData(licenseFileContents) },
+            });
+
+            var nugetService = new NugetV3Service(null,
+            mockFileSystem,
+            new List<string> { XFS.Path(@"c:\nugetcache") },
+            new Mock<IGithubService>().Object,
+            new NullLogger(), false,
+            evidenceCollectionMode: EvidenceLicenseTextCollectionMode.Unknown);
+
+            var component = await nugetService.GetComponentAsync("testpackage", "1.0.0", Component.ComponentScope.Required).ConfigureAwait(true);
+
+            if (isValidName)
+            {
+                Assert.NotNull(component.Licenses);
+                Assert.Single(component.Licenses);
+                Assert.NotNull(component.Licenses.First().License.Text);
+                //can be only base64 according to cyclonedx.org doc
+                Assert.Equal("base64", component.Licenses.First().License.Text.Encoding);
+                Assert.Equal("text/plain", component.Licenses.First().License.Text.ContentType);
+                var actualName = component.Licenses.First().License.Name;
+                Assert.True(actualName == $"License detected in: {licenseFileName}" || actualName == "Unknown - See URL");
+                var actualText = Encoding.UTF8.GetString(Convert.FromBase64String(component.Licenses.First().License.Text.Content));
+                Assert.Equal(licenseFileContents, actualText);
+            } else {
+                // file based license and invalid name? then no license expected
+                Assert.Null(component.Licenses);
+            }
+        }
+
+        [Theory]
+        [InlineData(EvidenceLicenseTextCollectionMode.None)]
+        [InlineData(EvidenceLicenseTextCollectionMode.Unknown)]
+        [InlineData(EvidenceLicenseTextCollectionMode.All)]
+
+        public async Task GetComponent_CollectLicenseText_LicenseNameFallsBackToUrl(EvidenceLicenseTextCollectionMode evidenceCollectionMode)
+        {
+            var nuspecFileContents = @"<?xml version=""1.0"" encoding=""utf-8""?>
+                <package xmlns=""http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd"">
+                <metadata>
+                    <id>testpackage</id>
+                    <license type=""file"">LICENSE.txt</license>
+                </metadata>
+                </package>";
+            var licenseFileContents = @"this is license text";
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\nugetcache\testpackage\1.0.0\testpackage.nuspec"), new MockFileData(nuspecFileContents) },
+                { XFS.Path($@"c:\nugetcache\testpackage\1.0.0\{"LICENSE.txt"}"), new MockFileData(licenseFileContents) },
+            });
+
+            var nugetService = new NugetV3Service(null,
+            mockFileSystem,
+            new List<string> { XFS.Path(@"c:\nugetcache") },
+            null,
+            new NullLogger(), false,
+            evidenceCollectionMode);
+
+            var component = await nugetService.GetComponentAsync("testpackage", "1.0.0", Component.ComponentScope.Required).ConfigureAwait(true);
+
+            switch (evidenceCollectionMode)
+            {
+                case EvidenceLicenseTextCollectionMode.None:
+                    Assert.Null(component.Evidence);
+                    Assert.Null(component.Licenses.First().License.Text);
+                    Assert.Equal("Unknown - See URL", component.Licenses.First().License.Name);
+                    break;
+                case EvidenceLicenseTextCollectionMode.Unknown:
+                    Assert.NotNull(component.Licenses);
+                    Assert.Single(component.Licenses);
+                    Assert.NotNull(component.Licenses.First().License.Text);
+                    Assert.Equal("base64", component.Licenses.First().License.Text.Encoding);
+                    Assert.Equal("text/plain", component.Licenses.First().License.Text.ContentType);
+                    Assert.Equal("Unknown - See URL", component.Licenses.First().License.Name);
+                    var actualText = Encoding.UTF8.GetString(Convert.FromBase64String(component.Licenses.First().License.Text.Content));
+                    Assert.Equal(licenseFileContents, actualText);
+                    break;
+                case EvidenceLicenseTextCollectionMode.All:
+                    Assert.NotNull(component.Licenses);
+                    Assert.Single(component.Licenses);
+                    //id set, but not the text
+                    Assert.Null(component.Licenses.First().License.Id);
+                    Assert.NotNull(component.Licenses.First().License.Name);
+                    Assert.Null(component.Licenses.First().License.Text);
+                    // now check the evidence
+                    Assert.NotNull(component.Evidence);
+                    Assert.NotNull(component.Evidence.Licenses);
+                    Assert.Single(component.Evidence.Licenses);
+                    Assert.NotNull(component.Evidence.Licenses.First().License.Text);
+                    Assert.Equal("License detected in: LICENSE.txt", component.Evidence.Licenses.First().License.Name);
+                    Assert.Equal("base64", component.Evidence.Licenses.First().License.Text.Encoding);
+                    Assert.Equal("text/plain", component.Evidence.Licenses.First().License.Text.ContentType);
+                    actualText = Encoding.UTF8.GetString(Convert.FromBase64String(component.Evidence.Licenses.First().License.Text.Content));
+                    Assert.Equal(licenseFileContents, actualText);
+                    break;
+                default:
+                    Assert.Fail("Unexpected evidence collection mode");
+                    break;
+            }
+        }
+
+        [Theory]
+        [InlineData(EvidenceLicenseTextCollectionMode.None)]
+        [InlineData(EvidenceLicenseTextCollectionMode.Unknown)]
+        [InlineData(EvidenceLicenseTextCollectionMode.All)]
+        public async Task GetComponent_CollectLicenseText_WhenLicenseIdCanBeResolved(EvidenceLicenseTextCollectionMode evidenceCollectionMode)
+        {
+            var nuspecFileContents = @"<?xml version=""1.0"" encoding=""utf-8""?>
+                <package xmlns=""http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd"">
+                <metadata>
+                    <id>testpackage</id>
+                    <licenseUrl>https://not-licence.url</licenseUrl>
+                    <repository url=""https://licence.url"" />
+                </metadata>
+                </package>";
+            var licenseFileContents = @"this is license text";
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\nugetcache\testpackage\1.0.0\testpackage.nuspec"), new MockFileData(nuspecFileContents) },
+                { XFS.Path(@"c:\nugetcache\testpackage\1.0.0\LICENSE.txt"), new MockFileData(licenseFileContents) },
+            });
+
+            var mockGitHubService = new Mock<IGithubService>();
+            mockGitHubService.Setup(x => x.GetLicenseAsync("https://licence.url")).Returns(Task.FromResult(new License { Id = "LicenseId" }));
+
+            var nugetService = new NugetV3Service(null,
+                mockFileSystem,
+                new List<string> { XFS.Path(@"c:\nugetcache") },
+                mockGitHubService.Object,
+                new NullLogger(), false,
+                evidenceCollectionMode);
+
+            var component = await nugetService.GetComponentAsync("testpackage", "1.0.0", Component.ComponentScope.Required).ConfigureAwait(true);
+
+            switch (evidenceCollectionMode)
+            {
+                case EvidenceLicenseTextCollectionMode.None:
+                    Assert.Null(component.Evidence);
+                    Assert.Null(component.Licenses.First().License.Text);
+                    Assert.Null(component.Licenses.First().License.Name);
+                    break;
+                case EvidenceLicenseTextCollectionMode.Unknown:
+                    Assert.Null(component.Evidence);
+                    Assert.Null(component.Licenses.First().License.Text);
+                    Assert.Null(component.Licenses.First().License.Name);
+                    break;
+                case EvidenceLicenseTextCollectionMode.All:
+                    Assert.NotNull(component.Licenses);
+                    Assert.Single(component.Licenses);
+                    //id set, but not the text
+                    Assert.NotNull(component.Licenses.First().License.Id);
+                    Assert.Null(component.Licenses.First().License.Name);
+                    Assert.Null(component.Licenses.First().License.Text);
+                    // now check the evidence
+                    Assert.NotNull(component.Evidence);
+                    Assert.NotNull(component.Evidence.Licenses);
+                    Assert.Single(component.Evidence.Licenses);
+                    Assert.NotNull(component.Evidence.Licenses.First().License.Text);
+                    Assert.Equal("License detected in: LICENSE.txt", component.Evidence.Licenses.First().License.Name);
+                    Assert.Equal("base64", component.Evidence.Licenses.First().License.Text.Encoding);
+                    Assert.Equal("text/plain", component.Evidence.Licenses.First().License.Text.ContentType);
+                    var actualText = Encoding.UTF8.GetString(Convert.FromBase64String(component.Evidence.Licenses.First().License.Text.Content));
+                    Assert.Equal(licenseFileContents, actualText);
+                    break;
+                default:
+                    Assert.Fail("Unexpected evidence collection mode");
+                    break;
+            }
+        }
+
+        [Theory]
+        [InlineData("Apache-2.0", EvidenceLicenseTextCollectionMode.None)]
+        [InlineData("Apache-2.0 OR MPL-2.0", EvidenceLicenseTextCollectionMode.None)]
+        [InlineData("Apache-2.0", EvidenceLicenseTextCollectionMode.Unknown)]
+        [InlineData("Apache-2.0 OR MPL-2.0", EvidenceLicenseTextCollectionMode.Unknown)]
+        [InlineData("Apache-2.0", EvidenceLicenseTextCollectionMode.All)]
+        [InlineData("Apache-2.0 OR MPL-2.0", EvidenceLicenseTextCollectionMode.All)]
+        public async Task GetComponent_CollectLicenseText_GetsTextWhenLicenseExpressionSet(string expression, EvidenceLicenseTextCollectionMode evidenceCollectionMode)
+        {
+            ///"License detected in"
+            var nuspecFileContents = $@"<?xml version=""1.0"" encoding=""utf-8""?>
+                <package xmlns=""http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd"">
+                <metadata>
+                    <id>testpackage</id>
+                    <license type=""expression"">{expression}</license>
+                </metadata>
+                </package>";
+            var licenseFileContents = @"this is license text";
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\nugetcache\testpackage\1.0.0\testpackage.nuspec"), new MockFileData(nuspecFileContents) },
+                { XFS.Path(@"c:\nugetcache\testpackage\1.0.0\LICENSE.txt"), new MockFileData(licenseFileContents) },
+            });
+
+            var mockGitHubService = new Mock<IGithubService>();
+
+            var nugetService = new NugetV3Service(null,
+                mockFileSystem,
+                new List<string> { XFS.Path(@"c:\nugetcache") },
+                mockGitHubService.Object,
+                new NullLogger(), false,
+                evidenceCollectionMode);
+
+            var component = await nugetService.GetComponentAsync("testpackage", "1.0.0", Component.ComponentScope.Required).ConfigureAwait(true);
+
+            switch (evidenceCollectionMode)
+            {
+                case EvidenceLicenseTextCollectionMode.None:
+                    Assert.Null(component.Evidence);
+                    Assert.Null(component.Licenses.First().License.Text);
+                    Assert.Null(component.Licenses.First().License.Name);
+                    break;
+                case EvidenceLicenseTextCollectionMode.Unknown:
+                    Assert.Null(component.Evidence);
+                    Assert.Null(component.Licenses.First().License.Text);
+                    Assert.Null(component.Licenses.First().License.Name);
+                    break;
+                case EvidenceLicenseTextCollectionMode.All:
+                    Assert.NotNull(component.Evidence.Licenses);
+                    Assert.Single(component.Evidence.Licenses);
+                    Assert.NotNull(component.Evidence.Licenses.First().License.Text);
+                    Assert.Equal("License detected in: LICENSE.txt", component.Evidence.Licenses.First().License.Name);
+                    Assert.Equal("base64", component.Evidence.Licenses.First().License.Text.Encoding);
+                    Assert.Equal("text/plain", component.Evidence.Licenses.First().License.Text.ContentType);
+                    var actualText = Encoding.UTF8.GetString(Convert.FromBase64String(component.Evidence.Licenses.First().License.Text.Content));
+                    Assert.Equal(licenseFileContents, actualText);
+                    break;
+                default:
+                    Assert.Fail("Unexpected evidence collection mode");
+                    break;
+            }
         }
     }
 }

--- a/CycloneDX/Models/RunOptions.cs
+++ b/CycloneDX/Models/RunOptions.cs
@@ -19,6 +19,24 @@ using System.Globalization;
 
 namespace CycloneDX.Models
 {
+    public enum EvidenceLicenseTextCollectionMode
+    {
+        /// <summary>
+        /// No evidence collection. This is the default.
+        /// </summary>
+        None,
+        /// <summary>
+        /// Collect evidence for all components which ship license file, regardless if license id or name is known or not.
+        /// </summary>
+        All,
+        /// <summary>
+        /// Collect license text only for components which have unknown license. This avoids collecting all license texts
+        /// for the case when license text can be obtained otherwise (like MIT) and therefore reduces the BOM size. In
+        /// contrast to the "All" mode, this mode will put license text into license block directly instead of evidence
+        /// part.
+        /// </summary>
+        Unknown,
+    }
     public class RunOptions
     {
         public string SolutionOrProjectFile { get; set; }
@@ -50,6 +68,6 @@ namespace CycloneDX.Models
         public Component.Classification setType { get; set; } = Component.Classification.Application;
         public bool setNugetPurl { get; set; }
         public string DependencyExcludeFilter { get; set; }
-
+        public EvidenceLicenseTextCollectionMode evidenceCollectionMode { get; set; } = EvidenceLicenseTextCollectionMode.None;
     }
 }

--- a/CycloneDX/Program.cs
+++ b/CycloneDX/Program.cs
@@ -58,13 +58,13 @@ namespace CycloneDX
             var setType = new Option<Component.Classification>(new[] { "--set-type", "-st" }, getDefaultValue: () => Component.Classification.Application, "Override the default BOM metadata component type (defaults to application).");
             var setNugetPurl = new Option<bool>(new[] { "--set-nuget-purl" }, "Override the default BOM metadata component bom ref and PURL as NuGet package.");
             var excludeFilter = new Option<string>(["--exclude-filter", "-ef"], "A comma separated list of dependencies to exclude in form 'name1@version1,name2@version2'. Transitive dependencies will also be removed.");
+            var evidenceCollectionMode = new Option<EvidenceLicenseTextCollectionMode>(new[] { "--collect-license-evidence", "-cle" }, "Collect license information from shipped files.");
             //Deprecated args
             var disableGithubLicenses = new Option<bool>(new[] { "--disable-github-licenses", "-dgl" }, "(Deprecated, this is the default setting now");
             var outputFilenameDeprecated = new Option<string>(new[] { "-f" }, "(Deprecated use -fn instead) Optionally provide a filename for the BOM (default: bom.xml or bom.json).");
             var excludeDevDeprecated = new Option<bool>(new[] {"-d" }, "(Deprecated use -ed instead) Exclude development dependencies from the BOM.");
             var scanProjectDeprecated = new Option<bool>(new[] {"-r" }, "(Deprecated use -rs instead) To be used with a single project file, it will recursively scan project references of the supplied project file.");
             var outputDirectoryDeprecated = new Option<string>(new[] { "--out", }, description: "(Deprecated use -output instead) The directory to write the BOM");
-
 
             RootCommand rootCommand = new RootCommand
             {
@@ -101,7 +101,8 @@ namespace CycloneDX
                 scanProjectDeprecated,
                 outputDirectoryDeprecated,
                 disableGithubLicenses,
-                excludeFilter
+                excludeFilter,
+                evidenceCollectionMode
             };
             rootCommand.Description = "A .NET Core global tool which creates CycloneDX Software Bill-of-Materials (SBOM) from .NET projects.";
             rootCommand.SetHandler(async (context) =>
@@ -136,7 +137,9 @@ namespace CycloneDX
                     setType = context.ParseResult.GetValueForOption(setType),
                     setNugetPurl = context.ParseResult.GetValueForOption(setNugetPurl),
                     includeProjectReferences = context.ParseResult.GetValueForOption(includeProjectReferences),
-                    DependencyExcludeFilter = context.ParseResult.GetValueForOption(excludeFilter)
+                    DependencyExcludeFilter = context.ParseResult.GetValueForOption(excludeFilter),
+                    evidenceCollectionMode = context.ParseResult.GetValueForOption(evidenceCollectionMode)
+
                 };
 
                 Runner runner = new Runner();

--- a/CycloneDX/Services/NugetV3ServiceFactory.cs
+++ b/CycloneDX/Services/NugetV3ServiceFactory.cs
@@ -15,7 +15,14 @@ namespace CycloneDX.Services
         {
             var nugetLogger = new NuGet.Common.NullLogger();
             var nugetInput = NugetInputFactory.Create(option.baseUrl, option.baseUrlUserName, option.baseUrlUSP, option.isPasswordClearText);
-            return new NugetV3Service(nugetInput, fileSystem, packageCachePaths, githubService, nugetLogger, option.disableHashComputation);
+            return new NugetV3Service(
+                nugetInput,
+                fileSystem,
+                packageCachePaths,
+                githubService,
+                nugetLogger,
+                option.disableHashComputation,
+                option.evidenceCollectionMode);
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Options:
   -st, --set-type   <Application|Container|Data|Device|Device_Driver|          Override the default BOM metadata component type (defaults to application). [default: Application]
                      File|Firmware|Framework|Library|
                      Machine_Learning_Model|Null|Operating_System|Platform>                                                                
+  -cle, --collect-license-evidence <None|All|Unknown> [default: None]          Collect license information from shipped files.
   --set-nuget-purl                                                             Override the default BOM metadata component bom ref and PURL as NuGet package.
   --version                                                                    Show version information
   -?, -h, --help                                                               Show help and usage information
@@ -104,6 +105,15 @@ Options:
     in the final binary output. For example, an application targets .NET 8, but has a dependency to a library,
     which only supports .NET Standard 1.6. Without filter, the libraries of .NET Standard 1.6 would be in the
     resulting SBOM. But they are not used by application as they do not exist in the binary output folder.
+
+*   `-cle, --collect-license-evidence`
+    The license evidence collection may be used to collect license information from shipped files, like LICENSE.txt.
+    This is particularly useful for packages, which have no license id provided, but rather information is provided in a file.
+    The default is `None` which means no license evidence will be collected. The other options are `All` which collects
+    all license evidence, even when the license id is known. Lastly, `Unknown` Collect license text only for components 
+    which have unknown license. This avoids collecting all license texts for the case when license text can be obtained 
+    otherwise (like MIT) and therefore reduces the BOM size. In contrast to the "All" mode, this mode will put license 
+    text into license block directly instead of evidence part.
 
 #### Examples
 To run the **CycloneDX** tool you need to specify a solution or project file. In case you pass a solution, the tool will aggregate all the projects.


### PR DESCRIPTION
The license evidence collection may be used to collect license information from shipped files, like LICENSE.txt. This is particularly useful for packages, which have no license id provided, but rather information is provided in a file. Also even when the license id or name is known, it still might be a good idea to have the license information from the time of BOM creation.

The default mode is `None` which means no license evidence will be collected. The other options are `All` which collects all license evidence, even when the license id is known. Lastly, `Unknown` Collect license text only for components which have unknown license. This avoids collecting all license texts for the case when license text can be obtained otherwise (like MIT) and therefore reduces the BOM size. In contrast to the "All" mode, this mode will put license text into license block directly instead of evidence part.

Signed-off-by: Roman Malytskyy malytskyy@users.noreply.github.com