### PR TITLE
fix: retain all matching dependency range versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Resolve dependency ranges with multiple matching package versions in solutions** (#1110) — solution scans no longer crash when more than one merged package version satisfies an unresolved NuGet dependency range; the BOM now retains an edge to every matching component
+
 ## [6.2.0] - 2026-04-27
 
 ### Added

--- a/CycloneDX.E2ETests/Snapshots/Issue1110Tests.DependencyRange_WithMultipleMatchingVersionsInSolution_ShouldSucceed.verified.txt
+++ b/CycloneDX.E2ETests/Snapshots/Issue1110Tests.DependencyRange_WithMultipleMatchingVersionsInSolution_ShouldSucceed.verified.txt
@@ -1,0 +1,105 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<bom xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" version="1" xmlns="http://cyclonedx.org/schema/bom/1.7">
+  <metadata>
+    <timestamp>{scrubbed-timestamp}</timestamp>
+    <tools>
+      <components>
+        <component type="application">
+          <authors>
+            <author>
+              <name>CycloneDX</name>
+            </author>
+          </authors>
+          <name>CycloneDX module for .NET</name>
+          <version>{scrubbed-version}</version>
+          <externalReferences>
+            <reference type="website">
+              <url>https://github.com/CycloneDX/cyclonedx-dotnet</url>
+            </reference>
+          </externalReferences>
+        </component>
+      </components>
+    </tools>
+    <component type="application" bom-ref="Issue1110Sln@0.0.0">
+      <name>Issue1110Sln</name>
+      <version>{scrubbed-version}</version>
+    </component>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="pkg:nuget/TestPkg.Issue1110.Logging@1.0.10">
+      <authors>
+        <author>
+          <name>CycloneDX E2E Tests</name>
+        </author>
+      </authors>
+      <name>TestPkg.Issue1110.Logging</name>
+      <version>{scrubbed-version}</version>
+      <description>Test package TestPkg.Issue1110.Logging</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-512">{scrubbed-hash}</hash>
+      </hashes>
+      <purl>pkg:nuget/TestPkg.Issue1110.Logging@1.0.10</purl>
+    </component>
+    <component type="library" bom-ref="pkg:nuget/TestPkg.Issue1110.Logging@1.0.3">
+      <authors>
+        <author>
+          <name>CycloneDX E2E Tests</name>
+        </author>
+      </authors>
+      <name>TestPkg.Issue1110.Logging</name>
+      <version>{scrubbed-version}</version>
+      <description>Test package TestPkg.Issue1110.Logging</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-512">{scrubbed-hash}</hash>
+      </hashes>
+      <purl>pkg:nuget/TestPkg.Issue1110.Logging@1.0.3</purl>
+    </component>
+    <component type="library" bom-ref="pkg:nuget/TestPkg.Issue1110.Logging@1.0.9">
+      <authors>
+        <author>
+          <name>CycloneDX E2E Tests</name>
+        </author>
+      </authors>
+      <name>TestPkg.Issue1110.Logging</name>
+      <version>{scrubbed-version}</version>
+      <description>Test package TestPkg.Issue1110.Logging</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-512">{scrubbed-hash}</hash>
+      </hashes>
+      <purl>pkg:nuget/TestPkg.Issue1110.Logging@1.0.9</purl>
+    </component>
+    <component type="library" bom-ref="pkg:nuget/TestPkg.Issue1110.Range@1.0.0">
+      <authors>
+        <author>
+          <name>CycloneDX E2E Tests</name>
+        </author>
+      </authors>
+      <name>TestPkg.Issue1110.Range</name>
+      <version>{scrubbed-version}</version>
+      <description>Test package TestPkg.Issue1110.Range</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-512">{scrubbed-hash}</hash>
+      </hashes>
+      <purl>pkg:nuget/TestPkg.Issue1110.Range@1.0.0</purl>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="Issue1110Sln@0.0.0">
+      <dependency ref="pkg:nuget/TestPkg.Issue1110.Logging@1.0.9" />
+      <dependency ref="pkg:nuget/TestPkg.Issue1110.Logging@1.0.3" />
+      <dependency ref="pkg:nuget/TestPkg.Issue1110.Range@1.0.0" />
+      <dependency ref="pkg:nuget/TestPkg.Issue1110.Logging@1.0.10" />
+    </dependency>
+    <dependency ref="pkg:nuget/TestPkg.Issue1110.Logging@1.0.10" />
+    <dependency ref="pkg:nuget/TestPkg.Issue1110.Logging@1.0.3" />
+    <dependency ref="pkg:nuget/TestPkg.Issue1110.Logging@1.0.9" />
+    <dependency ref="pkg:nuget/TestPkg.Issue1110.Range@1.0.0">
+      <dependency ref="pkg:nuget/TestPkg.Issue1110.Logging@1.0.9" />
+      <dependency ref="pkg:nuget/TestPkg.Issue1110.Logging@1.0.10" />
+    </dependency>
+  </dependencies>
+</bom>

--- a/CycloneDX.E2ETests/Tests/Issue1110Tests.cs
+++ b/CycloneDX.E2ETests/Tests/Issue1110Tests.cs
@@ -1,0 +1,89 @@
+// This file is part of CycloneDX Tool for .NET
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OWASP Foundation. All Rights Reserved.
+
+using System.Threading.Tasks;
+using CycloneDX.E2ETests.Builders;
+using CycloneDX.E2ETests.Infrastructure;
+using Xunit;
+using static VerifyXunit.Verifier;
+
+namespace CycloneDX.E2ETests.Tests
+{
+    /// <summary>
+    /// Regression tests for issue #1110: solution scanning must not fail when multiple
+    /// resolved package versions satisfy an unresolved dependency version range.
+    /// </summary>
+    [Collection("E2E")]
+    public sealed class Issue1110Tests
+    {
+        private readonly E2EFixture _fixture;
+
+        public Issue1110Tests(E2EFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        [Fact]
+        public async Task DependencyRange_WithMultipleMatchingVersionsInSolution_ShouldSucceed()
+        {
+            await _fixture.PushPackageAsync(NupkgBuilder.Build("TestPkg.Issue1110.Logging", "1.0.3"));
+            await _fixture.PushPackageAsync(NupkgBuilder.Build("TestPkg.Issue1110.Logging", "1.0.9"));
+            await _fixture.PushPackageAsync(NupkgBuilder.Build("TestPkg.Issue1110.Logging", "1.0.10"));
+            await _fixture.PushPackageAsync(NupkgBuilder.Build(
+                "TestPkg.Issue1110.Range", "1.0.0",
+                dependencies: new[] { new NupkgDependency("TestPkg.Issue1110.Logging", "[1.0.9, )") }));
+
+            // RangeProducer represents the project used to create the package. ConsumerA keeps
+            // the range unresolved by directly pinning a lower version, while ConsumerB resolves
+            // another version that also satisfies the package's range.
+            using var solution = await new SolutionBuilder("Issue1110Sln")
+                .AddProject("RangeProducer", p => p
+                    .WithTargetFramework("net8.0")
+                    .AddPackage("TestPkg.Issue1110.Logging", "1.0.9"))
+                .AddProject("ConsumerA", p => p
+                    .WithTargetFramework("net8.0")
+                    .AddPackage("TestPkg.Issue1110.Range", "1.0.0")
+                    .AddPackage("TestPkg.Issue1110.Logging", "1.0.3")
+                    .WithRawXml("""
+                        <PropertyGroup>
+                          <NoWarn>$(NoWarn);NU1605</NoWarn>
+                        </PropertyGroup>
+                        """))
+                .AddProject("ConsumerB", p => p
+                    .WithTargetFramework("net8.0")
+                    .AddPackage("TestPkg.Issue1110.Logging", "1.0.10"))
+                .BuildAsync(_fixture.NuGetFeedUrl);
+
+            using var outputDir = solution.CreateOutputDir();
+
+            var result = await _fixture.Runner.RunAsync(
+                solution.SolutionFile,
+                outputDir.Path,
+                new ToolRunOptions
+                {
+                    NuGetFeedUrl = _fixture.NuGetFeedUrl,
+                    NoSerialNumber = true,
+                    DisableHashComputation = true
+                });
+
+            Assert.True(result.Success,
+                $"Tool failed with exit code {result.ExitCode}.\nstderr:\n{result.StdErr}\nstdout:\n{result.StdOut}");
+
+            await Verify(result.BomContent);
+        }
+    }
+}

--- a/CycloneDX/Runner.cs
+++ b/CycloneDX/Runner.cs
@@ -356,12 +356,13 @@ namespace CycloneDX
                     foreach (var dep in package.Dependencies ?? [])
                     {
                         var lookupKey = (dep.Key.ToLower(CultureInfo.InvariantCulture), dep.Value?.ToLower(CultureInfo.InvariantCulture));
+                        var lookupKeys = new List<(string, string)>();
                         if (!bomRefLookup.ContainsKey(lookupKey))
                         {
                             var packageNameMatch = bomRefLookup.Where(x => x.Key.Item1 == dep.Key.ToLower(CultureInfo.InvariantCulture)).ToList();
                             if (packageNameMatch.Count == 1)
                             {
-                                lookupKey = packageNameMatch.First().Key;
+                                lookupKeys.Add(packageNameMatch.First().Key);
                             }
                             else if (packageNameMatch.Count > 1
                                 && VersionRange.TryParse(dep.Value, out var versionRange))
@@ -369,12 +370,12 @@ namespace CycloneDX
                                 // dep.Value is a version range stored verbatim from the nuspec (e.g. "[1.0.0]").
                                 // ResolveDependencyVersionRanges couldn't resolve it within this project's
                                 // assets because the satisfying version only exists in another project's assets.
-                                // Use the range to pick the correct candidate from the merged BOM.
-                                var rangeMatch = packageNameMatch.SingleOrDefault(
-                                    x => NuGetVersion.TryParse(x.Key.Item2, out var v) && versionRange.Satisfies(v));
-                                if (rangeMatch.Key != default)
-                                    lookupKey = rangeMatch.Key;
-                                else
+                                // The merged BOM does not retain project-specific resolution context,
+                                // so preserve every component version that satisfies the range.
+                                lookupKeys.AddRange(packageNameMatch
+                                    .Where(x => NuGetVersion.TryParse(x.Key.Item2, out var v) && versionRange.Satisfies(v))
+                                    .Select(x => x.Key));
+                                if (lookupKeys.Count == 0)
                                 {
                                     Console.Error.WriteLine($"Unable to locate valid bom ref for {dep.Key} {dep.Value}");
                                     return (int)ExitCode.UnableToLocateDependencyBomRef;
@@ -386,13 +387,20 @@ namespace CycloneDX
                                 return (int)ExitCode.UnableToLocateDependencyBomRef;
                             }
                         }
-
-                        var bomRef = bomRefLookup[lookupKey];
-                        transitiveDependencies.Add(bomRef);
-                        packageDependencies.Dependencies.Add(new Dependency
+                        else
                         {
-                            Ref = bomRef
-                        });
+                            lookupKeys.Add(lookupKey);
+                        }
+
+                        foreach (var resolvedLookupKey in lookupKeys)
+                        {
+                            var bomRef = bomRefLookup[resolvedLookupKey];
+                            transitiveDependencies.Add(bomRef);
+                            packageDependencies.Dependencies.Add(new Dependency
+                            {
+                                Ref = bomRef
+                            });
+                        }
                     }
                     dependencies.Add(packageDependencies);
                 }


### PR DESCRIPTION
## Summary
- retain every merged component version that satisfies an unresolved NuGet dependency range
- prevent solution scans from throwing when multiple versions satisfy the same range
- add a self-contained E2E Verify snapshot regression for #1110 using only the test feed
- document the fix in the changelog

Fixes #1110

## Verification
- `dotnet test CycloneDX.E2ETests --framework net10.0 --filter "FullyQualifiedName~Issue903Tests|FullyQualifiedName~Issue1110Tests"`
- `dotnet test CycloneDX.Tests --framework net10.0`
- `dotnet build /WarnAsError`