### PR TITLE
Fix hash computation for uncached nupkg

### DIFF
--- a/CycloneDX.Tests/NugetV3ServiceTests.cs
+++ b/CycloneDX.Tests/NugetV3ServiceTests.cs
@@ -276,6 +276,8 @@ namespace CycloneDX.Tests
 
             Assert.Equal(packageName, component.Name);
             Assert.Equal(packageVersion, component.Version);
+            Assert.Equal("83731B662EAF05379A23F8446EF47BBC111349DD4358B7BD8B51383FE9CF637E2FE62F78CEA52A0D7BDD582DC6FBBB5837D4A7B1D53DCF37A0AE7473E21EE7B1",
+                component.Hashes.Single().Content);
         }
 
         [Fact]

--- a/CycloneDX/Services/NugetV3Service.cs
+++ b/CycloneDX/Services/NugetV3Service.cs
@@ -224,6 +224,7 @@ namespace CycloneDX.Services
         {
             using (SHA512 sha = SHA512.Create())
             {
+                stream.Position = 0;
                 return sha.ComputeHash(stream);
             }
         }


### PR DESCRIPTION
Fix: When CycloneDX falls back to not use the cached nupkg in NugetV3Service.cs:GetNuspec() the hash computation fails because the stream position is not reset back to 0.