### PR TITLE
Populate url when processing license expressions

### DIFF
--- a/CycloneDX/Services/NugetV3Service.cs
+++ b/CycloneDX/Services/NugetV3Service.cs
@@ -265,6 +265,7 @@ namespace CycloneDX.Services
                     var license = new License();
                     license.Id = nugetLicense.Identifier;
                     license.Name = license.Id == null ? nugetLicense.Identifier : null;
+                    license.Url = licenseMetadata.LicenseUrl?.ToString().Trim();
                     component.Licenses ??= new List<LicenseChoice>();
                     component.Licenses.Add(new LicenseChoice { License = license });
                 };


### PR DESCRIPTION
When a NuGet package defines its license by expression type and then provides the licenseUrl, the latter is missed during the collection.

This change applies the optional licenseUrl to all licenses processed from the expression, in order not to lose the information.