### PR TITLE
build(deps): bump System.CommandLine from 2.0.0 to 2.0.5

### DIFF
--- a/CycloneDX.Tests/packages.lock.json
+++ b/CycloneDX.Tests/packages.lock.json
@@ -279,7 +279,7 @@
           "CycloneDX.Core": "[12.1.1, )",
           "NuGet.ProjectModel": "[7.0.1, )",
           "NuGet.Protocol": "[7.3.1, )",
-          "System.CommandLine": "[2.0.0, )",
+          "System.CommandLine": "[2.0.5, )",
           "System.IO.Abstractions": "[22.1.0, )"
         }
       },
@@ -313,9 +313,9 @@
       },
       "System.CommandLine": {
         "type": "CentralTransitive",
-        "requested": "[2.0.0, )",
-        "resolved": "2.0.0",
-        "contentHash": "Bjklzc5NoxqAGFi7BcGlY2TWAdB06Bq3a5sfRr3ubMRU80Mf98eyq3Y2UgR6xRV0TLznZmfe5T7mUjOunRNcdA=="
+        "requested": "[2.0.5, )",
+        "resolved": "2.0.5",
+        "contentHash": "2XtWAPk1G6arpe3OCFNrYYuf6iIboznxs2elJSGgd8e0euou7LfGYFon6hBEfDWNtOLr0M3+oUVgy1a5EGa41A=="
       },
       "System.IO.Abstractions": {
         "type": "CentralTransitive",
@@ -606,7 +606,7 @@
           "CycloneDX.Core": "[12.1.1, )",
           "NuGet.ProjectModel": "[7.0.1, )",
           "NuGet.Protocol": "[7.3.1, )",
-          "System.CommandLine": "[2.0.0, )",
+          "System.CommandLine": "[2.0.5, )",
           "System.IO.Abstractions": "[22.1.0, )"
         }
       },
@@ -640,9 +640,9 @@
       },
       "System.CommandLine": {
         "type": "CentralTransitive",
-        "requested": "[2.0.0, )",
-        "resolved": "2.0.0",
-        "contentHash": "Bjklzc5NoxqAGFi7BcGlY2TWAdB06Bq3a5sfRr3ubMRU80Mf98eyq3Y2UgR6xRV0TLznZmfe5T7mUjOunRNcdA=="
+        "requested": "[2.0.5, )",
+        "resolved": "2.0.5",
+        "contentHash": "2XtWAPk1G6arpe3OCFNrYYuf6iIboznxs2elJSGgd8e0euou7LfGYFon6hBEfDWNtOLr0M3+oUVgy1a5EGa41A=="
       },
       "System.IO.Abstractions": {
         "type": "CentralTransitive",
@@ -933,7 +933,7 @@
           "CycloneDX.Core": "[12.1.1, )",
           "NuGet.ProjectModel": "[7.0.1, )",
           "NuGet.Protocol": "[7.3.1, )",
-          "System.CommandLine": "[2.0.0, )",
+          "System.CommandLine": "[2.0.5, )",
           "System.IO.Abstractions": "[22.1.0, )"
         }
       },
@@ -967,9 +967,9 @@
       },
       "System.CommandLine": {
         "type": "CentralTransitive",
-        "requested": "[2.0.0, )",
-        "resolved": "2.0.0",
-        "contentHash": "Bjklzc5NoxqAGFi7BcGlY2TWAdB06Bq3a5sfRr3ubMRU80Mf98eyq3Y2UgR6xRV0TLznZmfe5T7mUjOunRNcdA=="
+        "requested": "[2.0.5, )",
+        "resolved": "2.0.5",
+        "contentHash": "2XtWAPk1G6arpe3OCFNrYYuf6iIboznxs2elJSGgd8e0euou7LfGYFon6hBEfDWNtOLr0M3+oUVgy1a5EGa41A=="
       },
       "System.IO.Abstractions": {
         "type": "CentralTransitive",

--- a/CycloneDX/packages.lock.json
+++ b/CycloneDX/packages.lock.json
@@ -32,9 +32,9 @@
       },
       "System.CommandLine": {
         "type": "Direct",
-        "requested": "[2.0.0, )",
-        "resolved": "2.0.0",
-        "contentHash": "Bjklzc5NoxqAGFi7BcGlY2TWAdB06Bq3a5sfRr3ubMRU80Mf98eyq3Y2UgR6xRV0TLznZmfe5T7mUjOunRNcdA=="
+        "requested": "[2.0.5, )",
+        "resolved": "2.0.5",
+        "contentHash": "2XtWAPk1G6arpe3OCFNrYYuf6iIboznxs2elJSGgd8e0euou7LfGYFon6hBEfDWNtOLr0M3+oUVgy1a5EGa41A=="
       },
       "System.IO.Abstractions": {
         "type": "Direct",
@@ -211,9 +211,9 @@
       },
       "System.CommandLine": {
         "type": "Direct",
-        "requested": "[2.0.0, )",
-        "resolved": "2.0.0",
-        "contentHash": "Bjklzc5NoxqAGFi7BcGlY2TWAdB06Bq3a5sfRr3ubMRU80Mf98eyq3Y2UgR6xRV0TLznZmfe5T7mUjOunRNcdA=="
+        "requested": "[2.0.5, )",
+        "resolved": "2.0.5",
+        "contentHash": "2XtWAPk1G6arpe3OCFNrYYuf6iIboznxs2elJSGgd8e0euou7LfGYFon6hBEfDWNtOLr0M3+oUVgy1a5EGa41A=="
       },
       "System.IO.Abstractions": {
         "type": "Direct",
@@ -390,9 +390,9 @@
       },
       "System.CommandLine": {
         "type": "Direct",
-        "requested": "[2.0.0, )",
-        "resolved": "2.0.0",
-        "contentHash": "Bjklzc5NoxqAGFi7BcGlY2TWAdB06Bq3a5sfRr3ubMRU80Mf98eyq3Y2UgR6xRV0TLznZmfe5T7mUjOunRNcdA=="
+        "requested": "[2.0.5, )",
+        "resolved": "2.0.5",
+        "contentHash": "2XtWAPk1G6arpe3OCFNrYYuf6iIboznxs2elJSGgd8e0euou7LfGYFon6hBEfDWNtOLr0M3+oUVgy1a5EGa41A=="
       },
       "System.IO.Abstractions": {
         "type": "Direct",

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,7 +15,7 @@
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="coverlet.collector" Version="10.0.0" />
-    <PackageVersion Include="System.CommandLine" Version="2.0.0" />
+    <PackageVersion Include="System.CommandLine" Version="2.0.5" />
     <PackageVersion Include="System.IO.Abstractions" Version="22.1.0" />
     <PackageVersion Include="System.IO.Abstractions.TestingHelpers" Version="22.1.0" />
     <!-- E2E test dependencies -->


### PR DESCRIPTION
Replaces the conflicting dependabot PR #1058 with a clean rebase onto master.

## Changes
- Bumps `System.CommandLine` from 2.0.0 to 2.0.5 in `Directory.Packages.props`
- Regenerates lock files for all projects

## Notes
The original dependabot PR #1058 had a merge conflict because master's lock file was regenerated to fix the NU1004 multi-TFM issue. This PR applies the same change cleanly on top of current master.

Closes #1058