### PR TITLE
feat(analyzer): support MSBuild-based project.assets.json resolution

### DIFF
--- a/CycloneDX.Tests/ProjectFileServiceTests.cs
+++ b/CycloneDX.Tests/ProjectFileServiceTests.cs
@@ -79,6 +79,9 @@ namespace CycloneDX.Tests
             mockDotnetUtilsService
                 .Setup(s => s.Restore(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
                 .Returns(new DotnetUtilsResult());
+            mockDotnetUtilsService
+                 .Setup(s => s.GetAssetsPath(It.IsAny<string>()))
+                 .Returns(new DotnetUtilsResult<string>() { Result = "" });
             var mockPackageFileService = new Mock<IPackagesFileService>();
             var mockProjectAssetsFileService = new Mock<IProjectAssetsFileService>();
             mockProjectAssetsFileService
@@ -114,6 +117,9 @@ namespace CycloneDX.Tests
             mockDotnetUtilsService
                 .Setup(s => s.Restore(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
                 .Throws(new ApplicationException("Restore should not be called"));
+            mockDotnetUtilsService
+                .Setup(s => s.GetAssetsPath(It.IsAny<string>()))
+                .Returns(new DotnetUtilsResult<string>() { Result = "" });
             var mockPackageFileService = new Mock<IPackagesFileService>();
             var mockProjectAssetsFileService = new Mock<IProjectAssetsFileService>();
             mockProjectAssetsFileService
@@ -150,6 +156,9 @@ namespace CycloneDX.Tests
             mockDotnetUtilsService
                 .Setup(s => s.Restore(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
                 .Returns(new DotnetUtilsResult());
+            mockDotnetUtilsService
+                .Setup(s => s.GetAssetsPath(It.IsAny<string>()))
+                .Returns(new DotnetUtilsResult<string>() { Result = "" });
             var mockPackageFileService = new Mock<IPackagesFileService>();
             var mockProjectAssetsFileService = new Mock<IProjectAssetsFileService>();
             mockProjectAssetsFileService
@@ -188,6 +197,9 @@ namespace CycloneDX.Tests
             mockDotnetUtilsService
                 .Setup(s => s.Restore(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
                 .Returns(new DotnetUtilsResult());
+            mockDotnetUtilsService
+                .Setup(s => s.GetAssetsPath(It.IsAny<string>()))
+                .Returns(new DotnetUtilsResult<string>() { Result = ""});
             var mockPackageFileService = new Mock<IPackagesFileService>();
             mockPackageFileService
                 .Setup(s => s.GetDotnetDependencysAsync(It.IsAny<string>()))
@@ -228,6 +240,9 @@ namespace CycloneDX.Tests
             mockDotnetUtilsService
                 .Setup(s => s.Restore(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
                 .Returns(new DotnetUtilsResult());
+            mockDotnetUtilsService
+             .Setup(s => s.GetAssetsPath(It.IsAny<string>()))
+             .Returns(new DotnetUtilsResult<string>() { Result = "" });
             var mockPackageFileService = new Mock<IPackagesFileService>();
             mockPackageFileService
                 .Setup(s => s.GetDotnetDependencysAsync(It.IsAny<string>()))

--- a/CycloneDX/Interfaces/IDotnetUtilsService.cs
+++ b/CycloneDX/Interfaces/IDotnetUtilsService.cs
@@ -22,6 +22,7 @@ namespace CycloneDX.Interfaces
 {
     public interface IDotnetUtilsService
     {
+        DotnetUtilsResult<string> GetAssetsPath(string projectFilePath);
         DotnetUtilsResult<List<string>> GetPackageCachePaths();
         DotnetUtilsResult Restore(string path, string framework, string runtime);
     }

--- a/CycloneDX/Services/ProjectFileService.cs
+++ b/CycloneDX/Services/ProjectFileService.cs
@@ -209,7 +209,7 @@ namespace CycloneDX.Services
                 }
             }
 
-            var assetsFilename = _fileSystem.Path.Combine(GetProjectProperty(projectFilePath, baseIntermediateOutputPath), "project.assets.json");
+            var assetsFilename = GetProjectAssetsFilePath(projectFilePath, baseIntermediateOutputPath);
             if (!_fileSystem.File.Exists(assetsFilename))
             {
                 Console.WriteLine($"File not found: \"{assetsFilename}\", \"{projectFilePath}\" ");
@@ -230,6 +230,21 @@ namespace CycloneDX.Services
                 }
             }
             return packages;
+        }
+
+        private string GetProjectAssetsFilePath(string projectFilePath, string baseIntermediateOutputPath)
+        {            
+            if (string.IsNullOrEmpty(baseIntermediateOutputPath ))
+            {
+                var result = _dotnetUtilsService.GetAssetsPath(projectFilePath);
+                if(result.Success && _fileSystem.File.Exists(result.Result))
+                {
+                    Console.WriteLine($"  Found Assetsfile under {result.Result}");
+                    return result.Result;
+                }                
+                
+            }
+            return _fileSystem.Path.Combine(GetProjectProperty(projectFilePath, baseIntermediateOutputPath), "project.assets.json");                        
         }
 
         /// <summary>


### PR DESCRIPTION
## ✨ What’s in this PR

Adds support for resolving `project.assets.json` using MSBuild’s evaluated property:

    dotnet msbuild <project> -getProperty:ProjectAssetsFile

This allows CycloneDX-dotnet to support SDK-style projects that use custom intermediate output paths 
(e.g., `UseArtifactsOutput`, `ArtifactsPath`, or custom `BaseIntermediateOutputPath` values).

## ✅ Behavior

- Falls back to the legacy `obj/` path logic if MSBuild resolution fails (e.g., legacy .NET Framework).
- Ensures compatibility without breaking existing projects.

## 🔒 Closes

Fixes #699
