### PR TITLE
Fix #915: handle UNLICENSED in NuGet license expressions

### DIFF
--- a/CycloneDX.Tests/NugetV3ServiceTests.cs
+++ b/CycloneDX.Tests/NugetV3ServiceTests.cs
@@ -483,6 +483,38 @@ namespace CycloneDX.Tests
         }
 
         [Fact]
+        public async Task GetComponent_UnlicensedLicenseExpression_MapsToLicenseName()
+        {
+            var nuspecFileContents = @"<?xml version=""1.0"" encoding=""utf-8""?>
+                <package xmlns=""http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd"">
+                <metadata>
+                    <id>testpackage</id>
+                    <license type=""expression"">UNLICENSED</license>
+                </metadata>
+                </package>";
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\nugetcache\testpackage\1.0.0\testpackage.nuspec"), new MockFileData(nuspecFileContents) },
+            });
+
+            var mockGitHubService = new Mock<IGithubService>();
+
+            var nugetService = new NugetV3Service(null,
+                mockFileSystem,
+                new List<string> { XFS.Path(@"c:\nugetcache") },
+                mockGitHubService.Object,
+                new NullLogger(), false);
+
+            var component = await nugetService.GetComponentAsync("testpackage", "1.0.0", Component.ComponentScope.Required).ConfigureAwait(true);
+
+            Assert.Single(component.Licenses);
+            Assert.Equal("UNLICENSED", component.Licenses.First().License.Name);
+            Assert.True(string.IsNullOrEmpty(component.Licenses.First().License.Id));
+        }
+
+
+
+        [Fact]
         public async Task GetComponent_MultiLicenseExpression_ReturnsComponent()
         {
             var nuspecFileContents = @"<?xml version=""1.0"" encoding=""utf-8""?>


### PR DESCRIPTION
Fixes #915

NuGet license expressions can legally include the "UNLICENSED" token. Today, when a package uses that token, cyclonedx-dotnet emits it as a CycloneDX "license.id", which results in invalid output because "UNLICENSED" is not an SPDX license identifier.

Changes:
- When parsing "LicenseType.Expression", map "UNLICENSED" (case-insensitive) to "license.name" instead of "license.id".
- Added a unit test covering the "UNLICENSED" license-expression behavior.

Notes:
- No behavior change for valid SPDX identifiers (e.g., Apache-2.0, MPL-2.0).
- Keeps output valid while still preserving the package’s intent.

Verification:
- dotnet test -c Release
- dotnet format --verify-no-changes --include CycloneDX/Services/NugetV3Service.cs CycloneDX.Tests/NugetV3ServiceTests.cs.