### PR TITLE
fix: resolve version-range bom-ref crash when scanning multi-project solutions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Fix crash when a nuspec declares an exact-range version constraint across multiple projects** (#1071) — when a package's nuspec dependency uses an exact version range (e.g. `[1.0.0]`) and multiple versions of that package are present in a multi-project solution, the tool no longer crashes with "Unable to locate valid bom ref"; the dependency edge is resolved to the version that satisfies the range
+
 ## [6.1.0]
 
 ### Added

--- a/CycloneDX.E2ETests/Infrastructure/NuGetServerFixture.cs
+++ b/CycloneDX.E2ETests/Infrastructure/NuGetServerFixture.cs
@@ -112,6 +112,23 @@ namespace CycloneDX.E2ETests.Infrastructure
 
             // TestPkg.Transitive 1.0.0 — used only as a transitive dep
             await PushPackageAsync(NupkgBuilder.Build("TestPkg.Transitive", "1.0.0")).ConfigureAwait(false);
+
+            // --- PR #903 / version-range bom-ref scenario ---
+            // TestPkg.Shared 1.0.0 — low-level package referenced via exact range [1.0.0, 1.0.0]
+            await PushPackageAsync(NupkgBuilder.Build("TestPkg.Shared", "1.0.0")).ConfigureAwait(false);
+
+            // TestPkg.Shared 2.0.0 — a second version of the same package, directly referenced by
+            // another project in the solution (creates ambiguity for the name-only fallback)
+            await PushPackageAsync(NupkgBuilder.Build("TestPkg.Shared", "2.0.0")).ConfigureAwait(false);
+
+            // TestPkg.Consumer 1.0.0 — declares its dep on TestPkg.Shared using exact-range notation
+            // ([1.0.0, 1.0.0]) as dotnet pack emits for packages with a fixed lower/upper bound.
+            // When NuGet resolves this alongside TestPkg.Shared 2.0.0 in another project, the
+            // project.assets.json stores the dep as "[1.0.0, 1.0.0]" which the tool must resolve.
+            await PushPackageAsync(NupkgBuilder.Build(
+                "TestPkg.Consumer", "1.0.0",
+                dependencies: new[] { new NupkgDependency("TestPkg.Shared", "[1.0.0, 1.0.0]") }
+            )).ConfigureAwait(false);
         }
 
         public async ValueTask DisposeAsync()

--- a/CycloneDX.E2ETests/Tests/Issue903Tests.cs
+++ b/CycloneDX.E2ETests/Tests/Issue903Tests.cs
@@ -15,6 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) OWASP Foundation. All Rights Reserved.
 
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using CycloneDX.E2ETests.Builders;
 using CycloneDX.E2ETests.Infrastructure;
@@ -54,21 +55,33 @@ namespace CycloneDX.E2ETests.Tests
         {
             // Reproduces the exact topology reported in PR #903 / issue comment by @ilehtoranta:
             //
-            //   ProjectA  — directly references TestPkg.Shared 2.0.0
+            //   ProjectB  — directly references TestPkg.Shared 1.0.0
+            //   ProjectA  — ProjectReference to ProjectB
+            //             — directly references TestPkg.Shared 2.0.0
             //             — directly references TestPkg.Consumer 1.0.0
             //   TestPkg.Consumer — depends on TestPkg.Shared [1.0.0, 1.0.0]  (exact-range notation)
             //
-            // After restore, ProjectA's project.assets.json contains two targets entries for
-            // TestPkg.Shared (1.0.0 and 2.0.0) and one dep entry under TestPkg.Consumer that
-            // reads "[1.0.0, 1.0.0]" instead of "1.0.0".
+            // After restore:
+            //   ProjectA's assets: NuGet resolves TestPkg.Shared to 2.0.0 (direct ref wins).
+            //     TestPkg.Consumer's dep is stored as "[1.0.0]" in project.assets.json.
+            //     ResolveDependencyVersionRanges cannot resolve it because 2.0.0 does not
+            //     satisfy the exact range [1.0.0]. Range string is left unresolved.
+            //   ProjectB's assets: resolves TestPkg.Shared/1.0.0.
+            //
+            // The tool merges both projects' packages into one BOM → both Shared 1.0.0 and 2.0.0
+            // are present. The name-only fallback in Runner.cs finds two candidates → crash.
             //
             // Before the fix: "Unable to locate valid bom ref for TestPkg.Shared [1.0.0, 1.0.0]"
             // After the fix:  tool succeeds and both versions appear in the BOM.
             using var solution = await new SolutionBuilder("Issue903Sln")
+                .AddProject("ProjectB", p => p
+                    .WithTargetFramework("net8.0")
+                    .AddPackage("TestPkg.Shared", "1.0.0"))
                 .AddProject("ProjectA", p => p
                     .WithTargetFramework("net8.0")
                     .AddPackage("TestPkg.Shared", "2.0.0")
-                    .AddPackage("TestPkg.Consumer", "1.0.0"))
+                    .AddPackage("TestPkg.Consumer", "1.0.0")
+                    .AddProjectReference("../ProjectB/ProjectB.csproj"))
                 .BuildAsync(_fixture.NuGetFeedUrl);
 
             using var outputDir = solution.CreateOutputDir();
@@ -86,13 +99,28 @@ namespace CycloneDX.E2ETests.Tests
             Assert.True(result.Success,
                 $"Tool failed with exit code {result.ExitCode}.\nstderr:\n{result.StdErr}\nstdout:\n{result.StdOut}");
 
-            // Both versions of the shared package must be present in the BOM
-            Assert.Contains("TestPkg.Shared", result.BomContent);
-            Assert.Contains("1.0.0", result.BomContent);
-            Assert.Contains("2.0.0", result.BomContent);
+            // Both versions of the shared package must appear as distinct components in the BOM.
+            // Scanning a solution is an explicit union of all projects — duplicate versions of the
+            // same package across projects are expected and correct.
+            Assert.Contains("pkg:nuget/TestPkg.Shared@1.0.0", result.BomContent);
+            Assert.Contains("pkg:nuget/TestPkg.Shared@2.0.0", result.BomContent);
+            Assert.Contains("pkg:nuget/TestPkg.Consumer@1.0.0", result.BomContent);
 
-            // The consumer package must be present
-            Assert.Contains("TestPkg.Consumer", result.BomContent);
+            // The critical correctness check: TestPkg.Consumer's dependency edge must point to
+            // TestPkg.Shared 1.0.0 (what its nuspec declares), not 2.0.0.
+            // In the XML the dependencies section looks like:
+            //   <dependency ref="pkg:nuget/TestPkg.Consumer@1.0.0">
+            //     <dependency ref="pkg:nuget/TestPkg.Shared@1.0.0"/>
+            //   </dependency>
+            var consumerDepBlock = Regex.Match(
+                result.BomContent,
+                @"<dependency ref=""pkg:nuget/TestPkg\.Consumer@1\.0\.0"">(.*?)</dependency>",
+                RegexOptions.Singleline).Value;
+
+            Assert.False(string.IsNullOrEmpty(consumerDepBlock),
+                "No dependency block found for TestPkg.Consumer@1.0.0");
+            Assert.Contains("pkg:nuget/TestPkg.Shared@1.0.0", consumerDepBlock);
+            Assert.DoesNotContain("pkg:nuget/TestPkg.Shared@2.0.0", consumerDepBlock);
         }
     }
 }

--- a/CycloneDX.E2ETests/Tests/Issue903Tests.cs
+++ b/CycloneDX.E2ETests/Tests/Issue903Tests.cs
@@ -1,0 +1,98 @@
+// This file is part of CycloneDX Tool for .NET
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OWASP Foundation. All Rights Reserved.
+
+using System.Threading.Tasks;
+using CycloneDX.E2ETests.Builders;
+using CycloneDX.E2ETests.Infrastructure;
+using Xunit;
+
+namespace CycloneDX.E2ETests.Tests
+{
+    /// <summary>
+    /// Regression tests for issue #903:
+    /// "Unable to locate valid bom ref for &lt;package&gt; [x.y.z, x.y.z]" when scanning a
+    /// solution that contains multiple projects referencing the same package at different versions.
+    ///
+    /// Root cause: NuGet stores a dependency's version constraint verbatim from the .nuspec into
+    /// project.assets.json. When a package declares its dep with exact-range notation
+    /// (e.g. "[1.0.0, 1.0.0]"), the version string stored in the lock file is a range, not a
+    /// plain version. Runner.cs builds its bomRefLookup keyed on plain versions only, so the
+    /// range string misses on the first lookup attempt. The name-only fallback at that point
+    /// succeeds only when exactly one version of the package is present in the BOM — but in a
+    /// multi-project solution a second version of the same package may be directly referenced,
+    /// giving two candidates and causing the error.
+    ///
+    /// The fix must resolve the range "[1.0.0, 1.0.0]" to the concrete version "1.0.0" and
+    /// look that up successfully even when another project directly pins "2.0.0".
+    /// </summary>
+    [Collection("E2E")]
+    public sealed class Issue903Tests
+    {
+        private readonly E2EFixture _fixture;
+
+        public Issue903Tests(E2EFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        [Fact]
+        public async Task VersionRangeDependency_MultipleVersionsInSolution_ShouldSucceed()
+        {
+            // Reproduces the exact topology reported in PR #903 / issue comment by @ilehtoranta:
+            //
+            //   ProjectA  — directly references TestPkg.Shared 2.0.0
+            //             — directly references TestPkg.Consumer 1.0.0
+            //   TestPkg.Consumer — depends on TestPkg.Shared [1.0.0, 1.0.0]  (exact-range notation)
+            //
+            // After restore, ProjectA's project.assets.json contains two targets entries for
+            // TestPkg.Shared (1.0.0 and 2.0.0) and one dep entry under TestPkg.Consumer that
+            // reads "[1.0.0, 1.0.0]" instead of "1.0.0".
+            //
+            // Before the fix: "Unable to locate valid bom ref for TestPkg.Shared [1.0.0, 1.0.0]"
+            // After the fix:  tool succeeds and both versions appear in the BOM.
+            using var solution = await new SolutionBuilder("Issue903Sln")
+                .AddProject("ProjectA", p => p
+                    .WithTargetFramework("net8.0")
+                    .AddPackage("TestPkg.Shared", "2.0.0")
+                    .AddPackage("TestPkg.Consumer", "1.0.0"))
+                .BuildAsync(_fixture.NuGetFeedUrl);
+
+            using var outputDir = solution.CreateOutputDir();
+
+            var result = await _fixture.Runner.RunAsync(
+                solution.SolutionFile,
+                outputDir.Path,
+                new ToolRunOptions
+                {
+                    NuGetFeedUrl = _fixture.NuGetFeedUrl,
+                    NoSerialNumber = true,
+                    DisableHashComputation = true,
+                });
+
+            Assert.True(result.Success,
+                $"Tool failed with exit code {result.ExitCode}.\nstderr:\n{result.StdErr}\nstdout:\n{result.StdOut}");
+
+            // Both versions of the shared package must be present in the BOM
+            Assert.Contains("TestPkg.Shared", result.BomContent);
+            Assert.Contains("1.0.0", result.BomContent);
+            Assert.Contains("2.0.0", result.BomContent);
+
+            // The consumer package must be present
+            Assert.Contains("TestPkg.Consumer", result.BomContent);
+        }
+    }
+}

--- a/CycloneDX/Runner.cs
+++ b/CycloneDX/Runner.cs
@@ -363,16 +363,21 @@ namespace CycloneDX
                                 lookupKey = packageNameMatch.First().Key;
                             }
                             else if (packageNameMatch.Count > 1
-                                && VersionRange.TryParse(dep.Value, out var versionRange)
-                                && packageNameMatch.Where(x => NuGetVersion.TryParse(x.Key.Item2, out var v)
-                                                               && versionRange.Satisfies(v))
-                                                   .ToList() is [var rangeMatch])
+                                && VersionRange.TryParse(dep.Value, out var versionRange))
                             {
                                 // dep.Value is a version range stored verbatim from the nuspec (e.g. "[1.0.0]").
                                 // ResolveDependencyVersionRanges couldn't resolve it within this project's
                                 // assets because the satisfying version only exists in another project's assets.
                                 // Use the range to pick the correct candidate from the merged BOM.
-                                lookupKey = rangeMatch.Key;
+                                var rangeMatch = packageNameMatch.SingleOrDefault(
+                                    x => NuGetVersion.TryParse(x.Key.Item2, out var v) && versionRange.Satisfies(v));
+                                if (rangeMatch.Key != default)
+                                    lookupKey = rangeMatch.Key;
+                                else
+                                {
+                                    Console.Error.WriteLine($"Unable to locate valid bom ref for {dep.Key} {dep.Value}");
+                                    return (int)ExitCode.UnableToLocateDependencyBomRef;
+                                }
                             }
                             else
                             {

--- a/CycloneDX/Runner.cs
+++ b/CycloneDX/Runner.cs
@@ -28,6 +28,7 @@ using CycloneDX.Models;
 using CycloneDX.Services;
 using static CycloneDX.Models.Component;
 using Json.Schema;
+using NuGet.Versioning;
 
 namespace CycloneDX
 {
@@ -360,6 +361,18 @@ namespace CycloneDX
                             if (packageNameMatch.Count == 1)
                             {
                                 lookupKey = packageNameMatch.First().Key;
+                            }
+                            else if (packageNameMatch.Count > 1
+                                && VersionRange.TryParse(dep.Value, out var versionRange)
+                                && packageNameMatch.Where(x => NuGetVersion.TryParse(x.Key.Item2, out var v)
+                                                               && versionRange.Satisfies(v))
+                                                   .ToList() is [var rangeMatch])
+                            {
+                                // dep.Value is a version range stored verbatim from the nuspec (e.g. "[1.0.0]").
+                                // ResolveDependencyVersionRanges couldn't resolve it within this project's
+                                // assets because the satisfying version only exists in another project's assets.
+                                // Use the range to pick the correct candidate from the merged BOM.
+                                lookupKey = rangeMatch.Key;
                             }
                             else
                             {


### PR DESCRIPTION
## Problem

When scanning a solution with multiple projects, the tool crashes with exit code 7:

```
Unable to locate valid bom ref for <Package> [1.0.0, 1.0.0]
```

### Root cause

The crash requires this specific topology:
- **ProjectA**: directly references `Pkg.Shared 2.0.0` + `Pkg.Consumer 1.0.0`
- **ProjectB**: directly references `Pkg.Shared 1.0.0`
- `Pkg.Consumer`'s nuspec declares its dep on `Pkg.Shared` with exact-range notation: `[1.0.0]`

NuGet stores the exact-range constraint verbatim from the nuspec into `project.assets.json`. `ResolveDependencyVersionRanges` in `ProjectAssetsFileService.cs` tries to resolve it by scanning the current project's runtime packages — but in ProjectA's assets, only `2.0.0` is present, and `2.0.0` does not satisfy `[1.0.0]`. The range string is left unresolved.

After merging both projects' packages into the BOM, both `Shared 1.0.0` (from ProjectB) and `2.0.0` (from ProjectA) are present. The name-only fallback in `Runner.cs` finds two candidates for the unresolved `[1.0.0]` range → crash.

## Fix

When the name-only fallback finds multiple candidates and `dep.Value` is a parseable `VersionRange`, use the range itself to select the single satisfying candidate before reaching the error path. This is a minimal, targeted change to `Runner.cs` with no changes to the existing resolution logic in `ProjectAssetsFileService.cs`.

`[1.0.0].Satisfies(1.0.0)` → true, `[1.0.0].Satisfies(2.0.0)` → false → exactly one match → correct bom-ref for `Shared 1.0.0`.

## Result

- Both `Shared 1.0.0` and `2.0.0` appear as distinct components in the BOM (correct — scanning a solution is a union of all projects)
- `Pkg.Consumer`'s dependency edge points to `Shared@1.0.0` (what its nuspec declares)
- Verified against the real-world reproducer from the issue (`CDXTest` solution with `Microsoft.CodeAnalysis.Workspaces.Common` at `5.0.0` and `5.3.0`)

## Testing

Adds an E2E regression test (`Issue903Tests`) with a two-project solution using fake packages served from a BaGetter Testcontainer. The test:
1. Verifies the tool succeeds (no crash)
2. Asserts both versions of the shared package are present as distinct components
3. Asserts the consumer's dependency edge points to the correct (`1.0.0`) version, not `2.0.0`

Closes #903