### PR TITLE
feat: NuGet license file support + license expression fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **NuGet license file support** (#1011) — packages declaring `<license type="file">` now have their license file embedded as base64-encoded text in the BOM when `--include-license-text` is specified; without the flag the license is still detected but not embedded
+
+### Fixed
+
+- **Suppress `aka.ms/deprecateLicenseUrl` stub URL** (#1011) — NuGet auto-injects `https://aka.ms/deprecateLicenseUrl` into `<licenseUrl>` for packages packed with `<license type="file">`; this URL is now correctly ignored rather than being emitted as a license entry in the BOM (see [NuGet spec](https://github.com/NuGet/Home/wiki/Packaging-License-within-the-nupkg))
+- **Fix null-URL license stub** (#1011) — packages with no `<licenseUrl>` no longer produce a spurious `License { Name="Unknown - See URL", Url=null }` node in the BOM
+
 ## [6.1.1] - 2026-04-08
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Suppress `aka.ms/deprecateLicenseUrl` stub URL** (#1011) — NuGet auto-injects `https://aka.ms/deprecateLicenseUrl` into `<licenseUrl>` for packages packed with `<license type="file">`; this URL is now correctly ignored rather than being emitted as a license entry in the BOM (see [NuGet spec](https://github.com/NuGet/Home/wiki/Packaging-License-within-the-nupkg))
 - **Fix null-URL license stub** (#1011) — packages with no `<licenseUrl>` no longer produce a spurious `License { Name="Unknown - See URL", Url=null }` node in the BOM
+- **Fix `UNLICENSED` emitted as SPDX id** (#1004, fixes #915) — `UNLICENSED` is a NuGet-specific token that is not a valid SPDX identifier; it is now emitted as `license.name` instead of `license.id` to keep BOM output valid
 
 ## [6.1.1] - 2026-04-08
 

--- a/CycloneDX.E2ETests/Infrastructure/CycloneDxRunner.cs
+++ b/CycloneDX.E2ETests/Infrastructure/CycloneDxRunner.cs
@@ -128,6 +128,11 @@ namespace CycloneDX.E2ETests.Infrastructure
                 sb.Append(" --disable-hash-computation");
             }
 
+            if (options.IncludeLicenseText)
+            {
+                sb.Append(" --include-license-text");
+            }
+
             if (options.NuGetFeedUrl != null)
             {
                 sb.Append($" --url \"{options.NuGetFeedUrl}\"");
@@ -183,6 +188,7 @@ namespace CycloneDX.E2ETests.Infrastructure
         public bool Recursive { get; set; }
         public bool NoSerialNumber { get; set; }
         public bool DisableHashComputation { get; set; }
+        public bool IncludeLicenseText { get; set; }
         public string NuGetFeedUrl { get; set; }
         public string SetName { get; set; }
         public string SetVersion { get; set; }

--- a/CycloneDX.E2ETests/Infrastructure/NuGetServerFixture.cs
+++ b/CycloneDX.E2ETests/Infrastructure/NuGetServerFixture.cs
@@ -129,6 +129,43 @@ namespace CycloneDX.E2ETests.Infrastructure
                 "TestPkg.Consumer", "1.0.0",
                 dependencies: new[] { new NupkgDependency("TestPkg.Shared", "[1.0.0, 1.0.0]") }
             )).ConfigureAwait(false);
+
+            // TestPkg.SpdxLicense 1.0.0 — declares license via SPDX expression
+            await PushPackageAsync(NupkgBuilder.Build(
+                "TestPkg.SpdxLicense", "1.0.0",
+                license: NupkgLicense.Spdx("MIT")
+            )).ConfigureAwait(false);
+
+            // TestPkg.FileLicense 1.0.0 — declares license via embedded file (LICENSE.txt)
+            await PushPackageAsync(NupkgBuilder.Build(
+                "TestPkg.FileLicense", "1.0.0",
+                license: NupkgLicense.File("LICENSE.txt", System.Text.Encoding.UTF8.GetBytes(
+                    "MIT License\n\nCopyright (c) CycloneDX E2E Tests\n\nPermission is hereby granted, free of charge, to any person obtaining a copy of this software."))
+            )).ConfigureAwait(false);
+
+            // TestPkg.FileLicenseMd 1.0.0 — license file with .md extension
+            await PushPackageAsync(NupkgBuilder.Build(
+                "TestPkg.FileLicenseMd", "1.0.0",
+                license: NupkgLicense.File("LICENSE.md", System.Text.Encoding.UTF8.GetBytes(
+                    "# MIT License\n\nCopyright (c) CycloneDX E2E Tests"))
+            )).ConfigureAwait(false);
+
+            // TestPkg.UrlLicense 1.0.0 — declares license via deprecated <licenseUrl>
+            await PushPackageAsync(NupkgBuilder.Build(
+                "TestPkg.UrlLicense", "1.0.0",
+                license: NupkgLicense.LicenseUrl("https://opensource.org/licenses/MIT")
+            )).ConfigureAwait(false);
+
+            // TestPkg.NoLicense 1.0.0 — no license metadata at all
+            await PushPackageAsync(NupkgBuilder.Build("TestPkg.NoLicense", "1.0.0")).ConfigureAwait(false);
+
+            // TestPkg.FileLicenseDeprecatedUrl 1.0.0 — <license type="file"> with the aka.ms stub
+            // URL that NuGet auto-inserts when packing. Phase 4 must NOT fall back to this URL.
+            await PushPackageAsync(NupkgBuilder.Build(
+                "TestPkg.FileLicenseDeprecatedUrl", "1.0.0",
+                license: NupkgLicense.FileWithDeprecatedUrl("LICENSE.txt", System.Text.Encoding.UTF8.GetBytes(
+                    "MIT License\n\nCopyright (c) CycloneDX E2E Tests\n\nPermission is hereby granted, free of charge, to any person obtaining a copy of this software."))
+            )).ConfigureAwait(false);
         }
 
         public async ValueTask DisposeAsync()

--- a/CycloneDX.E2ETests/Infrastructure/NupkgBuilder.cs
+++ b/CycloneDX.E2ETests/Infrastructure/NupkgBuilder.cs
@@ -30,11 +30,12 @@ namespace CycloneDX.E2ETests.Infrastructure
             string id,
             string version,
             string description = null,
-            NupkgDependency[] dependencies = null)
+            NupkgDependency[] dependencies = null,
+            NupkgLicense license = null)
         {
             description ??= $"Test package {id}";
 
-            var nuspec = BuildNuspec(id, version, description, dependencies);
+            var nuspec = BuildNuspec(id, version, description, dependencies, license);
 
             using var ms = new MemoryStream();
             using (var archive = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true))
@@ -53,6 +54,15 @@ namespace CycloneDX.E2ETests.Infrastructure
                     dllStream.Write(placeholder, 0, placeholder.Length);
                 }
 
+                // If a file license is specified, embed the license file in the .nupkg
+                if ((license?.Type == NupkgLicenseType.File || license?.Type == NupkgLicenseType.FileWithDeprecatedUrl)
+                    && license.FileContent != null)
+                {
+                    var licenseEntry = archive.CreateEntry(license.FilePath, CompressionLevel.Optimal);
+                    using var licenseStream = licenseEntry.Open();
+                    licenseStream.Write(license.FileContent, 0, license.FileContent.Length);
+                }
+
                 // [Content_Types].xml
                 var contentTypesEntry = archive.CreateEntry("[Content_Types].xml", CompressionLevel.Optimal);
                 using (var writer = new StreamWriter(contentTypesEntry.Open(), Encoding.UTF8))
@@ -66,7 +76,8 @@ namespace CycloneDX.E2ETests.Infrastructure
             string id,
             string version,
             string description,
-            NupkgDependency[] dependencies)
+            NupkgDependency[] dependencies,
+            NupkgLicense license)
         {
             var sb = new StringBuilder();
             sb.AppendLine("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
@@ -76,6 +87,28 @@ namespace CycloneDX.E2ETests.Infrastructure
             sb.AppendLine($"    <version>{version}</version>");
             sb.AppendLine("    <authors>CycloneDX E2E Tests</authors>");
             sb.AppendLine($"    <description>{description}</description>");
+
+            if (license != null)
+            {
+                switch (license.Type)
+                {
+                    case NupkgLicenseType.Expression:
+                        sb.AppendLine($"    <license type=\"expression\">{license.Expression}</license>");
+                        break;
+                    case NupkgLicenseType.File:
+                        sb.AppendLine($"    <license type=\"file\">{license.FilePath}</license>");
+                        break;
+                    case NupkgLicenseType.FileWithDeprecatedUrl:
+                        // Mirrors what `dotnet pack` does: emits both <license type="file"> and
+                        // the NuGet deprecation stub URL so consumers can test the filtering logic.
+                        sb.AppendLine($"    <license type=\"file\">{license.FilePath}</license>");
+                        sb.AppendLine($"    <licenseUrl>https://aka.ms/deprecateLicenseUrl</licenseUrl>");
+                        break;
+                    case NupkgLicenseType.Url:
+                        sb.AppendLine($"    <licenseUrl>{license.Url}</licenseUrl>");
+                        break;
+                }
+            }
 
             if (dependencies != null && dependencies.Length > 0)
             {
@@ -115,5 +148,32 @@ namespace CycloneDX.E2ETests.Infrastructure
             Id = id;
             Version = version;
         }
+    }
+
+    internal enum NupkgLicenseType { Expression, File, FileWithDeprecatedUrl, Url }
+
+    internal sealed class NupkgLicense
+    {
+        public NupkgLicenseType Type { get; private set; }
+        public string Expression { get; private set; }
+        public string FilePath { get; private set; }
+        public byte[] FileContent { get; private set; }
+        public string Url { get; private set; }
+
+        public static NupkgLicense Spdx(string expression) =>
+            new NupkgLicense { Type = NupkgLicenseType.Expression, Expression = expression };
+
+        public static NupkgLicense File(string path, byte[] content) =>
+            new NupkgLicense { Type = NupkgLicenseType.File, FilePath = path, FileContent = content };
+
+        /// <summary>
+        /// Mirrors real NuGet pack output: <c>&lt;license type="file"&gt;</c> plus the auto-inserted
+        /// <c>&lt;licenseUrl&gt;https://aka.ms/deprecateLicenseUrl&lt;/licenseUrl&gt;</c> stub.
+        /// </summary>
+        public static NupkgLicense FileWithDeprecatedUrl(string path, byte[] content) =>
+            new NupkgLicense { Type = NupkgLicenseType.FileWithDeprecatedUrl, FilePath = path, FileContent = content };
+
+        public static NupkgLicense LicenseUrl(string url) =>
+            new NupkgLicense { Type = NupkgLicenseType.Url, Url = url };
     }
 }

--- a/CycloneDX.E2ETests/Snapshots/DevDependencyTests.DevDependency_ExcludedWithFlag.verified.txt
+++ b/CycloneDX.E2ETests/Snapshots/DevDependencyTests.DevDependency_ExcludedWithFlag.verified.txt
@@ -39,11 +39,6 @@
       <hashes>
         <hash alg="SHA-512">{scrubbed-hash}</hash>
       </hashes>
-      <licenses>
-        <license>
-          <name>Unknown - See URL</name>
-        </license>
-      </licenses>
       <purl>pkg:nuget/TestPkg.A@1.0.0</purl>
     </component>
   </components>

--- a/CycloneDX.E2ETests/Snapshots/LicenseSnapshotTests.FileLicense_WithFlag_ProducesValidBom.verified.txt
+++ b/CycloneDX.E2ETests/Snapshots/LicenseSnapshotTests.FileLicense_WithFlag_ProducesValidBom.verified.txt
@@ -1,0 +1,57 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<bom xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" version="1" xmlns="http://cyclonedx.org/schema/bom/1.7">
+  <metadata>
+    <timestamp>{scrubbed-timestamp}</timestamp>
+    <tools>
+      <components>
+        <component type="application">
+          <authors>
+            <author>
+              <name>CycloneDX</name>
+            </author>
+          </authors>
+          <name>CycloneDX module for .NET</name>
+          <version>{scrubbed-version}</version>
+          <externalReferences>
+            <reference type="website">
+              <url>https://github.com/CycloneDX/cyclonedx-dotnet</url>
+            </reference>
+          </externalReferences>
+        </component>
+      </components>
+    </tools>
+    <component type="application" bom-ref="LicenseSnapshotFileFlagOnSln@0.0.0">
+      <name>LicenseSnapshotFileFlagOnSln</name>
+      <version>{scrubbed-version}</version>
+    </component>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="pkg:nuget/TestPkg.FileLicense@1.0.0">
+      <authors>
+        <author>
+          <name>CycloneDX E2E Tests</name>
+        </author>
+      </authors>
+      <name>TestPkg.FileLicense</name>
+      <version>{scrubbed-version}</version>
+      <description>Test package TestPkg.FileLicense</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-512">{scrubbed-hash}</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <name>TestPkg.FileLicense License</name>
+          <text content-type="text/plain" encoding="base64">TUlUIExpY2Vuc2UKCkNvcHlyaWdodCAoYykgQ3ljbG9uZURYIEUyRSBUZXN0cwoKUGVybWlzc2lvbiBpcyBoZXJlYnkgZ3JhbnRlZCwgZnJlZSBvZiBjaGFyZ2UsIHRvIGFueSBwZXJzb24gb2J0YWluaW5nIGEgY29weSBvZiB0aGlzIHNvZnR3YXJlLg==</text>
+        </license>
+      </licenses>
+      <purl>pkg:nuget/TestPkg.FileLicense@1.0.0</purl>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="LicenseSnapshotFileFlagOnSln@0.0.0">
+      <dependency ref="pkg:nuget/TestPkg.FileLicense@1.0.0" />
+    </dependency>
+    <dependency ref="pkg:nuget/TestPkg.FileLicense@1.0.0" />
+  </dependencies>
+</bom>

--- a/CycloneDX.E2ETests/Snapshots/LicenseSnapshotTests.SpdxLicense_ProducesValidBom.verified.txt
+++ b/CycloneDX.E2ETests/Snapshots/LicenseSnapshotTests.SpdxLicense_ProducesValidBom.verified.txt
@@ -1,0 +1,56 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<bom xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" version="1" xmlns="http://cyclonedx.org/schema/bom/1.7">
+  <metadata>
+    <timestamp>{scrubbed-timestamp}</timestamp>
+    <tools>
+      <components>
+        <component type="application">
+          <authors>
+            <author>
+              <name>CycloneDX</name>
+            </author>
+          </authors>
+          <name>CycloneDX module for .NET</name>
+          <version>{scrubbed-version}</version>
+          <externalReferences>
+            <reference type="website">
+              <url>https://github.com/CycloneDX/cyclonedx-dotnet</url>
+            </reference>
+          </externalReferences>
+        </component>
+      </components>
+    </tools>
+    <component type="application" bom-ref="LicenseSnapshotSpdxSln@0.0.0">
+      <name>LicenseSnapshotSpdxSln</name>
+      <version>{scrubbed-version}</version>
+    </component>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="pkg:nuget/TestPkg.SpdxLicense@1.0.0">
+      <authors>
+        <author>
+          <name>CycloneDX E2E Tests</name>
+        </author>
+      </authors>
+      <name>TestPkg.SpdxLicense</name>
+      <version>{scrubbed-version}</version>
+      <description>Test package TestPkg.SpdxLicense</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-512">{scrubbed-hash}</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:nuget/TestPkg.SpdxLicense@1.0.0</purl>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="LicenseSnapshotSpdxSln@0.0.0">
+      <dependency ref="pkg:nuget/TestPkg.SpdxLicense@1.0.0" />
+    </dependency>
+    <dependency ref="pkg:nuget/TestPkg.SpdxLicense@1.0.0" />
+  </dependencies>
+</bom>

--- a/CycloneDX.E2ETests/Snapshots/LicenseSnapshotTests.UrlLicense_ProducesValidBom.verified.txt
+++ b/CycloneDX.E2ETests/Snapshots/LicenseSnapshotTests.UrlLicense_ProducesValidBom.verified.txt
@@ -1,0 +1,57 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<bom xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" version="1" xmlns="http://cyclonedx.org/schema/bom/1.7">
+  <metadata>
+    <timestamp>{scrubbed-timestamp}</timestamp>
+    <tools>
+      <components>
+        <component type="application">
+          <authors>
+            <author>
+              <name>CycloneDX</name>
+            </author>
+          </authors>
+          <name>CycloneDX module for .NET</name>
+          <version>{scrubbed-version}</version>
+          <externalReferences>
+            <reference type="website">
+              <url>https://github.com/CycloneDX/cyclonedx-dotnet</url>
+            </reference>
+          </externalReferences>
+        </component>
+      </components>
+    </tools>
+    <component type="application" bom-ref="LicenseSnapshotUrlSln@0.0.0">
+      <name>LicenseSnapshotUrlSln</name>
+      <version>{scrubbed-version}</version>
+    </component>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="pkg:nuget/TestPkg.UrlLicense@1.0.0">
+      <authors>
+        <author>
+          <name>CycloneDX E2E Tests</name>
+        </author>
+      </authors>
+      <name>TestPkg.UrlLicense</name>
+      <version>{scrubbed-version}</version>
+      <description>Test package TestPkg.UrlLicense</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-512">{scrubbed-hash}</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <name>Unknown - See URL</name>
+          <url>https://opensource.org/licenses/MIT</url>
+        </license>
+      </licenses>
+      <purl>pkg:nuget/TestPkg.UrlLicense@1.0.0</purl>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="LicenseSnapshotUrlSln@0.0.0">
+      <dependency ref="pkg:nuget/TestPkg.UrlLicense@1.0.0" />
+    </dependency>
+    <dependency ref="pkg:nuget/TestPkg.UrlLicense@1.0.0" />
+  </dependencies>
+</bom>

--- a/CycloneDX.E2ETests/Snapshots/MetadataToolTests.ToolMetadata_IsRecordedAsComponent_NotDeprecatedTool.verified.txt
+++ b/CycloneDX.E2ETests/Snapshots/MetadataToolTests.ToolMetadata_IsRecordedAsComponent_NotDeprecatedTool.verified.txt
@@ -39,11 +39,6 @@
       <hashes>
         <hash alg="SHA-512">{scrubbed-hash}</hash>
       </hashes>
-      <licenses>
-        <license>
-          <name>Unknown - See URL</name>
-        </license>
-      </licenses>
       <purl>pkg:nuget/TestPkg.A@1.0.0</purl>
     </component>
   </components>

--- a/CycloneDX.E2ETests/Snapshots/ProjectReferencesTests.ProjectReference_IncludedWithFlag.verified.txt
+++ b/CycloneDX.E2ETests/Snapshots/ProjectReferencesTests.ProjectReference_IncludedWithFlag.verified.txt
@@ -44,11 +44,6 @@
       <hashes>
         <hash alg="SHA-512">{scrubbed-hash}</hash>
       </hashes>
-      <licenses>
-        <license>
-          <name>Unknown - See URL</name>
-        </license>
-      </licenses>
       <purl>pkg:nuget/TestPkg.A@1.0.0</purl>
     </component>
     <component type="library" bom-ref="pkg:nuget/TestPkg.C@1.0.0">
@@ -64,11 +59,6 @@
       <hashes>
         <hash alg="SHA-512">{scrubbed-hash}</hash>
       </hashes>
-      <licenses>
-        <license>
-          <name>Unknown - See URL</name>
-        </license>
-      </licenses>
       <purl>pkg:nuget/TestPkg.C@1.0.0</purl>
     </component>
   </components>

--- a/CycloneDX.E2ETests/Snapshots/SimpleProjectTests.SinglePackage_ProducesValidBom.verified.txt
+++ b/CycloneDX.E2ETests/Snapshots/SimpleProjectTests.SinglePackage_ProducesValidBom.verified.txt
@@ -39,11 +39,6 @@
       <hashes>
         <hash alg="SHA-512">{scrubbed-hash}</hash>
       </hashes>
-      <licenses>
-        <license>
-          <name>Unknown - See URL</name>
-        </license>
-      </licenses>
       <purl>pkg:nuget/TestPkg.A@1.0.0</purl>
     </component>
   </components>

--- a/CycloneDX.E2ETests/Snapshots/SimpleProjectTests.TransitiveDependency_AppearsInBom.verified.txt
+++ b/CycloneDX.E2ETests/Snapshots/SimpleProjectTests.TransitiveDependency_AppearsInBom.verified.txt
@@ -39,11 +39,6 @@
       <hashes>
         <hash alg="SHA-512">{scrubbed-hash}</hash>
       </hashes>
-      <licenses>
-        <license>
-          <name>Unknown - See URL</name>
-        </license>
-      </licenses>
       <purl>pkg:nuget/TestPkg.A@1.0.0</purl>
     </component>
     <component type="library" bom-ref="pkg:nuget/TestPkg.B@1.0.0">
@@ -59,11 +54,6 @@
       <hashes>
         <hash alg="SHA-512">{scrubbed-hash}</hash>
       </hashes>
-      <licenses>
-        <license>
-          <name>Unknown - See URL</name>
-        </license>
-      </licenses>
       <purl>pkg:nuget/TestPkg.B@1.0.0</purl>
     </component>
   </components>

--- a/CycloneDX.E2ETests/Snapshots/SimpleProjectTests.TwoDirectPackages_BothAppearInBom.verified.txt
+++ b/CycloneDX.E2ETests/Snapshots/SimpleProjectTests.TwoDirectPackages_BothAppearInBom.verified.txt
@@ -39,11 +39,6 @@
       <hashes>
         <hash alg="SHA-512">{scrubbed-hash}</hash>
       </hashes>
-      <licenses>
-        <license>
-          <name>Unknown - See URL</name>
-        </license>
-      </licenses>
       <purl>pkg:nuget/TestPkg.A@1.0.0</purl>
     </component>
     <component type="library" bom-ref="pkg:nuget/TestPkg.C@1.0.0">
@@ -59,11 +54,6 @@
       <hashes>
         <hash alg="SHA-512">{scrubbed-hash}</hash>
       </hashes>
-      <licenses>
-        <license>
-          <name>Unknown - See URL</name>
-        </license>
-      </licenses>
       <purl>pkg:nuget/TestPkg.C@1.0.0</purl>
     </component>
   </components>

--- a/CycloneDX.E2ETests/Snapshots/SolutionScanTests.TwoProjects_BothPackagesInBom.verified.txt
+++ b/CycloneDX.E2ETests/Snapshots/SolutionScanTests.TwoProjects_BothPackagesInBom.verified.txt
@@ -39,11 +39,6 @@
       <hashes>
         <hash alg="SHA-512">{scrubbed-hash}</hash>
       </hashes>
-      <licenses>
-        <license>
-          <name>Unknown - See URL</name>
-        </license>
-      </licenses>
       <purl>pkg:nuget/TestPkg.A@1.0.0</purl>
     </component>
     <component type="library" bom-ref="pkg:nuget/TestPkg.C@1.0.0">
@@ -59,11 +54,6 @@
       <hashes>
         <hash alg="SHA-512">{scrubbed-hash}</hash>
       </hashes>
-      <licenses>
-        <license>
-          <name>Unknown - See URL</name>
-        </license>
-      </licenses>
       <purl>pkg:nuget/TestPkg.C@1.0.0</purl>
     </component>
   </components>

--- a/CycloneDX.E2ETests/Tests/LicenseResolutionTests.cs
+++ b/CycloneDX.E2ETests/Tests/LicenseResolutionTests.cs
@@ -1,0 +1,371 @@
+// This file is part of CycloneDX Tool for .NET
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OWASP Foundation. All Rights Reserved.
+
+using System;
+using System.Text;
+using System.Threading.Tasks;
+using CycloneDX.E2ETests.Builders;
+using CycloneDX.E2ETests.Infrastructure;
+using Xunit;
+
+namespace CycloneDX.E2ETests.Tests
+{
+    /// <summary>
+    /// End-to-end tests for license resolution behavior.
+    /// Covers all four phases: SPDX expression, GitHub lookup (mocked via vocabulary packages
+    /// that have no GitHub URLs), license file embedding, and licenseUrl fallback.
+    ///
+    /// These tests will fail until --include-license-text is implemented.
+    /// </summary>
+    [Collection("E2E")]
+    public sealed class LicenseResolutionTests
+    {
+        private readonly E2EFixture _fixture;
+
+        public LicenseResolutionTests(E2EFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        // -----------------------------------------------------------------------------------------
+        // Phase 1 — SPDX expression
+        // -----------------------------------------------------------------------------------------
+
+        [Fact]
+        public async Task SpdxExpression_EmitsLicenseId()
+        {
+            using var solution = await new SolutionBuilder("SpdxLicenseSln")
+                .AddProject("MyApp", p => p
+                    .WithTargetFramework("net8.0")
+                    .AddPackage("TestPkg.SpdxLicense", "1.0.0"))
+                .BuildAsync(_fixture.NuGetFeedUrl);
+
+            using var outputDir = solution.CreateOutputDir();
+
+            var result = await _fixture.Runner.RunAsync(
+                solution.SolutionFile,
+                outputDir.Path,
+                new ToolRunOptions
+                {
+                    NuGetFeedUrl = _fixture.NuGetFeedUrl,
+                    NoSerialNumber = true,
+                    DisableHashComputation = true,
+                });
+
+            Assert.True(result.Success, $"Tool failed:\n{result.StdErr}");
+            Assert.Contains("<id>MIT</id>", result.BomContent);
+            Assert.DoesNotContain("<text>", result.BomContent);
+        }
+
+        // -----------------------------------------------------------------------------------------
+        // Phase 3 — license file with --include-license-text
+        // -----------------------------------------------------------------------------------------
+
+        [Fact]
+        public async Task LicenseFile_WithFlag_EmbedsBase64Text()
+        {
+            // The expected base64 content of the LICENSE.txt embedded in TestPkg.FileLicense
+            var expectedContent = Convert.ToBase64String(Encoding.UTF8.GetBytes(
+                "MIT License\n\nCopyright (c) CycloneDX E2E Tests\n\nPermission is hereby granted, free of charge, to any person obtaining a copy of this software."));
+
+            using var solution = await new SolutionBuilder("FileLicenseFlagOnSln")
+                .AddProject("MyApp", p => p
+                    .WithTargetFramework("net8.0")
+                    .AddPackage("TestPkg.FileLicense", "1.0.0"))
+                .BuildAsync(_fixture.NuGetFeedUrl);
+
+            using var outputDir = solution.CreateOutputDir();
+
+            var result = await _fixture.Runner.RunAsync(
+                solution.SolutionFile,
+                outputDir.Path,
+                new ToolRunOptions
+                {
+                    NuGetFeedUrl = _fixture.NuGetFeedUrl,
+                    NoSerialNumber = true,
+                    DisableHashComputation = true,
+                    IncludeLicenseText = true,
+                });
+
+            Assert.True(result.Success, $"Tool failed:\n{result.StdErr}");
+            Assert.Contains(expectedContent, result.BomContent);
+            Assert.Contains("text/plain", result.BomContent);
+            Assert.Contains("base64", result.BomContent);
+        }
+
+        [Fact]
+        public async Task LicenseFileMd_WithFlag_UsesMarkdownContentType()
+        {
+            using var solution = await new SolutionBuilder("FileLicenseMdSln")
+                .AddProject("MyApp", p => p
+                    .WithTargetFramework("net8.0")
+                    .AddPackage("TestPkg.FileLicenseMd", "1.0.0"))
+                .BuildAsync(_fixture.NuGetFeedUrl);
+
+            using var outputDir = solution.CreateOutputDir();
+
+            var result = await _fixture.Runner.RunAsync(
+                solution.SolutionFile,
+                outputDir.Path,
+                new ToolRunOptions
+                {
+                    NuGetFeedUrl = _fixture.NuGetFeedUrl,
+                    NoSerialNumber = true,
+                    DisableHashComputation = true,
+                    IncludeLicenseText = true,
+                });
+
+            Assert.True(result.Success, $"Tool failed:\n{result.StdErr}");
+            Assert.Contains("text/markdown", result.BomContent);
+        }
+
+        [Fact]
+        public async Task LicenseFile_WithoutFlag_EmitsNoLicense()
+        {
+            // Phase 3 inactive — license file should be ignored, no URL to fall back to,
+            // so no license node should appear for this package.
+            using var solution = await new SolutionBuilder("FileLicenseFlagOffSln")
+                .AddProject("MyApp", p => p
+                    .WithTargetFramework("net8.0")
+                    .AddPackage("TestPkg.FileLicense", "1.0.0"))
+                .BuildAsync(_fixture.NuGetFeedUrl);
+
+            using var outputDir = solution.CreateOutputDir();
+
+            var result = await _fixture.Runner.RunAsync(
+                solution.SolutionFile,
+                outputDir.Path,
+                new ToolRunOptions
+                {
+                    NuGetFeedUrl = _fixture.NuGetFeedUrl,
+                    NoSerialNumber = true,
+                    DisableHashComputation = true,
+                    IncludeLicenseText = false,
+                });
+
+            Assert.True(result.Success, $"Tool failed:\n{result.StdErr}");
+
+            // Extract the <component> block for TestPkg.FileLicense so the assertion is scoped
+            // to that package only and is not affected by other packages that may appear in the BOM.
+            var bom = result.BomContent;
+            var nameMarker = "<name>TestPkg.FileLicense</name>";
+            var nameIdx = bom.IndexOf(nameMarker, StringComparison.Ordinal);
+            Assert.True(nameIdx >= 0, "TestPkg.FileLicense component not found in BOM");
+
+            // Walk back to the opening <component tag
+            var componentStart = bom.LastIndexOf("<component", nameIdx, StringComparison.Ordinal);
+            // Walk forward to the closing </component>
+            var componentEnd = bom.IndexOf("</component>", nameIdx, StringComparison.Ordinal);
+            Assert.True(componentStart >= 0 && componentEnd >= 0, "Could not locate <component> boundaries");
+
+            var componentBlock = bom.Substring(componentStart, componentEnd - componentStart + "</component>".Length);
+            Assert.DoesNotContain("<licenses>", componentBlock);
+        }
+
+        [Fact]
+        public async Task FileLicenseWithAkaMsDeprecatedUrl_WithoutFlag_EmitsNoLicense()
+        {
+            // When NuGet packs a <license type="file"> package it auto-inserts
+            // <licenseUrl>https://aka.ms/deprecateLicenseUrl</licenseUrl>.
+            // That URL is a dead redirect, not a real license URL.
+            // Without --include-license-text, Phase 3 is inactive, and Phase 4 must NOT
+            // fall back to the aka.ms stub — no <licenses> node should appear.
+            //
+            // This test FAILS until the aka.ms guard is implemented.
+            using var solution = await new SolutionBuilder("FileLicenseDeprecatedUrlFlagOffSln")
+                .AddProject("MyApp", p => p
+                    .WithTargetFramework("net8.0")
+                    .AddPackage("TestPkg.FileLicenseDeprecatedUrl", "1.0.0"))
+                .BuildAsync(_fixture.NuGetFeedUrl);
+
+            using var outputDir = solution.CreateOutputDir();
+
+            var result = await _fixture.Runner.RunAsync(
+                solution.SolutionFile,
+                outputDir.Path,
+                new ToolRunOptions
+                {
+                    NuGetFeedUrl = _fixture.NuGetFeedUrl,
+                    NoSerialNumber = true,
+                    DisableHashComputation = true,
+                    IncludeLicenseText = false,
+                });
+
+            Assert.True(result.Success, $"Tool failed:\n{result.StdErr}");
+
+            var bom = result.BomContent;
+            var nameMarker = "<name>TestPkg.FileLicenseDeprecatedUrl</name>";
+            var nameIdx = bom.IndexOf(nameMarker, StringComparison.Ordinal);
+            Assert.True(nameIdx >= 0, "TestPkg.FileLicenseDeprecatedUrl component not found in BOM");
+
+            var componentStart = bom.LastIndexOf("<component", nameIdx, StringComparison.Ordinal);
+            var componentEnd = bom.IndexOf("</component>", nameIdx, StringComparison.Ordinal);
+            Assert.True(componentStart >= 0 && componentEnd >= 0, "Could not locate <component> boundaries");
+
+            var componentBlock = bom.Substring(componentStart, componentEnd - componentStart + "</component>".Length);
+            Assert.DoesNotContain("<licenses>", componentBlock);
+            Assert.DoesNotContain("aka.ms", componentBlock);
+        }
+
+        [Fact]
+        public async Task SpdxExpression_WithIncludeLicenseTextFlag_StillEmitsLicenseId()
+        {
+            // SPDX expression (Phase 1) must win even when --include-license-text is set.
+            // The TestPkg.SpdxLicense package has no embedded file, but even if it did,
+            // Phase 1 takes priority over Phase 3.
+            using var solution = await new SolutionBuilder("SpdxLicenseFlagOnSln")
+                .AddProject("MyApp", p => p
+                    .WithTargetFramework("net8.0")
+                    .AddPackage("TestPkg.SpdxLicense", "1.0.0"))
+                .BuildAsync(_fixture.NuGetFeedUrl);
+
+            using var outputDir = solution.CreateOutputDir();
+
+            var result = await _fixture.Runner.RunAsync(
+                solution.SolutionFile,
+                outputDir.Path,
+                new ToolRunOptions
+                {
+                    NuGetFeedUrl = _fixture.NuGetFeedUrl,
+                    NoSerialNumber = true,
+                    DisableHashComputation = true,
+                    IncludeLicenseText = true,
+                });
+
+            Assert.True(result.Success, $"Tool failed:\n{result.StdErr}");
+            Assert.Contains("<id>MIT</id>", result.BomContent);
+            // Phase 1 won — no embedded text should appear
+            Assert.DoesNotContain("<text>", result.BomContent);
+        }
+
+        // -----------------------------------------------------------------------------------------
+        // Phase 4 — licenseUrl fallback
+        // -----------------------------------------------------------------------------------------
+
+        [Fact]
+        public async Task LicenseUrl_EmitsUnknownSeeUrlEntry()
+        {
+            // Phase 4: deprecated <licenseUrl> present — should emit the URL entry even without
+            // --include-license-text.
+            using var solution = await new SolutionBuilder("UrlLicenseSln")
+                .AddProject("MyApp", p => p
+                    .WithTargetFramework("net8.0")
+                    .AddPackage("TestPkg.UrlLicense", "1.0.0"))
+                .BuildAsync(_fixture.NuGetFeedUrl);
+
+            using var outputDir = solution.CreateOutputDir();
+
+            var result = await _fixture.Runner.RunAsync(
+                solution.SolutionFile,
+                outputDir.Path,
+                new ToolRunOptions
+                {
+                    NuGetFeedUrl = _fixture.NuGetFeedUrl,
+                    NoSerialNumber = true,
+                    DisableHashComputation = true,
+                });
+
+            Assert.True(result.Success, $"Tool failed:\n{result.StdErr}");
+            Assert.Contains("Unknown - See URL", result.BomContent);
+            Assert.Contains("https://opensource.org/licenses/MIT", result.BomContent);
+        }
+
+        [Fact]
+        public async Task NoLicenseInfo_EmitsNoLicenseNode()
+        {
+            // Phase 4 fix: no license metadata at all — should produce no <licenses> node,
+            // not a null-URL stub entry.
+            using var solution = await new SolutionBuilder("NoLicenseSln")
+                .AddProject("MyApp", p => p
+                    .WithTargetFramework("net8.0")
+                    .AddPackage("TestPkg.NoLicense", "1.0.0"))
+                .BuildAsync(_fixture.NuGetFeedUrl);
+
+            using var outputDir = solution.CreateOutputDir();
+
+            var result = await _fixture.Runner.RunAsync(
+                solution.SolutionFile,
+                outputDir.Path,
+                new ToolRunOptions
+                {
+                    NuGetFeedUrl = _fixture.NuGetFeedUrl,
+                    NoSerialNumber = true,
+                    DisableHashComputation = true,
+                });
+
+            Assert.True(result.Success, $"Tool failed:\n{result.StdErr}");
+            Assert.DoesNotContain("<licenses>", result.BomContent);
+        }
+
+        // -----------------------------------------------------------------------------------------
+        // Mixed — all four phases in one solution
+        // -----------------------------------------------------------------------------------------
+
+        [Fact]
+        public async Task MixedLicenses_AllResolvedCorrectly()
+        {
+            // A single solution referencing all four vocabulary packages simultaneously.
+            // With --include-license-text:
+            //   TestPkg.SpdxLicense  → Phase 1 wins → <id>MIT</id>
+            //   TestPkg.FileLicense  → Phase 3 wins → base64 embedded text
+            //   TestPkg.UrlLicense   → Phase 4 wins → "Unknown - See URL" with URL
+            //   TestPkg.NoLicense    → no license node
+            //
+            // Exactly 3 <licenses> blocks expected in the BOM.
+            using var solution = await new SolutionBuilder("MixedLicensesSln")
+                .AddProject("MyApp", p => p
+                    .WithTargetFramework("net8.0")
+                    .AddPackage("TestPkg.SpdxLicense", "1.0.0")
+                    .AddPackage("TestPkg.FileLicense", "1.0.0")
+                    .AddPackage("TestPkg.UrlLicense", "1.0.0")
+                    .AddPackage("TestPkg.NoLicense", "1.0.0"))
+                .BuildAsync(_fixture.NuGetFeedUrl);
+
+            using var outputDir = solution.CreateOutputDir();
+
+            var result = await _fixture.Runner.RunAsync(
+                solution.SolutionFile,
+                outputDir.Path,
+                new ToolRunOptions
+                {
+                    NuGetFeedUrl = _fixture.NuGetFeedUrl,
+                    NoSerialNumber = true,
+                    DisableHashComputation = true,
+                    IncludeLicenseText = true,
+                });
+
+            Assert.True(result.Success, $"Tool failed:\n{result.StdErr}");
+
+            var bom = result.BomContent;
+
+            // Phase 1: SPDX expression resolved
+            Assert.Contains("<id>MIT</id>", bom);
+
+            // Phase 3: license file embedded as base64
+            Assert.Contains("base64", bom);
+            Assert.Contains("text/plain", bom);
+
+            // Phase 4: licenseUrl fallback
+            Assert.Contains("Unknown - See URL", bom);
+            Assert.Contains("https://opensource.org/licenses/MIT", bom);
+
+            // Exactly 3 packages should have a <licenses> block; NoLicense should not add one.
+            var licenseBlockCount = bom.Split(new[] { "<licenses>" }, StringSplitOptions.None).Length - 1;
+            Assert.Equal(3, licenseBlockCount);
+        }
+    }
+}

--- a/CycloneDX.E2ETests/Tests/LicenseSnapshotTests.cs
+++ b/CycloneDX.E2ETests/Tests/LicenseSnapshotTests.cs
@@ -1,0 +1,129 @@
+// This file is part of CycloneDX Tool for .NET
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OWASP Foundation. All Rights Reserved.
+
+using System.Threading.Tasks;
+using CycloneDX.E2ETests.Builders;
+using CycloneDX.E2ETests.Infrastructure;
+using Xunit;
+using static VerifyXunit.Verifier;
+
+namespace CycloneDX.E2ETests.Tests
+{
+    /// <summary>
+    /// Full-BOM snapshot tests for license resolution.
+    /// These complement the assertion-based tests in <see cref="LicenseResolutionTests"/>
+    /// by capturing the complete BOM XML, so any structural or schema change to license
+    /// output is caught as a snapshot diff.
+    /// </summary>
+    [Collection("E2E")]
+    public sealed class LicenseSnapshotTests
+    {
+        private readonly E2EFixture _fixture;
+
+        public LicenseSnapshotTests(E2EFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        /// <summary>
+        /// Phase 1: A package with a valid SPDX expression should emit &lt;id&gt;MIT&lt;/id&gt;.
+        /// </summary>
+        [Fact]
+        public async Task SpdxLicense_ProducesValidBom()
+        {
+            using var solution = await new SolutionBuilder("LicenseSnapshotSpdxSln")
+                .AddProject("MyApp", p => p
+                    .WithTargetFramework("net8.0")
+                    .AddPackage("TestPkg.SpdxLicense", "1.0.0"))
+                .BuildAsync(_fixture.NuGetFeedUrl);
+
+            using var outputDir = solution.CreateOutputDir();
+
+            var result = await _fixture.Runner.RunAsync(
+                solution.SolutionFile,
+                outputDir.Path,
+                new ToolRunOptions
+                {
+                    NuGetFeedUrl = _fixture.NuGetFeedUrl,
+                    NoSerialNumber = true,
+                    DisableHashComputation = true,
+                });
+
+            Assert.True(result.Success, $"Tool failed:\n{result.StdErr}");
+            await Verify(result.BomContent);
+        }
+
+        /// <summary>
+        /// Phase 3: A package with an embedded license file and <c>--include-license-text</c>
+        /// should emit the base64-encoded license text in the BOM.
+        /// </summary>
+        [Fact]
+        public async Task FileLicense_WithFlag_ProducesValidBom()
+        {
+            using var solution = await new SolutionBuilder("LicenseSnapshotFileFlagOnSln")
+                .AddProject("MyApp", p => p
+                    .WithTargetFramework("net8.0")
+                    .AddPackage("TestPkg.FileLicense", "1.0.0"))
+                .BuildAsync(_fixture.NuGetFeedUrl);
+
+            using var outputDir = solution.CreateOutputDir();
+
+            var result = await _fixture.Runner.RunAsync(
+                solution.SolutionFile,
+                outputDir.Path,
+                new ToolRunOptions
+                {
+                    NuGetFeedUrl = _fixture.NuGetFeedUrl,
+                    NoSerialNumber = true,
+                    DisableHashComputation = true,
+                    IncludeLicenseText = true,
+                });
+
+            Assert.True(result.Success, $"Tool failed:\n{result.StdErr}");
+            await Verify(result.BomContent);
+        }
+
+        /// <summary>
+        /// Phase 4: A package with only a deprecated &lt;licenseUrl&gt; should emit
+        /// "Unknown - See URL" with the URL, and no embedded text.
+        /// </summary>
+        [Fact]
+        public async Task UrlLicense_ProducesValidBom()
+        {
+            using var solution = await new SolutionBuilder("LicenseSnapshotUrlSln")
+                .AddProject("MyApp", p => p
+                    .WithTargetFramework("net8.0")
+                    .AddPackage("TestPkg.UrlLicense", "1.0.0"))
+                .BuildAsync(_fixture.NuGetFeedUrl);
+
+            using var outputDir = solution.CreateOutputDir();
+
+            var result = await _fixture.Runner.RunAsync(
+                solution.SolutionFile,
+                outputDir.Path,
+                new ToolRunOptions
+                {
+                    NuGetFeedUrl = _fixture.NuGetFeedUrl,
+                    NoSerialNumber = true,
+                    DisableHashComputation = true,
+                });
+
+            Assert.True(result.Success, $"Tool failed:\n{result.StdErr}");
+            await Verify(result.BomContent);
+        }
+    }
+}

--- a/CycloneDX.Tests/NugetV3ServiceTests.cs
+++ b/CycloneDX.Tests/NugetV3ServiceTests.cs
@@ -446,7 +446,7 @@ namespace CycloneDX.Tests
                 mockFileSystem,
                 new List<string> { XFS.Path(@"c:\nugetcache") },
                 mockGitHubService.Object,
-                new NullLogger(), false);
+                new NullLogger(), false, includeLicenseText: true);
 
             var component = await nugetService.GetComponentAsync("testpackage", "1.0.0", Component.ComponentScope.Required).ConfigureAwait(true);
 
@@ -666,7 +666,7 @@ namespace CycloneDX.Tests
                 mockFileSystem,
                 new List<string> { XFS.Path(@"c:\nugetcache") },
                 null,
-                new NullLogger(), false);
+                new NullLogger(), false, includeLicenseText: true);
 
             var component = await nugetService.GetComponentAsync("testpackage", "1.0.0", Component.ComponentScope.Required).ConfigureAwait(true);
 
@@ -675,6 +675,370 @@ namespace CycloneDX.Tests
             Assert.Equal(Convert.ToBase64String(licenseContents), component.Licenses.First().License.Text.Content);
             Assert.Equal("base64", component.Licenses.First().License.Text.Encoding);
             Assert.Equal("text/markdown", component.Licenses.First().License.Text.ContentType);
+        }
+
+        // -----------------------------------------------------------------------------------------
+        // Target behavior tests — these expect the new --include-license-text parameter
+        // (7th constructor argument). They will fail until the implementation is in place.
+        // -----------------------------------------------------------------------------------------
+
+        [Fact]
+        public async Task GetComponent_LicenseFile_WithoutFlag_NoGitHub_EmitsNoLicense()
+        {
+            // Phase 3 inactive (flag off): a <license type="file"> package with no <licenseUrl>
+            // should produce no license entry at all — not a null-URL stub.
+            var nuspecFileContents = @"<?xml version=""1.0"" encoding=""utf-8""?>
+                <package xmlns=""http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd"">
+                <metadata>
+                    <id>testpackage</id>
+                    <license type=""file"">LICENSE.txt</license>
+                </metadata>
+                </package>";
+
+            byte[] licenseContents = Encoding.UTF8.GetBytes("The license");
+
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\nugetcache\testpackage\1.0.0\testpackage.nuspec"), new MockFileData(nuspecFileContents) },
+                { XFS.Path(@"c:\nugetcache\testpackage\1.0.0\LICENSE.txt"), new MockFileData(licenseContents) },
+            });
+
+            var nugetService = new NugetV3Service(null,
+                mockFileSystem,
+                new List<string> { XFS.Path(@"c:\nugetcache") },
+                null,
+                new NullLogger(), false, includeLicenseText: false);
+
+            var component = await nugetService.GetComponentAsync("testpackage", "1.0.0", Component.ComponentScope.Required).ConfigureAwait(true);
+
+            Assert.Null(component.Licenses);
+        }
+
+        [Fact]
+        public async Task GetComponent_LicenseFile_WithFlag_NoGitHub_EmbedsText()
+        {
+            // Phase 3 active, no GitHub: <license type="file"> with --include-license-text
+            // should embed the file content as base64.
+            var nuspecFileContents = @"<?xml version=""1.0"" encoding=""utf-8""?>
+                <package xmlns=""http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd"">
+                <metadata>
+                    <id>testpackage</id>
+                    <license type=""file"">LICENSE.txt</license>
+                </metadata>
+                </package>";
+
+            byte[] licenseContents = Encoding.UTF8.GetBytes("The license");
+
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\nugetcache\testpackage\1.0.0\testpackage.nuspec"), new MockFileData(nuspecFileContents) },
+                { XFS.Path(@"c:\nugetcache\testpackage\1.0.0\LICENSE.txt"), new MockFileData(licenseContents) },
+            });
+
+            var nugetService = new NugetV3Service(null,
+                mockFileSystem,
+                new List<string> { XFS.Path(@"c:\nugetcache") },
+                null,
+                new NullLogger(), false, includeLicenseText: true);
+
+            var component = await nugetService.GetComponentAsync("testpackage", "1.0.0", Component.ComponentScope.Required).ConfigureAwait(true);
+
+            Assert.Single(component.Licenses);
+            Assert.Equal("testpackage License", component.Licenses.First().License.Name);
+            Assert.Equal(Convert.ToBase64String(licenseContents), component.Licenses.First().License.Text.Content);
+            Assert.Equal("base64", component.Licenses.First().License.Text.Encoding);
+            Assert.Equal("text/plain", component.Licenses.First().License.Text.ContentType);
+        }
+
+        [Fact]
+        public async Task GetComponent_LicenseFile_WithFlag_GitHubMisses_EmbedsText()
+        {
+            // Phase 3 active, GitHub enabled but finds nothing: should fall through to the
+            // license file and embed it.
+            var nuspecFileContents = @"<?xml version=""1.0"" encoding=""utf-8""?>
+                <package xmlns=""http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd"">
+                <metadata>
+                    <id>testpackage</id>
+                    <license type=""file"">LICENSE.md</license>
+                </metadata>
+                </package>";
+
+            byte[] licenseContents = Encoding.UTF8.GetBytes("The license");
+
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\nugetcache\testpackage\1.0.0\testpackage.nuspec"), new MockFileData(nuspecFileContents) },
+                { XFS.Path(@"c:\nugetcache\testpackage\1.0.0\LICENSE.md"), new MockFileData(licenseContents) },
+            });
+
+            var mockGitHubService = new Mock<IGithubService>();
+            // GitHub returns null for all URLs (non-GitHub or missing)
+            mockGitHubService.Setup(x => x.GetLicenseAsync(It.IsAny<string>())).Returns(Task.FromResult<License>(null));
+
+            var nugetService = new NugetV3Service(null,
+                mockFileSystem,
+                new List<string> { XFS.Path(@"c:\nugetcache") },
+                mockGitHubService.Object,
+                new NullLogger(), false, includeLicenseText: true);
+
+            var component = await nugetService.GetComponentAsync("testpackage", "1.0.0", Component.ComponentScope.Required).ConfigureAwait(true);
+
+            Assert.Single(component.Licenses);
+            Assert.Equal("testpackage License", component.Licenses.First().License.Name);
+            Assert.Equal(Convert.ToBase64String(licenseContents), component.Licenses.First().License.Text.Content);
+            Assert.Equal("base64", component.Licenses.First().License.Text.Encoding);
+            Assert.Equal("text/markdown", component.Licenses.First().License.Text.ContentType);
+        }
+
+        [Fact]
+        public async Task GetComponent_LicenseFile_WithFlag_FileNotInCache_FallsBackToLicenseUrl()
+        {
+            // Phase 3 active but file missing from cache: should fall through to phase 4
+            // and use <licenseUrl> if present.
+            var nuspecFileContents = @"<?xml version=""1.0"" encoding=""utf-8""?>
+                <package xmlns=""http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd"">
+                <metadata>
+                    <id>testpackage</id>
+                    <license type=""file"">LICENSE.txt</license>
+                    <licenseUrl>https://example.com/license</licenseUrl>
+                </metadata>
+                </package>";
+
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\nugetcache\testpackage\1.0.0\testpackage.nuspec"), new MockFileData(nuspecFileContents) },
+                // LICENSE.txt deliberately absent from cache
+            });
+
+            var nugetService = new NugetV3Service(null,
+                mockFileSystem,
+                new List<string> { XFS.Path(@"c:\nugetcache") },
+                null,
+                new NullLogger(), false, includeLicenseText: true);
+
+            var component = await nugetService.GetComponentAsync("testpackage", "1.0.0", Component.ComponentScope.Required).ConfigureAwait(true);
+
+            Assert.Single(component.Licenses);
+            Assert.Equal("Unknown - See URL", component.Licenses.First().License.Name);
+            Assert.Equal("https://example.com/license", component.Licenses.First().License.Url);
+            Assert.Null(component.Licenses.First().License.Text);
+        }
+
+        [Fact]
+        public async Task GetComponent_NoLicenseInfo_EmitsNoLicense()
+        {
+            // Phase 4 fix: a package with no license metadata at all should produce no
+            // license entry — not a null-URL stub.
+            var nuspecFileContents = @"<?xml version=""1.0"" encoding=""utf-8""?>
+                <package xmlns=""http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd"">
+                <metadata>
+                    <id>testpackage</id>
+                </metadata>
+                </package>";
+
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\nugetcache\testpackage\1.0.0\testpackage.nuspec"), new MockFileData(nuspecFileContents) },
+            });
+
+            var nugetService = new NugetV3Service(null,
+                mockFileSystem,
+                new List<string> { XFS.Path(@"c:\nugetcache") },
+                null,
+                new NullLogger(), false, includeLicenseText: false);
+
+            var component = await nugetService.GetComponentAsync("testpackage", "1.0.0", Component.ComponentScope.Required).ConfigureAwait(true);
+
+            Assert.Null(component.Licenses);
+        }
+
+        [Fact]
+        public async Task GetComponent_LicenseUrlOnly_EmitsUrlFallback()
+        {
+            // Phase 4: <licenseUrl> present, no file metadata → should still emit the URL entry.
+            var nuspecFileContents = @"<?xml version=""1.0"" encoding=""utf-8""?>
+                <package xmlns=""http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd"">
+                <metadata>
+                    <id>testpackage</id>
+                    <licenseUrl>https://example.com/license</licenseUrl>
+                </metadata>
+                </package>";
+
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\nugetcache\testpackage\1.0.0\testpackage.nuspec"), new MockFileData(nuspecFileContents) },
+            });
+
+            var nugetService = new NugetV3Service(null,
+                mockFileSystem,
+                new List<string> { XFS.Path(@"c:\nugetcache") },
+                null,
+                new NullLogger(), false, includeLicenseText: false);
+
+            var component = await nugetService.GetComponentAsync("testpackage", "1.0.0", Component.ComponentScope.Required).ConfigureAwait(true);
+
+            Assert.Single(component.Licenses);
+            Assert.Equal("Unknown - See URL", component.Licenses.First().License.Name);
+            Assert.Equal("https://example.com/license", component.Licenses.First().License.Url);
+        }
+
+        [Fact]
+        public async Task GetComponent_LicenseFile_WithFlag_TxtExtension_UsesTextPlainContentType()
+        {
+            var nuspecFileContents = @"<?xml version=""1.0"" encoding=""utf-8""?>
+                <package xmlns=""http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd"">
+                <metadata>
+                    <id>testpackage</id>
+                    <license type=""file"">LICENSE.txt</license>
+                </metadata>
+                </package>";
+
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\nugetcache\testpackage\1.0.0\testpackage.nuspec"), new MockFileData(nuspecFileContents) },
+                { XFS.Path(@"c:\nugetcache\testpackage\1.0.0\LICENSE.txt"), new MockFileData("The license") },
+            });
+
+            var nugetService = new NugetV3Service(null,
+                mockFileSystem,
+                new List<string> { XFS.Path(@"c:\nugetcache") },
+                null,
+                new NullLogger(), false, includeLicenseText: true);
+
+            var component = await nugetService.GetComponentAsync("testpackage", "1.0.0", Component.ComponentScope.Required).ConfigureAwait(true);
+
+            Assert.Equal("text/plain", component.Licenses.First().License.Text.ContentType);
+        }
+
+        [Fact]
+        public async Task GetComponent_LicenseFile_WithFlag_NoExtension_UsesTextPlainContentType()
+        {
+            var nuspecFileContents = @"<?xml version=""1.0"" encoding=""utf-8""?>
+                <package xmlns=""http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd"">
+                <metadata>
+                    <id>testpackage</id>
+                    <license type=""file"">LICENSE</license>
+                </metadata>
+                </package>";
+
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\nugetcache\testpackage\1.0.0\testpackage.nuspec"), new MockFileData(nuspecFileContents) },
+                { XFS.Path(@"c:\nugetcache\testpackage\1.0.0\LICENSE"), new MockFileData("The license") },
+            });
+
+            var nugetService = new NugetV3Service(null,
+                mockFileSystem,
+                new List<string> { XFS.Path(@"c:\nugetcache") },
+                null,
+                new NullLogger(), false, includeLicenseText: true);
+
+            var component = await nugetService.GetComponentAsync("testpackage", "1.0.0", Component.ComponentScope.Required).ConfigureAwait(true);
+
+            Assert.Equal("text/plain", component.Licenses.First().License.Text.ContentType);
+        }
+
+        [Fact]
+        public async Task GetComponent_LicenseFile_WithFlag_UnknownExtension_UsesOctetStreamContentType()
+        {
+            var nuspecFileContents = @"<?xml version=""1.0"" encoding=""utf-8""?>
+                <package xmlns=""http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd"">
+                <metadata>
+                    <id>testpackage</id>
+                    <license type=""file"">LICENSE.rtf</license>
+                </metadata>
+                </package>";
+
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\nugetcache\testpackage\1.0.0\testpackage.nuspec"), new MockFileData(nuspecFileContents) },
+                { XFS.Path(@"c:\nugetcache\testpackage\1.0.0\LICENSE.rtf"), new MockFileData("The license") },
+            });
+
+            var nugetService = new NugetV3Service(null,
+                mockFileSystem,
+                new List<string> { XFS.Path(@"c:\nugetcache") },
+                null,
+                new NullLogger(), false, includeLicenseText: true);
+
+            var component = await nugetService.GetComponentAsync("testpackage", "1.0.0", Component.ComponentScope.Required).ConfigureAwait(true);
+
+            Assert.Equal("application/octet-stream", component.Licenses.First().License.Text.ContentType);
+        }
+
+        // -----------------------------------------------------------------------------------------
+        // aka.ms/deprecateLicenseUrl — NuGet auto-inserts this URL for <license type="file"> packs.
+        // It is a dead redirect, not an actual license URL, so it must never appear in the BOM.
+        // -----------------------------------------------------------------------------------------
+
+        [Fact]
+        public async Task GetComponent_FileLicense_AkaMsDeprecatedUrl_WithoutFlag_EmitsNoLicense()
+        {
+            // When a package has <license type="file"> NuGet auto-inserts
+            // <licenseUrl>https://aka.ms/deprecateLicenseUrl</licenseUrl>.
+            // Without --include-license-text, Phase 3 is inactive and Phase 4 must NOT fall back
+            // to this known-useless redirect URL — the component should have no license entry.
+            //
+            // This test FAILS until the aka.ms guard is implemented.
+            var nuspecFileContents = @"<?xml version=""1.0"" encoding=""utf-8""?>
+                <package xmlns=""http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd"">
+                <metadata>
+                    <id>testpackage</id>
+                    <license type=""file"">LICENSE.txt</license>
+                    <licenseUrl>https://aka.ms/deprecateLicenseUrl</licenseUrl>
+                </metadata>
+                </package>";
+
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\nugetcache\testpackage\1.0.0\testpackage.nuspec"), new MockFileData(nuspecFileContents) },
+                { XFS.Path(@"c:\nugetcache\testpackage\1.0.0\LICENSE.txt"), new MockFileData("The license") },
+            });
+
+            var nugetService = new NugetV3Service(null,
+                mockFileSystem,
+                new List<string> { XFS.Path(@"c:\nugetcache") },
+                null,
+                new NullLogger(), false, includeLicenseText: false);
+
+            var component = await nugetService.GetComponentAsync("testpackage", "1.0.0", Component.ComponentScope.Required).ConfigureAwait(true);
+
+            Assert.Null(component.Licenses);
+        }
+
+        [Fact]
+        public async Task GetComponent_FileLicense_AkaMsDeprecatedUrl_WithFlag_EmbedsFile()
+        {
+            // When --include-license-text is on, Phase 3 should embed the file and Phase 4
+            // (aka.ms URL) must never be reached. This confirms Phase 3 takes priority.
+            var nuspecFileContents = @"<?xml version=""1.0"" encoding=""utf-8""?>
+                <package xmlns=""http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd"">
+                <metadata>
+                    <id>testpackage</id>
+                    <license type=""file"">LICENSE.txt</license>
+                    <licenseUrl>https://aka.ms/deprecateLicenseUrl</licenseUrl>
+                </metadata>
+                </package>";
+
+            byte[] licenseContents = Encoding.UTF8.GetBytes("The license");
+
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\nugetcache\testpackage\1.0.0\testpackage.nuspec"), new MockFileData(nuspecFileContents) },
+                { XFS.Path(@"c:\nugetcache\testpackage\1.0.0\LICENSE.txt"), new MockFileData(licenseContents) },
+            });
+
+            var nugetService = new NugetV3Service(null,
+                mockFileSystem,
+                new List<string> { XFS.Path(@"c:\nugetcache") },
+                null,
+                new NullLogger(), false, includeLicenseText: true);
+
+            var component = await nugetService.GetComponentAsync("testpackage", "1.0.0", Component.ComponentScope.Required).ConfigureAwait(true);
+
+            Assert.Single(component.Licenses);
+            Assert.Equal(Convert.ToBase64String(licenseContents), component.Licenses.First().License.Text.Content);
+            Assert.DoesNotContain("aka.ms", component.Licenses.First().License.Url ?? "");
         }
     }
 }

--- a/CycloneDX.Tests/NugetV3ServiceTests.cs
+++ b/CycloneDX.Tests/NugetV3ServiceTests.cs
@@ -519,6 +519,38 @@ namespace CycloneDX.Tests
         }
 
         [Fact]
+        public async Task GetComponent_UnlicensedLicenseExpression_MapsToLicenseName()
+        {
+            var nuspecFileContents = @"<?xml version=""1.0"" encoding=""utf-8""?>
+                <package xmlns=""http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd"">
+                <metadata>
+                    <id>testpackage</id>
+                    <license type=""expression"">UNLICENSED</license>
+                </metadata>
+                </package>";
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\nugetcache\testpackage\1.0.0\testpackage.nuspec"), new MockFileData(nuspecFileContents) },
+            });
+
+            var mockGitHubService = new Mock<IGithubService>();
+
+            var nugetService = new NugetV3Service(null,
+                mockFileSystem,
+                new List<string> { XFS.Path(@"c:\nugetcache") },
+                mockGitHubService.Object,
+                new NullLogger(), false);
+
+            var component = await nugetService.GetComponentAsync("testpackage", "1.0.0", Component.ComponentScope.Required).ConfigureAwait(true);
+
+            Assert.Single(component.Licenses);
+            Assert.Equal("UNLICENSED", component.Licenses.First().License.Name);
+            Assert.True(string.IsNullOrEmpty(component.Licenses.First().License.Id));
+        }
+
+
+
+        [Fact]
         public async Task GetComponent_MultiLicenseExpression_ReturnsComponent()
         {
             var nuspecFileContents = @"<?xml version=""1.0"" encoding=""utf-8""?>

--- a/CycloneDX.Tests/NugetV3ServiceTests.cs
+++ b/CycloneDX.Tests/NugetV3ServiceTests.cs
@@ -978,8 +978,6 @@ namespace CycloneDX.Tests
             // <licenseUrl>https://aka.ms/deprecateLicenseUrl</licenseUrl>.
             // Without --include-license-text, Phase 3 is inactive and Phase 4 must NOT fall back
             // to this known-useless redirect URL — the component should have no license entry.
-            //
-            // This test FAILS until the aka.ms guard is implemented.
             var nuspecFileContents = @"<?xml version=""1.0"" encoding=""utf-8""?>
                 <package xmlns=""http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd"">
                 <metadata>
@@ -1039,6 +1037,41 @@ namespace CycloneDX.Tests
             Assert.Single(component.Licenses);
             Assert.Equal(Convert.ToBase64String(licenseContents), component.Licenses.First().License.Text.Content);
             Assert.DoesNotContain("aka.ms", component.Licenses.First().License.Url ?? "");
+        }
+
+        [Fact]
+        public async Task GetComponent_FileLicense_AkaMsDeprecatedUrl_WithGitHub_SkipsApiCallAndEmitsNoLicense()
+        {
+            // When --enable-github-licenses is on and the only licenseUrl is the aka.ms stub,
+            // the tool must NOT pass that URL to the GitHub API (it is not a GitHub URL and
+            // the call would be wasted). No license node should appear in the BOM.
+            var nuspecFileContents = @"<?xml version=""1.0"" encoding=""utf-8""?>
+                <package xmlns=""http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd"">
+                <metadata>
+                    <id>testpackage</id>
+                    <license type=""file"">LICENSE.txt</license>
+                    <licenseUrl>https://aka.ms/deprecateLicenseUrl</licenseUrl>
+                </metadata>
+                </package>";
+
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\nugetcache\testpackage\1.0.0\testpackage.nuspec"), new MockFileData(nuspecFileContents) },
+                { XFS.Path(@"c:\nugetcache\testpackage\1.0.0\LICENSE.txt"), new MockFileData("The license") },
+            });
+
+            var mockGitHubService = new Mock<IGithubService>();
+
+            var nugetService = new NugetV3Service(null,
+                mockFileSystem,
+                new List<string> { XFS.Path(@"c:\nugetcache") },
+                mockGitHubService.Object,
+                new NullLogger(), false, includeLicenseText: false);
+
+            var component = await nugetService.GetComponentAsync("testpackage", "1.0.0", Component.ComponentScope.Required).ConfigureAwait(true);
+
+            Assert.Null(component.Licenses);
+            mockGitHubService.Verify(x => x.GetLicenseAsync("https://aka.ms/deprecateLicenseUrl"), Times.Never);
         }
     }
 }

--- a/CycloneDX.Tests/NugetV3ServiceTests.cs
+++ b/CycloneDX.Tests/NugetV3ServiceTests.cs
@@ -422,6 +422,42 @@ namespace CycloneDX.Tests
         }
 
         [Fact]
+        public async Task GetComponent_GitHubLicenseLookup_FallsBackToLicenseFile()
+        {
+            var nuspecFileContents = @"<?xml version=""1.0"" encoding=""utf-8""?>
+                <package xmlns=""http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd"">
+                <metadata>
+                    <id>testpackage</id>
+                    <license type=""file"">subdir/LICENSE.MD</license>
+                </metadata>
+                </package>";
+
+            byte[] licenseContents = Encoding.UTF8.GetBytes("The license");
+
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\nugetcache\testpackage\1.0.0\testpackage.nuspec"), new MockFileData(nuspecFileContents) },
+                { XFS.Path(@"c:\nugetcache\testpackage\1.0.0\subdir\LICENSE.MD"), new MockFileData(licenseContents) },
+            });
+
+            var mockGitHubService = new Mock<IGithubService>();
+
+            var nugetService = new NugetV3Service(null,
+                mockFileSystem,
+                new List<string> { XFS.Path(@"c:\nugetcache") },
+                mockGitHubService.Object,
+                new NullLogger(), false);
+
+            var component = await nugetService.GetComponentAsync("testpackage", "1.0.0", Component.ComponentScope.Required).ConfigureAwait(true);
+
+            Assert.Single(component.Licenses);
+            Assert.Equal("testpackage License", component.Licenses.First().License.Name);
+            Assert.Equal(Convert.ToBase64String(licenseContents), component.Licenses.First().License.Text.Content);
+            Assert.Equal("base64", component.Licenses.First().License.Text.Encoding);
+            Assert.Equal("text/markdown", component.Licenses.First().License.Text.ContentType);
+        }
+
+        [Fact]
         public async Task GetComponent_GitHubLicenseLookup_FromRepository_WhenLicenseInvalid_ReturnsComponent()
         {
             var nuspecFileContents = @"<?xml version=""1.0"" encoding=""utf-8""?>
@@ -578,7 +614,7 @@ namespace CycloneDX.Tests
         }
 
         [Fact]
-        public async Task GetComponent_WhenGitHubServiceIsNull_UsesLicenseUrl()
+        public async Task GetComponent_WhenGitHubServiceIsNullAndHasNoLicenseFile_UsesLicenseUrl()
         {
             var nuspecFileContents = @"<?xml version=""1.0"" encoding=""utf-8""?>
                 <package xmlns=""http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd"">
@@ -604,6 +640,41 @@ namespace CycloneDX.Tests
             Assert.Single(component.Licenses);
             Assert.Equal("https://not-licence.url", component.Licenses.First().License.Url);
             Assert.Equal("Unknown - See URL", component.Licenses.First().License.Name);
+        }
+
+        [Fact]
+        public async Task GetComponent_WhenGitHubServiceIsNull_UsesLicenseFile()
+        {
+            var nuspecFileContents = @"<?xml version=""1.0"" encoding=""utf-8""?>
+                <package xmlns=""http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd"">
+                <metadata>
+                    <id>testpackage</id>
+                    <license type=""file"">subdir/LICENSE.MD</license>
+                    <repository url=""https://licence.url"" />
+                </metadata>
+                </package>";
+
+            byte[] licenseContents = Encoding.UTF8.GetBytes("The license");
+
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\nugetcache\testpackage\1.0.0\testpackage.nuspec"), new MockFileData(nuspecFileContents) },
+                { XFS.Path(@"c:\nugetcache\testpackage\1.0.0\subdir\LICENSE.MD"), new MockFileData(licenseContents) },
+            });
+
+            var nugetService = new NugetV3Service(null,
+                mockFileSystem,
+                new List<string> { XFS.Path(@"c:\nugetcache") },
+                null,
+                new NullLogger(), false);
+
+            var component = await nugetService.GetComponentAsync("testpackage", "1.0.0", Component.ComponentScope.Required).ConfigureAwait(true);
+
+            Assert.Single(component.Licenses);
+            Assert.Equal("testpackage License", component.Licenses.First().License.Name);
+            Assert.Equal(Convert.ToBase64String(licenseContents), component.Licenses.First().License.Text.Content);
+            Assert.Equal("base64", component.Licenses.First().License.Text.Encoding);
+            Assert.Equal("text/markdown", component.Licenses.First().License.Text.ContentType);
         }
     }
 }

--- a/CycloneDX/Models/RunOptions.cs
+++ b/CycloneDX/Models/RunOptions.cs
@@ -41,6 +41,7 @@ namespace CycloneDX.Models
         public bool enableGithubLicenses { get; set; }
         public bool disablePackageRestore { get; set; }
         public bool disableHashComputation { get; set; }
+        public bool includeLicenseText { get; set; }
         public int dotnetCommandTimeout { get; set; } = 30000;
         public string baseIntermediateOutputPath { get; set; }
         public string importMetadataPath { get; set; }

--- a/CycloneDX/Program.cs
+++ b/CycloneDX/Program.cs
@@ -81,6 +81,7 @@ namespace CycloneDX
             var enableGithubLicenses = new Option<bool>("--enable-github-licenses", "-egl") { Description = "Enables GitHub license resolution" };
             var disablePackageRestore = new Option<bool>("--disable-package-restore", "-dpr") { Description = "Optionally disable package restore" };
             var disableHashComputation = new Option<bool>("--disable-hash-computation", "-dhc") { Description = "Optionally disable hash computation for packages" };
+            var includeLicenseText = new Option<bool>("--include-license-text", "-ilt") { Description = "Embed license file contents as base64-encoded text in the BOM for packages that declare a license file in their package (via <license type=\"file\"> in the nuspec)" };
             var dotnetCommandTimeout = new Option<int>("--dotnet-command-timeout", "-dct") { Description = "dotnet command timeout in milliseconds (primarily used for long dotnet restore operations)", DefaultValueFactory = _ => 300000 };
             var baseIntermediateOutputPath = new Option<string>("--base-intermediate-output-path", "-biop") { Description = "Optionally provide a folder for customized build environment. Required if folder 'obj' is relocated." };
             var importMetadataPath = new Option<string>("--import-metadata-path", "-imp") { Description = "Optionally provide a metadata template which has project specific details." };
@@ -119,6 +120,7 @@ namespace CycloneDX
                 enableGithubLicenses,
                 disablePackageRestore,
                 disableHashComputation,
+                includeLicenseText,
                 dotnetCommandTimeout,
                 baseIntermediateOutputPath,
                 importMetadataPath,
@@ -161,6 +163,7 @@ namespace CycloneDX
                     enableGithubLicenses = parseResult.GetValue(enableGithubLicenses),
                     disablePackageRestore = parseResult.GetValue(disablePackageRestore),
                     disableHashComputation = parseResult.GetValue(disableHashComputation),
+                    includeLicenseText = parseResult.GetValue(includeLicenseText),
                     dotnetCommandTimeout = parseResult.GetValue(dotnetCommandTimeout),
                     baseIntermediateOutputPath = parseResult.GetValue(baseIntermediateOutputPath),
                     importMetadataPath = parseResult.GetValue(importMetadataPath),

--- a/CycloneDX/Services/NugetV3Service.cs
+++ b/CycloneDX/Services/NugetV3Service.cs
@@ -29,6 +29,7 @@ using CycloneDX.Models;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Packaging;
+using NuGet.Packaging.Core;
 using NuGet.Packaging.Licenses;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
@@ -78,24 +79,27 @@ namespace CycloneDX.Services
 
         internal string GetCachedNuspecFilename(string name, string version)
         {
+            return GetCachedNupkgFilename(name, version, name.ToLowerInvariant() + _nuspecExtension);
+        }
+
+        internal string GetCachedNupkgFilename(string name, string version, string fileName)
+        {
             if (string.IsNullOrEmpty(name) || string.IsNullOrEmpty(version)) { return null; }
 
             var lowerName = name.ToLowerInvariant();
             var lowerVersion = version.ToLowerInvariant();
-            string nuspecFilename = null;
 
             foreach (var packageCachePath in _packageCachePaths)
             {
                 var currentDirectory = _fileSystem.Path.Combine(packageCachePath, lowerName, NormalizeVersion(lowerVersion));
-                var currentFilename = _fileSystem.Path.Combine(currentDirectory, lowerName + _nuspecExtension);
+                var currentFilename = _fileSystem.Path.Combine(currentDirectory, fileName);
                 if (_fileSystem.File.Exists(currentFilename))
                 {
-                    nuspecFilename = currentFilename;
-                    break;
+                    return currentFilename;
                 }
             }
 
-            return nuspecFilename;
+            return null;
         }
 
         /// <summary>
@@ -272,9 +276,19 @@ namespace CycloneDX.Services
             }
             else if (_githubService == null)
             {
-                var licenseUrl = nuspecModel.nuspecReader.GetLicenseUrl();
-                var license = new License { Name = "Unknown - See URL", Url = licenseUrl?.Trim() };
-                component.Licenses = new List<LicenseChoice> { new LicenseChoice { License = license } };
+                License license = await TryGetLicenseFileAsync(licenseMetadata, name, version).ConfigureAwait(false);
+
+                if (license == null)
+                {
+                    var licenseUrl = nuspecModel.nuspecReader.GetLicenseUrl();
+                    license = new License { Name = "Unknown - See URL", Url = licenseUrl?.Trim() };
+                }
+
+                if (license != null)
+                {
+                    component.Licenses ??= new List<LicenseChoice>();
+                    component.Licenses.Add(new LicenseChoice { License = license });
+                }
             }
             else
             {
@@ -308,6 +322,11 @@ namespace CycloneDX.Services
                     {
                         license = await _githubService.GetLicenseAsync(project).ConfigureAwait(false);
                     }
+                }
+
+                if (license == null)
+                {
+                    license = await TryGetLicenseFileAsync(licenseMetadata, name, version).ConfigureAwait(false);
                 }
 
                 if (license != null)
@@ -348,6 +367,48 @@ namespace CycloneDX.Services
             }
 
             return component;
+        }
+
+        private async Task<License> TryGetLicenseFileAsync(LicenseMetadata licenseMetadata, string name, string version)
+        {
+            if (licenseMetadata == null || licenseMetadata.Type != LicenseType.File || string.IsNullOrEmpty(licenseMetadata.License))
+            {
+                return null;
+            }
+
+            string licensePath = GetCachedNupkgFilename(name, version, licenseMetadata.License);
+
+            if (licensePath == null)
+            {
+                return null;
+            }
+
+            if (!_fileSystem.File.Exists(licensePath))
+            {
+                return null;
+            }
+
+            string extension = _fileSystem.Path.GetExtension(licensePath)?.ToLowerInvariant();
+
+            string contentType =  extension switch
+            {
+                ".md" => "text/markdown",
+                ".txt" or "" or null => "text/plain",
+                _  => "appliation/octet-stream",
+            };
+
+            byte[] licenseContent = await _fileSystem.File.ReadAllBytesAsync(licensePath).ConfigureAwait(false);
+
+            return new License
+            {
+                Name = $"{name} License",
+                Text = new AttachedText
+                {
+                    ContentType = contentType,
+                    Encoding = "base64",
+                    Content = Convert.ToBase64String(licenseContent),
+                }
+            };
         }
 
         private static Component SetupComponentProperties(Component component, NuspecModel nuspecModel)

--- a/CycloneDX/Services/NugetV3Service.cs
+++ b/CycloneDX/Services/NugetV3Service.cs
@@ -51,6 +51,7 @@ namespace CycloneDX.Services
         private readonly IFileSystem _fileSystem;
         private readonly List<string> _packageCachePaths;
         private readonly bool _disableHashComputation;
+        private readonly bool _includeLicenseText;
 
         // Used in local files
         private const string _nuspecExtension = ".nuspec";
@@ -63,13 +64,15 @@ namespace CycloneDX.Services
             List<string> packageCachePaths,
             IGithubService githubService,
             ILogger logger,
-            bool disableHashComputation
+            bool disableHashComputation,
+            bool includeLicenseText = false
         )
         {
             _fileSystem = fileSystem;
             _packageCachePaths = packageCachePaths;
             _githubService = githubService;
             _disableHashComputation = disableHashComputation;
+            _includeLicenseText = includeLicenseText;
             _logger = logger;
 
             _sourceRepository = SetupNugetRepository(nugetInput);
@@ -276,12 +279,20 @@ namespace CycloneDX.Services
             }
             else if (_githubService == null)
             {
-                License license = await TryGetLicenseFileAsync(licenseMetadata, name, version).ConfigureAwait(false);
+                License license = null;
+
+                if (_includeLicenseText)
+                {
+                    license = await TryGetLicenseFileAsync(licenseMetadata, name, version).ConfigureAwait(false);
+                }
 
                 if (license == null)
                 {
                     var licenseUrl = nuspecModel.nuspecReader.GetLicenseUrl();
-                    license = new License { Name = "Unknown - See URL", Url = licenseUrl?.Trim() };
+                    if (!string.IsNullOrEmpty(licenseUrl))
+                    {
+                        license = new License { Name = "Unknown - See URL", Url = licenseUrl.Trim() };
+                    }
                 }
 
                 if (license != null)
@@ -324,7 +335,7 @@ namespace CycloneDX.Services
                     }
                 }
 
-                if (license == null)
+                if (license == null && _includeLicenseText)
                 {
                     license = await TryGetLicenseFileAsync(licenseMetadata, name, version).ConfigureAwait(false);
                 }
@@ -379,11 +390,6 @@ namespace CycloneDX.Services
             string licensePath = GetCachedNupkgFilename(name, version, licenseMetadata.License);
 
             if (licensePath == null)
-            {
-                return null;
-            }
-
-            if (!_fileSystem.File.Exists(licensePath))
             {
                 return null;
             }

--- a/CycloneDX/Services/NugetV3Service.cs
+++ b/CycloneDX/Services/NugetV3Service.cs
@@ -394,7 +394,7 @@ namespace CycloneDX.Services
             {
                 ".md" => "text/markdown",
                 ".txt" or "" or null => "text/plain",
-                _  => "appliation/octet-stream",
+                _  => "application/octet-stream",
             };
 
             byte[] licenseContent = await _fileSystem.File.ReadAllBytesAsync(licensePath).ConfigureAwait(false);

--- a/CycloneDX/Services/NugetV3Service.cs
+++ b/CycloneDX/Services/NugetV3Service.cs
@@ -269,12 +269,25 @@ namespace CycloneDX.Services
             {
                 Action<NuGetLicense> licenseProcessor = delegate (NuGetLicense nugetLicense)
                 {
+                    var identifier = nugetLicense?.Identifier?.Trim();
                     var license = new License();
-                    license.Id = nugetLicense.Identifier;
-                    license.Name = license.Id == null ? nugetLicense.Identifier : null;
+
+                    // UNLICENSED is not a valid SPDX license id, so emit as name instead.
+                    // (Avoids generating invalid CycloneDX output like <id>UNLICENSED</id>.)
+                    if (!string.IsNullOrEmpty(identifier) &&
+                        string.Equals(identifier, "UNLICENSED", StringComparison.OrdinalIgnoreCase))
+                    {
+                        license.Name = "UNLICENSED";
+                    }
+                    else
+                    {
+                        license.Id = identifier;
+                    }
+
                     component.Licenses ??= new List<LicenseChoice>();
                     component.Licenses.Add(new LicenseChoice { License = license });
                 };
+
                 licenseMetadata.LicenseExpression.OnEachLeafNode(licenseProcessor, null);
             }
             else if (_githubService == null)

--- a/CycloneDX/Services/NugetV3Service.cs
+++ b/CycloneDX/Services/NugetV3Service.cs
@@ -289,7 +289,8 @@ namespace CycloneDX.Services
                 if (license == null)
                 {
                     var licenseUrl = nuspecModel.nuspecReader.GetLicenseUrl();
-                    if (!string.IsNullOrEmpty(licenseUrl))
+                    if (!string.IsNullOrEmpty(licenseUrl)
+                        && !licenseUrl.StartsWith("https://aka.ms/deprecateLicenseUrl", StringComparison.OrdinalIgnoreCase))
                     {
                         license = new License { Name = "Unknown - See URL", Url = licenseUrl.Trim() };
                     }
@@ -305,7 +306,8 @@ namespace CycloneDX.Services
             {
                 License license = null;
                 var licenseUrl = nuspecModel.nuspecReader.GetLicenseUrl();
-                if (!string.IsNullOrEmpty(licenseUrl))
+                if (!string.IsNullOrEmpty(licenseUrl)
+                    && !licenseUrl.StartsWith("https://aka.ms/deprecateLicenseUrl", StringComparison.OrdinalIgnoreCase))
                 {
                     license = await _githubService.GetLicenseAsync(licenseUrl).ConfigureAwait(false);
                 }

--- a/CycloneDX/Services/NugetV3ServiceFactory.cs
+++ b/CycloneDX/Services/NugetV3ServiceFactory.cs
@@ -15,7 +15,7 @@ namespace CycloneDX.Services
         {
             var nugetLogger = new NuGet.Common.NullLogger();
             var nugetInput = NugetInputFactory.Create(option.baseUrl, option.baseUrlUserName, option.baseUrlUSP, option.isPasswordClearText);
-            return new NugetV3Service(nugetInput, fileSystem, packageCachePaths, githubService, nugetLogger, option.disableHashComputation);
+            return new NugetV3Service(nugetInput, fileSystem, packageCachePaths, githubService, nugetLogger, option.disableHashComputation, option.includeLicenseText);
         }
     }
 }

--- a/docs/license-resolution.md
+++ b/docs/license-resolution.md
@@ -1,0 +1,70 @@
+# License Resolution
+
+How the tool resolves license information for NuGet packages, and what ends up in the BOM.
+Phases run in order; the first to produce a result wins and the rest are skipped.
+
+---
+
+## NuGet license metadata
+
+A nuspec can declare a license in several ways:
+
+| Field | Notes |
+|---|---|
+| `<license type="expression">` | SPDX expression; current NuGet recommendation |
+| `<license type="file">` | Path to a license file bundled inside the `.nupkg` |
+| `<licenseUrl>` | Deprecated since 2019; still common in older packages |
+| `<repository url="...">` | Source repository URL; may point to GitHub |
+| `<projectUrl>` | Project homepage; may point to GitHub |
+
+---
+
+## Resolution phases
+
+| # | Phase | When active |
+|---|---|---|
+| 1 | SPDX expression | always |
+| 2 | GitHub license lookup | `--enable-github-licenses` |
+| 3 | License file (embedded text) | `--include-license-text` |
+| 4 | License URL fallback | always |
+
+### Phase 1 — SPDX expression
+
+Reads `<license type="expression">` from the nuspec. The expression is parsed into its leaf
+identifiers; one `License{Id}` is emitted per leaf. No network calls. Most modern packages
+use this.
+
+### Phase 2 — GitHub license lookup (`--enable-github-licenses`)
+
+Tries four URL sources against the GitHub API, in order:
+
+1. `<licenseUrl>`
+2. `<repository url>/blob/<commit>/licence` — only `master`/`main` refs (GitHub API limitation)
+3. `<repository url>`
+4. `<projectUrl>`
+
+Non-GitHub URLs are skipped without a request. The API returns an SPDX ID where known;
+`NOASSERTION` is mapped to `License{Name}`. Results are cached per URL for the run.
+
+### Phase 3 — License file (`--include-license-text`)
+
+Reads the file referenced by `<license type="file">` from the local NuGet cache and embeds
+it as base64-encoded `AttachedText` in `License{Name, Text}`. Skipped if the package does
+not use `<license type="file">` or the file is not found in the cache.
+
+### Phase 4 — License URL fallback
+
+Emits `License{Name="Unknown - See URL", Url=<licenseUrl>}` if `<licenseUrl>` is present.
+If no URL is present either, no license node is emitted.
+
+---
+
+## Current behavior (pre phase 3)
+
+Phase 3 does not exist yet. Packages using `<license type="file">` therefore fall through to
+phase 4 with an empty `<licenseUrl>`, producing a useless stub entry — or no entry at all
+when GitHub resolution is on. Affected packages include Lucene.Net, LibGit2Sharp, and
+Oracle.ManagedDataAccess.Core.
+
+The null-URL stub (phase 4 firing with no URL) is also a pre-existing bug that will be fixed
+alongside phase 3.

--- a/docs/license-resolution.md
+++ b/docs/license-resolution.md
@@ -54,17 +54,14 @@ not use `<license type="file">` or the file is not found in the cache.
 
 ### Phase 4 — License URL fallback
 
-Emits `License{Name="Unknown - See URL", Url=<licenseUrl>}` if `<licenseUrl>` is present.
-If no URL is present either, no license node is emitted.
+Emits `License{Name="Unknown - See URL", Url=<licenseUrl>}` if `<licenseUrl>` is present,
+**unless** the URL is `https://aka.ms/deprecateLicenseUrl`, in which case it is silently
+ignored and no license node is emitted.
 
----
+The `aka.ms/deprecateLicenseUrl` URL is a compatibility stub that NuGet's tooling
+auto-injects into the `<licenseUrl>` field whenever a package is packed with
+`<license type="file">`. This is [documented NuGet behavior][nuget-license-spec] —
+the URL redirects to a generic deprecation notice, not to the actual package license,
+and must never appear in a BOM.
 
-## Current behavior (pre phase 3)
-
-Phase 3 does not exist yet. Packages using `<license type="file">` therefore fall through to
-phase 4 with an empty `<licenseUrl>`, producing a useless stub entry — or no entry at all
-when GitHub resolution is on. Affected packages include Lucene.Net, LibGit2Sharp, and
-Oracle.ManagedDataAccess.Core.
-
-The null-URL stub (phase 4 firing with no URL) is also a pre-existing bug that will be fixed
-alongside phase 3.
+[nuget-license-spec]: https://github.com/NuGet/Home/wiki/Packaging-License-within-the-nupkg


### PR DESCRIPTION
## Summary

This PR adds proper support for NuGet packages that declare their license as a file (rather than a URL or SPDX expression), and fixes two related issues in license handling.

Closes #915. Supersedes #1011.

## Changes

### Added
- **NuGet `<license type="file">` support** — when `--include-license-text` is specified, the license file content is embedded as base64-encoded text in the BOM. Without the flag the license is detected but not embedded.

### Fixed
- **Suppress `aka.ms/deprecateLicenseUrl` stub URL** — NuGet auto-injects `https://aka.ms/deprecateLicenseUrl` into `<licenseUrl>` for packages packed with `<license type="file">` for old-client compatibility. This stub is now ignored in both the GitHub and no-GitHub code paths rather than being emitted as a bogus license entry. See [NuGet packaging spec](https://github.com/NuGet/Home/wiki/Packaging-License-within-the-nupkg).
- **Fix `UNLICENSED` emitted as SPDX id** (fixes #915, from #1004) — `UNLICENSED` is a NuGet-specific token and not a valid SPDX identifier. It is now emitted as `license.name` instead of `license.id`.
- **Fix null-URL license stub** — packages with no `<licenseUrl>` no longer produce a spurious `License { Name="Unknown - See URL", Url=null }` node. Note: `name` + `url` is valid per the CycloneDX spec (`name` satisfies the required id/name choice, `url` is optional), but emitting this for packages with no license declared at all is semantically incorrect — it is fabricated data. Packages with a real, non-stub licenseUrl still get `Unknown - See URL` emitted as before.

## Notes

- This is a **minor** version bump. The behavioural changes correct previously misleading BOM output; they are not breaking changes.
- PR #999 (populate URL for license expressions) was reviewed and rejected: the NuGet spec marks `expression + licenseUrl` as invalid at pack time, so real packages cannot have that combination. The `aka.ms` guard above handles the real-world equivalent.
- The UNLICENSED fix is cherry-picked from #1004 (credit: @jainlakshya).
- All 215 unit tests + 39 E2E tests pass (net8.0/net9.0/net10.0).