### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -1,6 +1,9 @@
 # For details of what checks are run for PRs please refer below
 name: .NET Core CI
 
+permissions:
+  contents: read
+
 on: [pull_request, workflow_dispatch]
 
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/CycloneDX/cyclonedx-dotnet/security/code-scanning/5](https://github.com/CycloneDX/cyclonedx-dotnet/security/code-scanning/5)

To fix the issue, we will add a `permissions` block to the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the actions used in the workflow, the following permissions are needed:
- `contents: read` for accessing the repository's contents.
- `pull-requests: write` if the commented-out step for adding a coverage PR comment is re-enabled in the future.

The `permissions` block will be added at the root level to apply to all jobs in the workflow. If specific jobs require different permissions, they can override the root-level permissions by defining their own `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
